### PR TITLE
feat(stats): add unrealised profit to portfolio and category stats

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -83,7 +83,8 @@ export default function MainApp({ session, onLogout }) {
   const { dumpProfit, referralProfit, bondsProfit } = profits;
 
   // Destructure settings
-  const { numberFormat, visibleColumns, visibleProfits, altAccountTimer, showCategoryStats } = settings;
+  const { numberFormat, visibleColumns, visibleProfits, altAccountTimer, showCategoryStats,
+          showUnrealisedProfitStats, showCategoryUnrealisedProfit } = settings;
   // Local UI state
   const [collapsedCategories, setCollapsedCategories] = useState(() => {
     // Load collapsed state from localStorage on initial render
@@ -1058,6 +1059,8 @@ export default function MainApp({ session, onLogout }) {
               onAddReferralProfit={() => setShowReferralProfitModal(true)}
               onAddBondsProfit={() => setShowBondsProfitModal(true)}
               numberFormat={numberFormat}
+              geData={gePrices}
+              showUnrealisedProfitStats={showUnrealisedProfitStats}
             />
 
             {/* Milestone Progress Bar and Chart Buttons Row */}
@@ -1189,6 +1192,7 @@ export default function MainApp({ session, onLogout }) {
                 currentTime={currentTime}
                 numberFormat={numberFormat}
                 showCategoryStats={showCategoryStats}
+                showCategoryUnrealisedProfit={showCategoryUnrealisedProfit}
                 geData={gePrices}
                 geIconMap={geIconMap}
               />
@@ -1360,6 +1364,10 @@ export default function MainApp({ session, onLogout }) {
             onVisibleProfitsChange={(newProfits) => updateSettings({ visibleProfits: newProfits })}
             showCategoryStats={showCategoryStats}
             onShowCategoryStatsChange={(value) => updateSettings({ showCategoryStats: value })}
+            showUnrealisedProfitStats={showUnrealisedProfitStats}
+            onShowUnrealisedProfitStatsChange={(v) => updateSettings({ showUnrealisedProfitStats: v })}
+            showCategoryUnrealisedProfit={showCategoryUnrealisedProfit}
+            onShowCategoryUnrealisedProfitChange={(v) => updateSettings({ showCategoryUnrealisedProfit: v })}
             onCancel={() => setShowSettingsModal(false)}
             onChangePassword={() => {
               setShowSettingsModal(false);

--- a/src/components/CategorySection.jsx
+++ b/src/components/CategorySection.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Plus, Trash2 } from 'lucide-react';
 import StockTable from './StockTable';
 import { formatNumber } from '../utils/formatters';
+import { calculateUnrealizedProfit } from '../utils/taxUtils';
 
 export default function CategorySection({
   category,
@@ -33,6 +34,7 @@ export default function CategorySection({
   currentTime,
   numberFormat,
   showCategoryStats,
+  showCategoryUnrealisedProfit = false,
   geData = {},
   geIconMap = {},
   onArchive
@@ -205,6 +207,20 @@ export default function CategorySection({
               value={formatNumber(categoryStocks.reduce((sum, s) => sum + s.totalCostSold, 0), numberFormat)}
               color="rgb(192, 132, 252)"
             />
+            {showCategoryUnrealisedProfit && (() => {
+              const total = categoryStocks.reduce((sum, s) => {
+                const high = s.itemId ? geData[s.itemId]?.high : null;
+                const val = calculateUnrealizedProfit(s, high, s.itemId);
+                return sum + (val ?? 0);
+              }, 0);
+              return (
+                <StatItem
+                  label="Unreal. Profit"
+                  value={`${total >= 0 ? '+' : ''}${formatNumber(total, numberFormat)}`}
+                  color={total >= 0 ? 'rgb(52, 211, 153)' : 'rgb(248, 113, 113)'}
+                />
+              );
+            })()}
           </div>
 
           <StockTable

--- a/src/components/PortfolioSummary.jsx
+++ b/src/components/PortfolioSummary.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Plus } from 'lucide-react';
 import { formatNumber } from '../utils/formatters';
 import { calculateStocksProfit, calculateTotalProfit } from '../utils/calculations';
+import { calculateUnrealizedProfit } from '../utils/taxUtils';
 
 export default function PortfolioSummary({
   stocks,
@@ -12,10 +13,20 @@ export default function PortfolioSummary({
   onAddDumpProfit,
   onAddReferralProfit,
   onAddBondsProfit,
-  numberFormat
+  numberFormat,
+  geData = {},
+  showUnrealisedProfitStats = false
 }) {
   const stocksProfit = calculateStocksProfit(stocks);
   const totalProfit = calculateTotalProfit(stocks, dumpProfit, referralProfit, bondsProfit);
+
+  const totalUnrealised = showUnrealisedProfitStats
+    ? stocks.reduce((sum, s) => {
+        const high = s.itemId ? geData[s.itemId]?.high : null;
+        const val = calculateUnrealizedProfit(s, high, s.itemId);
+        return sum + (val ?? 0);
+      }, 0)
+    : null;
 
   const totalPortfolio = stocks.reduce((sum, s) => sum + s.totalCost, 0);
   const totalShares = stocks.reduce((sum, s) => sum + s.shares, 0);
@@ -102,6 +113,15 @@ export default function PortfolioSummary({
               color: 'rgb(161, 98, 7)',
               hoverColor: 'rgb(133, 77, 14)'
             }}
+          />
+        )}
+
+        {/* Unrealised Profit */}
+        {showUnrealisedProfitStats && (
+          <SummaryCard
+            label="Unrealised Profit:"
+            value={`${totalUnrealised >= 0 ? '+' : ''}${formatNumber(totalUnrealised, numberFormat)}`}
+            color={totalUnrealised >= 0 ? 'rgb(52, 211, 153)' : 'rgb(248, 113, 113)'}
           />
         )}
       </div>

--- a/src/components/modals/ModalContainer.jsx
+++ b/src/components/modals/ModalContainer.jsx
@@ -7,14 +7,19 @@ export default function ModalContainer({ isOpen, children }) {
     <div style={{
       position: 'fixed',
       inset: 0,
-      background: 'rgba(0, 0, 0, 0.6)',
-      backdropFilter: 'blur(4px)',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      zIndex: 50
+      zIndex: 200,
+      overflowY: 'auto',
     }}>
-      {children}
+      <div style={{
+        minHeight: '100%',
+        display: 'flex',
+        alignItems: 'flex-start',
+        justifyContent: 'center',
+        padding: '2rem 1rem',
+        background: 'rgba(0, 0, 0, 0.7)',
+      }}>
+        {children}
+      </div>
     </div>
   );
 }

--- a/src/components/modals/SettingsModal.jsx
+++ b/src/components/modals/SettingsModal.jsx
@@ -34,6 +34,10 @@ export default function SettingsModal({
   onVisibleProfitsChange,
   showCategoryStats,
   onShowCategoryStatsChange,
+  showUnrealisedProfitStats,
+  onShowUnrealisedProfitStatsChange,
+  showCategoryUnrealisedProfit,
+  onShowCategoryUnrealisedProfitChange,
   onCancel,
   onChangePassword
 }) {
@@ -175,6 +179,37 @@ export default function SettingsModal({
         </div>
       </div>
 
+      {/* Stats Display Section */}
+      <div style={{ marginBottom: '1.5rem' }}>
+        <label style={{ display: 'block', fontSize: '0.875rem', fontWeight: '600', marginBottom: '0.75rem' }}>
+          Stats Display
+        </label>
+        <label
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.75rem',
+            padding: '0.75rem',
+            background: 'rgb(51, 65, 85)',
+            borderRadius: '0.5rem',
+            cursor: 'pointer',
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={showUnrealisedProfitStats}
+            onChange={(e) => onShowUnrealisedProfitStatsChange(e.target.checked)}
+            style={{ width: '18px', height: '18px', cursor: 'pointer' }}
+          />
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: '0.875rem', marginBottom: '0.25rem' }}>Show Unrealised Profit in Portfolio Stats</div>
+            <div style={{ fontSize: '0.75rem', color: 'rgb(156, 163, 175)' }}>
+              Display total estimated unrealised profit in the top summary cards
+            </div>
+          </div>
+        </label>
+      </div>
+
       {/* Category Statistics Section */}
       <div style={{ marginBottom: '1.5rem' }}>
         <label style={{ display: 'block', fontSize: '0.875rem', fontWeight: '600', marginBottom: '0.75rem' }}>
@@ -201,6 +236,31 @@ export default function SettingsModal({
             <div style={{ fontSize: '0.875rem', marginBottom: '0.25rem' }}>Show Category Statistics</div>
             <div style={{ fontSize: '0.75rem', color: 'rgb(156, 163, 175)' }}>
               Display stock status counts (⏰Timer, ✓OK, 🔒Hold, 🔴Low) next to category names
+            </div>
+          </div>
+        </label>
+        <label
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.75rem',
+            padding: '0.75rem',
+            background: 'rgb(51, 65, 85)',
+            borderRadius: '0.5rem',
+            cursor: 'pointer',
+            marginTop: '0.5rem',
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={showCategoryUnrealisedProfit}
+            onChange={(e) => onShowCategoryUnrealisedProfitChange(e.target.checked)}
+            style={{ width: '18px', height: '18px', cursor: 'pointer' }}
+          />
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: '0.875rem', marginBottom: '0.25rem' }}>Show Unrealised Profit in Category Stats</div>
+            <div style={{ fontSize: '0.75rem', color: 'rgb(156, 163, 175)' }}>
+              Display estimated unrealised profit per category based on live GE high prices
             </div>
           </div>
         </label>

--- a/src/hooks/useSettings.js
+++ b/src/hooks/useSettings.js
@@ -23,7 +23,9 @@ export function useSettings(userId) {
     visibleColumns: DEFAULT_VISIBLE_COLUMNS,
     visibleProfits: DEFAULT_VISIBLE_PROFITS,
     altAccountTimer: null,
-    showCategoryStats: false
+    showCategoryStats: false,
+    showUnrealisedProfitStats: false,
+    showCategoryUnrealisedProfit: true,
   });
   const [loading, setLoading] = useState(true);
 
@@ -62,7 +64,9 @@ export function useSettings(userId) {
         },
         visibleProfits: data.visible_profits || DEFAULT_VISIBLE_PROFITS.bondsProfit,
         altAccountTimer: data.alt_account_timer,
-        showCategoryStats: data.show_category_stats || false
+        showCategoryStats: data.show_category_stats || false,
+        showUnrealisedProfitStats: data.show_unrealised_profit_stats ?? false,
+        showCategoryUnrealisedProfit: data.show_category_unrealised_profit ?? true,
       });
     } else {
       const { error: insertError } = await supabase
@@ -92,7 +96,9 @@ export function useSettings(userId) {
       visible_columns: newSettings.visibleColumns,
       visible_profits: newSettings.visibleProfits,
       alt_account_timer: newSettings.altAccountTimer,
-      show_category_stats: newSettings.showCategoryStats
+      show_category_stats: newSettings.showCategoryStats,
+      show_unrealised_profit_stats: newSettings.showUnrealisedProfitStats,
+      show_category_unrealised_profit: newSettings.showCategoryUnrealisedProfit,
     };
 
     const { error } = await supabase


### PR DESCRIPTION
  ## Summary
  Adds toggleable unrealised profit display to both the portfolio summary cards and per-category stats strip. Values are calculated using live GE high prices after 2% tax and are controlled via two new settings backed by     
  `user_settings` DB columns.

  ## Changes
  - `useSettings`: add `showUnrealisedProfitStats` (default off) and `showCategoryUnrealisedProfit` (default on) with DB persistence
  - `PortfolioSummary`: add optional "Unrealised Profit" summary card in the bottom row
  - `CategorySection`: add optional "Unreal. Profit" stat item in the category stats strip
  - `SettingsModal`: add "Stats Display" section with portfolio toggle, and second checkbox in "Category Display Options"
  - `ModalContainer`: fix scrolling for tall modals — raise z-index above sticky header, use scrollable outer wrapper