### PR TITLE
fix(modals): prevent duplicate transactions on double-click

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -5,7 +5,8 @@
       "Bash(curl:*)",
       "Skill(new-branch)",
       "Bash(git checkout:*)",
-      "Bash(npm run:*)"
+      "Bash(npm run:*)",
+      "Bash(grep:*)"
     ]
   }
 }

--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -113,6 +113,7 @@ export default function MainApp({ session, onLogout }) {
   // Modal states
   const [showBuyModal, setShowBuyModal] = useState(false);
   const [showSellModal, setShowSellModal] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [selectedMilestonePeriod, setSelectedMilestonePeriod] = useState('day');
   const [showAdjustModal, setShowAdjustModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -392,6 +393,8 @@ export default function MainApp({ session, onLogout }) {
   };
 
   const handleBuy = async (data) => {
+    if (isSubmitting) return;
+    setIsSubmitting(true);
     const { shares, price, startTimer } = data;
     const total = shares * price;
 
@@ -419,30 +422,36 @@ export default function MainApp({ session, onLogout }) {
       newOnHold = false;
     }
 
-    await updateStock(selectedStock.id, {
-      totalCost: selectedStock.totalCost + total,
-      shares: newShares,
-      timerEndTime
-    });
+    try {
+      await updateStock(selectedStock.id, {
+        totalCost: selectedStock.totalCost + total,
+        shares: newShares,
+        timerEndTime
+      });
 
-    await addTransaction({
-      stockId: selectedStock.id,
-      stockName: selectedStock.name,
-      type: 'buy',
-      shares,
-      price,
-      total,
-      date: new Date().toISOString()
-    });
-    await refetch();
-    highlightRow(selectedStock.id);
-    setShowBuyModal(false);
+      await addTransaction({
+        stockId: selectedStock.id,
+        stockName: selectedStock.name,
+        type: 'buy',
+        shares,
+        price,
+        total,
+        date: new Date().toISOString()
+      });
+      await refetch();
+      highlightRow(selectedStock.id);
+      setShowBuyModal(false);
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   const [milestoneProgress, setMilestoneProgress] = useState({ day: 0, week: 0, month: 0, year: 0 });
 
 
   const handleSell = async (data) => {
+    if (isSubmitting) return;
+    setIsSubmitting(true);
     const { shares, price } = data;
     const total = shares * price;
 
@@ -450,35 +459,39 @@ export default function MainApp({ session, onLogout }) {
     const costBasisOfSharesSold = avgBuy * shares;
     const profit = total - costBasisOfSharesSold;
 
-    await updateStock(selectedStock.id, {
-      shares: selectedStock.shares - shares,
-      totalCost: selectedStock.totalCost - costBasisOfSharesSold,
-      sharesSold: selectedStock.sharesSold + shares,
-      totalCostSold: selectedStock.totalCostSold + total,
-      totalCostBasisSold: (selectedStock.totalCostBasisSold || 0) + costBasisOfSharesSold
-    });
+    try {
+      await updateStock(selectedStock.id, {
+        shares: selectedStock.shares - shares,
+        totalCost: selectedStock.totalCost - costBasisOfSharesSold,
+        sharesSold: selectedStock.sharesSold + shares,
+        totalCostSold: selectedStock.totalCostSold + total,
+        totalCostBasisSold: (selectedStock.totalCostBasisSold || 0) + costBasisOfSharesSold
+      });
 
-    const newTransaction = await addTransaction({
-      stockId: selectedStock.id,
-      stockName: selectedStock.name,
-      type: 'sell',
-      shares,
-      price,
-      total,
-      date: new Date().toISOString()
-    });
+      const newTransaction = await addTransaction({
+        stockId: selectedStock.id,
+        stockName: selectedStock.name,
+        type: 'sell',
+        shares,
+        price,
+        total,
+        date: new Date().toISOString()
+      });
 
-    const profitEntry = await addProfitEntry('stock', profit, selectedStock.id, newTransaction?.id ?? null);
+      const profitEntry = await addProfitEntry('stock', profit, selectedStock.id, newTransaction?.id ?? null);
 
-    if (newTransaction && profitEntry) {
-      await supabase
-        .from('transactions')
-        .update({ profit_history_id: profitEntry.id })
-        .eq('id', newTransaction.id);
+      if (newTransaction && profitEntry) {
+        await supabase
+          .from('transactions')
+          .update({ profit_history_id: profitEntry.id })
+          .eq('id', newTransaction.id);
+      }
+      await refetch();
+      highlightRow(selectedStock.id);
+      setShowSellModal(false);
+    } finally {
+      setIsSubmitting(false);
     }
-    await refetch();
-    highlightRow(selectedStock.id);
-    setShowSellModal(false);
   };
 
   const handleAdjust = async (data) => {
@@ -1205,6 +1218,7 @@ export default function MainApp({ session, onLogout }) {
                 onConfirm={handleBuy}
                 onCancel={() => setShowBuyModal(false)}
                 geData={gePrices}
+                isSubmitting={isSubmitting}
               />
             </ModalContainer>
 
@@ -1214,6 +1228,7 @@ export default function MainApp({ session, onLogout }) {
                 onConfirm={handleSell}
                 onCancel={() => setShowSellModal(false)}
                 geData={gePrices}
+                isSubmitting={isSubmitting}
               />
             </ModalContainer>
 

--- a/src/components/modals/BuyModal.jsx
+++ b/src/components/modals/BuyModal.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { formatNumber, parseMK } from '../../utils/formatters';
 
-export default function BuyModal({ stock, onConfirm, onCancel, geData = {} }) {
+export default function BuyModal({ stock, onConfirm, onCancel, geData = {}, isSubmitting = false }) {
   const [shares, setShares] = useState((stock.limit4h * 1).toString());
   const [price, setPrice] = useState('');
   const [startTimer, setStartTimer] = useState(true);
@@ -313,19 +313,21 @@ export default function BuyModal({ stock, onConfirm, onCancel, geData = {} }) {
         <div style={{ display: 'flex', gap: '0.75rem', paddingTop: '1rem' }}>
           <button
             onClick={handleConfirm}
+            disabled={isSubmitting}
             style={{
               flex: 1,
               padding: '0.5rem 1rem',
-              background: 'rgb(21, 128, 61)',
+              background: isSubmitting ? 'rgb(100, 100, 100)' : 'rgb(21, 128, 61)',
               borderRadius: '0.5rem',
               transition: 'background 0.2s',
               border: 'none',
               color: 'white',
-              cursor: 'pointer',
-              fontWeight: '500'
+              cursor: isSubmitting ? 'not-allowed' : 'pointer',
+              fontWeight: '500',
+              opacity: isSubmitting ? 0.5 : 1
             }}
-            onMouseOver={(e) => e.currentTarget.style.background = 'rgb(22, 101, 52)'}
-            onMouseOut={(e) => e.currentTarget.style.background = 'rgb(21, 128, 61)'}
+            onMouseOver={(e) => { if (!isSubmitting) e.currentTarget.style.background = 'rgb(22, 101, 52)'; }}
+            onMouseOut={(e) => { if (!isSubmitting) e.currentTarget.style.background = 'rgb(21, 128, 61)'; }}
           >
             Confirm
           </button>

--- a/src/components/modals/ModalContainer.jsx
+++ b/src/components/modals/ModalContainer.jsx
@@ -13,7 +13,7 @@ export default function ModalContainer({ isOpen, children }) {
       <div style={{
         minHeight: '100%',
         display: 'flex',
-        alignItems: 'flex-start',
+        alignItems: 'center',
         justifyContent: 'center',
         padding: '2rem 1rem',
         background: 'rgba(0, 0, 0, 0.7)',

--- a/src/components/modals/SellModal.jsx
+++ b/src/components/modals/SellModal.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { formatNumber, parseMK } from '../../utils/formatters';
 
-export default function SellModal({ stock, onConfirm, onCancel, geData = {} }) {
+export default function SellModal({ stock, onConfirm, onCancel, geData = {}, isSubmitting = false }) {
   const [shares, setShares] = useState('');
   const [price, setPrice] = useState('');
   const [useTotal, setUseTotal] = useState(false);
@@ -325,32 +325,32 @@ export default function SellModal({ stock, onConfirm, onCancel, geData = {} }) {
         <div style={{ display: 'flex', gap: '0.75rem', paddingTop: '1rem' }}>
           <button
             onClick={handleConfirm}
-            disabled={!shares || parseFloat(shares) > stock.shares || parseFloat(shares) <= 0}
+            disabled={isSubmitting || !shares || parseFloat(shares) > stock.shares || parseFloat(shares) <= 0}
             style={{
               flex: 1,
               padding: '0.5rem 1rem',
-              background: (!shares || parseFloat(shares) > stock.shares || parseFloat(shares) <= 0)
+              background: (isSubmitting || !shares || parseFloat(shares) > stock.shares || parseFloat(shares) <= 0)
                 ? 'rgb(100, 100, 100)'
                 : 'rgb(185, 28, 28)',
               borderRadius: '0.5rem',
               transition: 'background 0.2s',
               border: 'none',
               color: 'white',
-              cursor: (!shares || parseFloat(shares) > stock.shares || parseFloat(shares) <= 0)
+              cursor: (isSubmitting || !shares || parseFloat(shares) > stock.shares || parseFloat(shares) <= 0)
                 ? 'not-allowed'
                 : 'pointer',
               fontWeight: '500',
-              opacity: (!shares || parseFloat(shares) > stock.shares || parseFloat(shares) <= 0)
+              opacity: (isSubmitting || !shares || parseFloat(shares) > stock.shares || parseFloat(shares) <= 0)
                 ? 0.5
                 : 1
             }}
             onMouseOver={(e) => {
-              if (shares && parseFloat(shares) <= stock.shares && parseFloat(shares) > 0) {
+              if (!isSubmitting && shares && parseFloat(shares) <= stock.shares && parseFloat(shares) > 0) {
                 e.currentTarget.style.background = 'rgb(153, 27, 27)';
               }
             }}
             onMouseOut={(e) => {
-              if (shares && parseFloat(shares) <= stock.shares && parseFloat(shares) > 0) {
+              if (!isSubmitting && shares && parseFloat(shares) <= stock.shares && parseFloat(shares) > 0) {
                 e.currentTarget.style.background = 'rgb(185, 28, 28)';
               }
             }}


### PR DESCRIPTION
## Summary
  Double-clicking the Confirm button in Buy/Sell modals could fire multiple concurrent submissions, writing duplicate transactions to the database. This adds an isSubmitting guard to block concurrent executions and disables  
  the button while submitting. Also restores modal vertical centering which was broken by a previous commit.

  ## Changes
  - Add `isSubmitting` state to `MainApp` with a guard at the start of `handleBuy`/`handleSell` and `try/finally` reset
  - Pass `isSubmitting` prop to `BuyModal` and `SellModal`; disable Confirm button while submitting
  - Fix `ModalContainer` `alignItems` back to `center` (was changed to `flex-start` in a previous commit, causing modals to appear at the top of the screen)