### PR TITLE
feat(modals): support K/M shorthand in shares quantity input

### DIFF
--- a/src/components/modals/BuyModal.jsx
+++ b/src/components/modals/BuyModal.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { formatNumber } from '../../utils/formatters';
+import { formatNumber, parseMK } from '../../utils/formatters';
 
 export default function BuyModal({ stock, onConfirm, onCancel, geData = {} }) {
   const [shares, setShares] = useState((stock.limit4h * 1).toString());
@@ -18,6 +18,14 @@ export default function BuyModal({ stock, onConfirm, onCancel, geData = {} }) {
     setPrice(avgPrice);
     setTotalAmount((stock.limit4h * parseFloat(avgPrice)).toFixed(0));
   }, [stock]);
+
+  const handleSharesBlur = () => {
+    const parsed = parseMK(shares);
+    setShares(parsed);
+    if (price && parsed) {
+      setTotalAmount((parseFloat(parsed) * parseFloat(price)).toFixed(0));
+    }
+  };
 
   const handleMultiplierChange = (mult) => {
     setMultiplier(mult);
@@ -160,7 +168,7 @@ export default function BuyModal({ stock, onConfirm, onCancel, geData = {} }) {
             ))}
           </div>
           <input
-            type="number"
+            type="text"
             value={shares}
             onChange={(e) => setShares(e.target.value)}
             placeholder="Number of shares"
@@ -174,7 +182,7 @@ export default function BuyModal({ stock, onConfirm, onCancel, geData = {} }) {
               color: 'white'
             }}
             onFocus={(e) => e.target.style.borderColor = 'rgb(34, 197, 94)'}
-            onBlur={(e) => e.target.style.borderColor = 'transparent'}
+            onBlur={(e) => { handleSharesBlur(); e.target.style.borderColor = 'transparent'; }}
           />
         </div>
         <div>

--- a/src/components/modals/SellModal.jsx
+++ b/src/components/modals/SellModal.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { formatNumber } from '../../utils/formatters';
+import { formatNumber, parseMK } from '../../utils/formatters';
 
 export default function SellModal({ stock, onConfirm, onCancel, geData = {} }) {
   const [shares, setShares] = useState('');
@@ -11,6 +11,11 @@ export default function SellModal({ stock, onConfirm, onCancel, geData = {} }) {
     const avgSell = stock.sharesSold > 0 ? stock.totalCostSold / stock.sharesSold : 0;
     setPrice((Math.round(avgSell * 100) / 100).toFixed(0));
   }, [stock]);
+
+  const handleSharesBlur = () => {
+    const parsed = parseMK(shares);
+    setShares(parsed);
+  };
 
   const handleConfirm = () => {
     if (useTotal) {
@@ -210,13 +215,10 @@ export default function SellModal({ stock, onConfirm, onCancel, geData = {} }) {
             </button>
           </div>
           <input
-            type="number"
+            type="text"
             value={shares}
             onChange={(e) => setShares(e.target.value)}
             placeholder="Number of shares"
-            max={stock.shares}
-            min="0"
-            step="1"
             style={{
               width: '100%',
               padding: '0.5rem 1rem',
@@ -227,7 +229,7 @@ export default function SellModal({ stock, onConfirm, onCancel, geData = {} }) {
               color: 'white'
             }}
             onFocus={(e) => e.target.style.borderColor = 'rgb(239, 68, 68)'}
-            onBlur={(e) => e.target.style.borderColor = 'transparent'}
+            onBlur={(e) => { handleSharesBlur(); e.target.style.borderColor = 'transparent'; }}
           />
         </div>
         <div>

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -1,3 +1,16 @@
+export const parseMK = (value) => {
+  const str = String(value).trim().toLowerCase();
+  if (str.endsWith('m')) {
+    const num = parseFloat(str) * 1_000_000;
+    return isNaN(num) ? value : String(Math.round(num));
+  }
+  if (str.endsWith('k')) {
+    const num = parseFloat(str) * 1_000;
+    return isNaN(num) ? value : String(Math.round(num));
+  }
+  return value;
+};
+
 export const formatNumber = (num, numberFormat = 'compact') => {
   if (num == null || isNaN(num)) return '-';
 


### PR DESCRIPTION
## Summary
  Allows users to type shorthand like `1k` or `2.5m` in the shares quantity field when buying or selling stock. The value is resolved to a number on blur.

  ## Changes
  - Added `parseMK` utility to `formatters.js` that converts `k`/`m` suffixes to full numbers
  - Updated shares input in `BuyModal` and `SellModal` to `type="text"` with blur-time parsing
  - Recalculates total cost in `BuyModal` after M/K value is resolved