### PR TITLE
feat(milestones): add milestone history recording and viewer

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -77,7 +77,7 @@ export default function MainApp({ session, onLogout }) {
   const { settings, loading: settingsLoading, updateSettings } = useSettings(userId);
   const { profits, loading: profitsLoading, updateProfit } = useProfits(userId);
   const { profitHistory, loading: profitHistoryLoading, addProfitEntry, refetch: refetchProfitHistory } = useProfitHistory(userId);
-  const { milestones, milestoneHistory, loading: milestonesLoading, updateMilestone, recordMilestoneAchievement, PRESET_GOALS } = useMilestones(userId);
+  const { milestones, milestoneHistory, loading: milestonesLoading, updateMilestone, recordMilestoneAchievement, recordCompletedPeriods, PRESET_GOALS } = useMilestones(userId);
 
   // Destructure profits
   const { dumpProfit, referralProfit, bondsProfit } = profits;
@@ -118,6 +118,7 @@ export default function MainApp({ session, onLogout }) {
   const [showAdjustModal, setShowAdjustModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showMilestoneModal, setShowMilestoneModal] = useState(false);
+  const [milestoneInitialView, setMilestoneInitialView] = useState('main');
   const [showNewStockModal, setShowNewStockModal] = useState(false);
   const [showCategoryModal, setShowCategoryModal] = useState(false);
   const [showAltTimerModal, setShowAltTimerModal] = useState(false);
@@ -365,6 +366,10 @@ export default function MainApp({ session, onLogout }) {
     };
 
     setMilestoneProgress(newProgress);
+
+    if (!milestonesLoading) {
+      recordCompletedPeriods(profitHistory, milestones);
+    }
   }, [dataLoaded, profitHistory, milestones]);
 
   useEffect(() => {
@@ -1031,7 +1036,8 @@ export default function MainApp({ session, onLogout }) {
             milestones={milestones}
             milestoneProgress={milestoneProgress}
             onNavigateToTrade={() => navigateToPage('trade')}
-            onOpenMilestoneModal={() => setShowMilestoneModal(true)}
+            onOpenMilestoneModal={() => { setMilestoneInitialView('main'); setShowMilestoneModal(true); }}
+            onOpenMilestoneHistory={() => { setMilestoneInitialView('history'); setShowMilestoneModal(true); }}
           />
         ) : currentPage === 'history' ? (
           <HistoryPage
@@ -1090,7 +1096,7 @@ export default function MainApp({ session, onLogout }) {
                 currentProgress={milestoneProgress}
                 selectedPeriod={selectedMilestonePeriod}
                 onPeriodChange={setSelectedMilestonePeriod}
-                onOpenModal={() => setShowMilestoneModal(true)}
+                onOpenModal={() => { setMilestoneInitialView('main'); setShowMilestoneModal(true); }}
                 numberFormat={numberFormat}
               />
 
@@ -1483,6 +1489,8 @@ export default function MainApp({ session, onLogout }) {
           <MilestoneTrackerModal
             milestones={milestones}
             currentProgress={milestoneProgress}
+            milestoneHistory={milestoneHistory}
+            initialView={milestoneInitialView}
             onUpdateMilestone={handleUpdateMilestone}
             onCancel={() => setShowMilestoneModal(false)}
             numberFormat={numberFormat}

--- a/src/components/modals/MilestoneTrackerModal.jsx
+++ b/src/components/modals/MilestoneTrackerModal.jsx
@@ -2,9 +2,35 @@ import React, { useState } from 'react';
 import { X } from 'lucide-react';
 import { formatNumber } from '../../utils/formatters';
 
+const formatPeriodRange = (periodStart, period) => {
+  // Parse as local date (YYYY-MM-DD) to avoid UTC shift issues
+  const parts = periodStart.split('-');
+  const localStart = new Date(parseInt(parts[0]), parseInt(parts[1]) - 1, parseInt(parts[2]));
+
+  switch (period) {
+    case 'day':
+      return localStart.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+    case 'week': {
+      const end = new Date(localStart);
+      end.setDate(end.getDate() + 6);
+      const startStr = localStart.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+      const endStr = end.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+      return `${startStr} – ${endStr}`;
+    }
+    case 'month':
+      return localStart.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+    case 'year':
+      return localStart.getFullYear().toString();
+    default:
+      return periodStart;
+  }
+};
+
 export default function MilestoneTrackerModal({
   milestones,
   currentProgress,
+  milestoneHistory,
+  initialView,
   onUpdateMilestone,
   onCancel,
   numberFormat,
@@ -13,6 +39,7 @@ export default function MilestoneTrackerModal({
   const [selectedPeriod, setSelectedPeriod] = useState('week');
   const [editingGoal, setEditingGoal] = useState(false);
   const [customGoal, setCustomGoal] = useState('');
+  const [showHistory, setShowHistory] = useState(initialView === 'history');
 
   const periods = [
     { key: 'day', label: 'Day', emoji: '☀️' },
@@ -26,6 +53,8 @@ export default function MilestoneTrackerModal({
   const percentage = currentMilestone.goal > 0 ? (progress / currentMilestone.goal) * 100 : 0;
   const displayPercentage = Math.min(percentage, 100);
   const isComplete = progress >= currentMilestone.goal;
+
+  const filteredHistory = (milestoneHistory || []).filter(r => r.period === selectedPeriod);
 
   const getResetTime = (period) => {
     const now = new Date();
@@ -73,6 +102,38 @@ export default function MilestoneTrackerModal({
     }
   };
 
+  const periodTabRow = (
+    <div style={{
+      display: 'flex',
+      gap: '0.5rem',
+      marginBottom: '1.5rem',
+      background: 'rgb(15, 23, 42)',
+      padding: '0.25rem',
+      borderRadius: '0.5rem'
+    }}>
+      {periods.map(period => (
+        <button
+          key={period.key}
+          onClick={() => setSelectedPeriod(period.key)}
+          style={{
+            flex: 1,
+            padding: '0.5rem',
+            background: selectedPeriod === period.key ? 'rgb(37, 99, 235)' : 'transparent',
+            border: 'none',
+            borderRadius: '0.375rem',
+            color: 'white',
+            cursor: 'pointer',
+            fontSize: '0.875rem',
+            fontWeight: '500',
+            transition: 'background 0.2s'
+          }}
+        >
+          {period.emoji} {period.label}
+        </button>
+      ))}
+    </div>
+  );
+
   return (
     <div style={{
       background: 'rgb(30, 41, 59)',
@@ -103,229 +164,306 @@ export default function MilestoneTrackerModal({
         </button>
       </div>
 
-      {/* Period Tabs */}
-      <div style={{
-        display: 'flex',
-        gap: '0.5rem',
-        marginBottom: '1.5rem',
-        background: 'rgb(15, 23, 42)',
-        padding: '0.25rem',
-        borderRadius: '0.5rem'
-      }}>
-        {periods.map(period => (
+      {showHistory ? (
+        <>
+          {/* Back button */}
           <button
-            key={period.key}
-            onClick={() => setSelectedPeriod(period.key)}
+            onClick={() => setShowHistory(false)}
             style={{
-              flex: 1,
-              padding: '0.5rem',
-              background: selectedPeriod === period.key ? 'rgb(37, 99, 235)' : 'transparent',
+              background: 'none',
               border: 'none',
-              borderRadius: '0.375rem',
-              color: 'white',
+              color: 'rgb(156, 163, 175)',
               cursor: 'pointer',
               fontSize: '0.875rem',
-              fontWeight: '500',
-              transition: 'background 0.2s'
+              padding: 0,
+              marginBottom: '1rem',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.25rem'
             }}
           >
-            {period.emoji} {period.label}
+            ← Back
           </button>
-        ))}
-      </div>
 
-      {/* Progress Display */}
-      <div style={{ marginBottom: '1.5rem' }}>
-        {/* Progress Bar */}
-        <div style={{
-          background: 'rgb(15, 23, 42)',
-          borderRadius: '0.75rem',
-          padding: '1.5rem',
-          border: '1px solid rgb(51, 65, 85)'
-        }}>
-          <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.75rem' }}>
-            <span style={{ fontSize: '0.875rem', color: 'rgb(156, 163, 175)' }}>Progress</span>
-            <span style={{ fontSize: '0.875rem', fontWeight: 'bold', color: isComplete ? 'rgb(34, 197, 94)' : 'white' }}>
-              {percentage.toFixed(1)}%
-            </span>
-          </div>
+          {periodTabRow}
 
-          {/* Progress Bar */}
+          {/* History list */}
           <div style={{
-            width: '100%',
-            height: '1rem',
-            background: 'rgb(51, 65, 85)',
-            borderRadius: '0.5rem',
-            overflow: 'hidden',
-            marginBottom: '1rem'
+            maxHeight: '400px',
+            overflowY: 'auto',
+            marginBottom: '1rem',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '0.5rem'
           }}>
-            <div style={{
-              width: `${displayPercentage}%`,
-              height: '100%',
-              background: isComplete 
-                ? 'linear-gradient(90deg, rgb(34, 197, 94), rgb(22, 163, 74))'
-                : percentage > 75 
-                  ? 'linear-gradient(90deg, rgb(234, 179, 8), rgb(202, 138, 4))'
-                  : 'linear-gradient(90deg, rgb(59, 130, 246), rgb(37, 99, 235))',
-              transition: 'width 0.3s ease'
-            }}></div>
-          </div>
-
-          {/* Amount Display */}
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
-            <div>
-              <div style={{ fontSize: '1.75rem', fontWeight: 'bold', color: isComplete ? 'rgb(34, 197, 94)' : 'white' }}>
-                {formatNumber(progress, numberFormat)}
+            {filteredHistory.length === 0 ? (
+              <div style={{
+                textAlign: 'center',
+                color: 'rgb(156, 163, 175)',
+                padding: '2rem 0',
+                fontSize: '0.875rem'
+              }}>
+                No history yet
               </div>
-              <div style={{ fontSize: '0.75rem', color: 'rgb(156, 163, 175)', marginTop: '0.25rem' }}>
-                of {formatNumber(currentMilestone.goal, numberFormat)}
-              </div>
-            </div>
-            {isComplete && (
-              <div style={{ fontSize: '2rem' }}>🎉</div>
+            ) : (
+              filteredHistory.map((record) => {
+                const hit = record.actual_amount >= record.goal_amount;
+                return (
+                  <div
+                    key={record.id}
+                    style={{
+                      background: 'rgb(15, 23, 42)',
+                      borderRadius: '0.5rem',
+                      padding: '0.75rem 1rem',
+                      border: '1px solid rgb(51, 65, 85)',
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                      gap: '1rem'
+                    }}
+                  >
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ fontSize: '0.875rem', fontWeight: '500', marginBottom: '0.25rem' }}>
+                        {record.period_start ? formatPeriodRange(record.period_start, record.period) : '—'}
+                      </div>
+                      <div style={{ fontSize: '0.75rem', color: 'rgb(156, 163, 175)' }}>
+                        {formatNumber(record.actual_amount, numberFormat)} / {formatNumber(record.goal_amount, numberFormat)}
+                      </div>
+                    </div>
+                    <div style={{
+                      fontSize: '0.75rem',
+                      fontWeight: '600',
+                      padding: '0.25rem 0.625rem',
+                      borderRadius: '9999px',
+                      background: hit ? 'rgba(34, 197, 94, 0.15)' : 'rgba(239, 68, 68, 0.15)',
+                      color: hit ? 'rgb(34, 197, 94)' : 'rgb(239, 68, 68)',
+                      whiteSpace: 'nowrap'
+                    }}>
+                      {hit ? '✓ Hit' : '✗ Missed'}
+                    </div>
+                  </div>
+                );
+              })
             )}
           </div>
 
-          {/* Reset Timer */}
-          <div style={{
-            marginTop: '1rem',
-            paddingTop: '1rem',
-            borderTop: '1px solid rgb(51, 65, 85)',
-            fontSize: '0.75rem',
-            color: 'rgb(156, 163, 175)',
-            textAlign: 'center'
-          }}>
-            ⏱️ {getResetTime(selectedPeriod)}
-          </div>
-        </div>
-      </div>
+          {/* Done button */}
+          <button
+            onClick={onCancel}
+            style={{
+              width: '100%',
+              padding: '0.75rem',
+              background: 'rgb(37, 99, 235)',
+              border: 'none',
+              borderRadius: '0.5rem',
+              color: 'white',
+              cursor: 'pointer',
+              fontSize: '0.875rem',
+              fontWeight: '500'
+            }}
+            onMouseOver={(e) => e.currentTarget.style.background = 'rgb(29, 78, 216)'}
+            onMouseOut={(e) => e.currentTarget.style.background = 'rgb(37, 99, 235)'}
+          >
+            Done
+          </button>
+        </>
+      ) : (
+        <>
+          {periodTabRow}
 
-      {/* Goal Selection */}
-      {editingGoal ? (
-        <div style={{ marginBottom: '1rem' }}>
-          <label style={{ display: 'block', fontSize: '0.875rem', fontWeight: '600', marginBottom: '0.75rem' }}>
-            Select Goal Amount
-          </label>
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '0.5rem', marginBottom: '0.75rem' }}>
-            {PRESET_GOALS.map(goal => (
-              <button
-                key={goal}
-                onClick={() => handleGoalSelect(goal)}
-                style={{
-                  padding: '0.75rem',
-                  background: currentMilestone.goal === goal ? 'rgb(37, 99, 235)' : 'rgb(51, 65, 85)',
-                  border: 'none',
-                  borderRadius: '0.5rem',
-                  color: 'white',
-                  cursor: 'pointer',
-                  fontSize: '0.875rem',
-                  fontWeight: '500'
-                }}
-              >
-                {formatNumber(goal, numberFormat)}
-              </button>
-            ))}
-          </div>
-          
-          {/* Custom Goal Input */}
-          <div style={{ marginBottom: '0.75rem' }}>
-            <label style={{ display: 'block', fontSize: '0.75rem', color: 'rgb(156, 163, 175)', marginBottom: '0.5rem' }}>
-              Or enter custom amount:
-            </label>
-            <div style={{ display: 'flex', gap: '0.5rem' }}>
-              <input
-                type="number"
-                value={customGoal}
-                onChange={(e) => setCustomGoal(e.target.value)}
-                placeholder="Enter custom goal"
-                style={{
-                  flex: 1,
-                  padding: '0.75rem',
-                  background: 'rgb(15, 23, 42)',
-                  border: '1px solid rgb(51, 65, 85)',
-                  borderRadius: '0.5rem',
-                  color: 'white',
-                  fontSize: '0.875rem'
-                }}
-              />
-              <button
-                onClick={handleCustomGoalSubmit}
-                disabled={!customGoal || parseFloat(customGoal) <= 0}
-                style={{
-                  padding: '0.75rem 1.25rem',
-                  background: (!customGoal || parseFloat(customGoal) <= 0) 
-                    ? 'rgb(71, 85, 105)' 
-                    : 'rgb(34, 197, 94)',
-                  border: 'none',
-                  borderRadius: '0.5rem',
-                  color: 'white',
-                  cursor: (!customGoal || parseFloat(customGoal) <= 0) ? 'not-allowed' : 'pointer',
-                  fontSize: '0.875rem',
-                  fontWeight: '500'
-                }}
-              >
-                Set
-              </button>
+          {/* Progress Display */}
+          <div style={{ marginBottom: '1.5rem' }}>
+            <div style={{
+              background: 'rgb(15, 23, 42)',
+              borderRadius: '0.75rem',
+              padding: '1.5rem',
+              border: '1px solid rgb(51, 65, 85)'
+            }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.75rem' }}>
+                <span style={{ fontSize: '0.875rem', color: 'rgb(156, 163, 175)' }}>Progress</span>
+                <span style={{ fontSize: '0.875rem', fontWeight: 'bold', color: isComplete ? 'rgb(34, 197, 94)' : 'white' }}>
+                  {percentage.toFixed(1)}%
+                </span>
+              </div>
+
+              {/* Progress Bar */}
+              <div style={{
+                width: '100%',
+                height: '1rem',
+                background: 'rgb(51, 65, 85)',
+                borderRadius: '0.5rem',
+                overflow: 'hidden',
+                marginBottom: '1rem'
+              }}>
+                <div style={{
+                  width: `${displayPercentage}%`,
+                  height: '100%',
+                  background: isComplete
+                    ? 'linear-gradient(90deg, rgb(34, 197, 94), rgb(22, 163, 74))'
+                    : percentage > 75
+                      ? 'linear-gradient(90deg, rgb(234, 179, 8), rgb(202, 138, 4))'
+                      : 'linear-gradient(90deg, rgb(59, 130, 246), rgb(37, 99, 235))',
+                  transition: 'width 0.3s ease'
+                }}></div>
+              </div>
+
+              {/* Amount Display */}
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+                <div>
+                  <div style={{ fontSize: '1.75rem', fontWeight: 'bold', color: isComplete ? 'rgb(34, 197, 94)' : 'white' }}>
+                    {formatNumber(progress, numberFormat)}
+                  </div>
+                  <div style={{ fontSize: '0.75rem', color: 'rgb(156, 163, 175)', marginTop: '0.25rem' }}>
+                    of {formatNumber(currentMilestone.goal, numberFormat)}
+                  </div>
+                </div>
+                {isComplete && (
+                  <div style={{ fontSize: '2rem' }}>🎉</div>
+                )}
+              </div>
+
+              {/* Reset Timer */}
+              <div style={{
+                marginTop: '1rem',
+                paddingTop: '1rem',
+                borderTop: '1px solid rgb(51, 65, 85)',
+                fontSize: '0.75rem',
+                color: 'rgb(156, 163, 175)',
+                textAlign: 'center'
+              }}>
+                ⏱️ {getResetTime(selectedPeriod)}
+              </div>
             </div>
           </div>
 
+          {/* Goal Selection */}
+          {editingGoal ? (
+            <div style={{ marginBottom: '1rem' }}>
+              <label style={{ display: 'block', fontSize: '0.875rem', fontWeight: '600', marginBottom: '0.75rem' }}>
+                Select Goal Amount
+              </label>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '0.5rem', marginBottom: '0.75rem' }}>
+                {PRESET_GOALS.map(goal => (
+                  <button
+                    key={goal}
+                    onClick={() => handleGoalSelect(goal)}
+                    style={{
+                      padding: '0.75rem',
+                      background: currentMilestone.goal === goal ? 'rgb(37, 99, 235)' : 'rgb(51, 65, 85)',
+                      border: 'none',
+                      borderRadius: '0.5rem',
+                      color: 'white',
+                      cursor: 'pointer',
+                      fontSize: '0.875rem',
+                      fontWeight: '500'
+                    }}
+                  >
+                    {formatNumber(goal, numberFormat)}
+                  </button>
+                ))}
+              </div>
+
+              {/* Custom Goal Input */}
+              <div style={{ marginBottom: '0.75rem' }}>
+                <label style={{ display: 'block', fontSize: '0.75rem', color: 'rgb(156, 163, 175)', marginBottom: '0.5rem' }}>
+                  Or enter custom amount:
+                </label>
+                <div style={{ display: 'flex', gap: '0.5rem' }}>
+                  <input
+                    type="number"
+                    value={customGoal}
+                    onChange={(e) => setCustomGoal(e.target.value)}
+                    placeholder="Enter custom goal"
+                    style={{
+                      flex: 1,
+                      padding: '0.75rem',
+                      background: 'rgb(15, 23, 42)',
+                      border: '1px solid rgb(51, 65, 85)',
+                      borderRadius: '0.5rem',
+                      color: 'white',
+                      fontSize: '0.875rem'
+                    }}
+                  />
+                  <button
+                    onClick={handleCustomGoalSubmit}
+                    disabled={!customGoal || parseFloat(customGoal) <= 0}
+                    style={{
+                      padding: '0.75rem 1.25rem',
+                      background: (!customGoal || parseFloat(customGoal) <= 0)
+                        ? 'rgb(71, 85, 105)'
+                        : 'rgb(34, 197, 94)',
+                      border: 'none',
+                      borderRadius: '0.5rem',
+                      color: 'white',
+                      cursor: (!customGoal || parseFloat(customGoal) <= 0) ? 'not-allowed' : 'pointer',
+                      fontSize: '0.875rem',
+                      fontWeight: '500'
+                    }}
+                  >
+                    Set
+                  </button>
+                </div>
+              </div>
+
+              <button
+                onClick={() => setEditingGoal(false)}
+                style={{
+                  width: '100%',
+                  padding: '0.5rem',
+                  background: 'transparent',
+                  border: '1px solid rgb(71, 85, 105)',
+                  borderRadius: '0.5rem',
+                  color: 'rgb(156, 163, 175)',
+                  cursor: 'pointer',
+                  fontSize: '0.875rem'
+                }}
+              >
+                Cancel
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={() => setEditingGoal(true)}
+              style={{
+                width: '100%',
+                padding: '0.75rem',
+                background: 'rgb(51, 65, 85)',
+                border: 'none',
+                borderRadius: '0.5rem',
+                color: 'white',
+                cursor: 'pointer',
+                fontSize: '0.875rem',
+                fontWeight: '500',
+                marginBottom: '0.75rem'
+              }}
+              onMouseOver={(e) => e.currentTarget.style.background = 'rgb(71, 85, 105)'}
+              onMouseOut={(e) => e.currentTarget.style.background = 'rgb(51, 65, 85)'}
+            >
+              Change Goal
+            </button>
+          )}
+
+          {/* Close Button */}
           <button
-            onClick={() => setEditingGoal(false)}
+            onClick={onCancel}
             style={{
               width: '100%',
-              padding: '0.5rem',
-              background: 'transparent',
-              border: '1px solid rgb(71, 85, 105)',
+              padding: '0.75rem',
+              background: 'rgb(37, 99, 235)',
+              border: 'none',
               borderRadius: '0.5rem',
-              color: 'rgb(156, 163, 175)',
+              color: 'white',
               cursor: 'pointer',
-              fontSize: '0.875rem'
+              fontSize: '0.875rem',
+              fontWeight: '500'
             }}
+            onMouseOver={(e) => e.currentTarget.style.background = 'rgb(29, 78, 216)'}
+            onMouseOut={(e) => e.currentTarget.style.background = 'rgb(37, 99, 235)'}
           >
-            Cancel
+            Done
           </button>
-        </div>
-      ) : (
-        <button
-          onClick={() => setEditingGoal(true)}
-          style={{
-            width: '100%',
-            padding: '0.75rem',
-            background: 'rgb(51, 65, 85)',
-            border: 'none',
-            borderRadius: '0.5rem',
-            color: 'white',
-            cursor: 'pointer',
-            fontSize: '0.875rem',
-            fontWeight: '500',
-            marginBottom: '1rem'
-          }}
-          onMouseOver={(e) => e.currentTarget.style.background = 'rgb(71, 85, 105)'}
-          onMouseOut={(e) => e.currentTarget.style.background = 'rgb(51, 65, 85)'}
-        >
-          Change Goal
-        </button>
+        </>
       )}
-
-      {/* Close Button */}
-      <button
-        onClick={onCancel}
-        style={{
-          width: '100%',
-          padding: '0.75rem',
-          background: 'rgb(37, 99, 235)',
-          border: 'none',
-          borderRadius: '0.5rem',
-          color: 'white',
-          cursor: 'pointer',
-          fontSize: '0.875rem',
-          fontWeight: '500'
-        }}
-        onMouseOver={(e) => e.currentTarget.style.background = 'rgb(29, 78, 216)'}
-        onMouseOut={(e) => e.currentTarget.style.background = 'rgb(37, 99, 235)'}
-      >
-        Done
-      </button>
     </div>
   );
 }

--- a/src/hooks/useMilestones.js
+++ b/src/hooks/useMilestones.js
@@ -3,6 +3,79 @@ import { supabase } from '../lib/supabase';
 
 const PRESET_GOALS = [10000000, 50000000, 100000000, 500000000, 1000000000]; // 10M, 50M, 100M, 500M, 1B
 
+// --- Period helpers ---
+
+const getPeriodStart = (date, period) => {
+  const d = new Date(date);
+  switch (period) {
+    case 'day':
+      d.setHours(0, 0, 0, 0);
+      return d;
+    case 'week': {
+      const day = d.getDay();
+      const diff = day === 0 ? -6 : 1 - day; // Monday = start
+      d.setDate(d.getDate() + diff);
+      d.setHours(0, 0, 0, 0);
+      return d;
+    }
+    case 'month':
+      d.setDate(1);
+      d.setHours(0, 0, 0, 0);
+      return d;
+    case 'year':
+      d.setMonth(0, 1);
+      d.setHours(0, 0, 0, 0);
+      return d;
+    default:
+      return d;
+  }
+};
+
+const getPeriodEnd = (periodStart, period) => {
+  const d = new Date(periodStart);
+  switch (period) {
+    case 'day':
+      d.setDate(d.getDate() + 1);
+      return d;
+    case 'week':
+      d.setDate(d.getDate() + 7);
+      return d;
+    case 'month':
+      d.setMonth(d.getMonth() + 1);
+      return d;
+    case 'year':
+      d.setFullYear(d.getFullYear() + 1);
+      return d;
+    default:
+      return d;
+  }
+};
+
+// Returns all completed period start dates between minDate and now (exclusive current period)
+const generatePastPeriods = (period, minDate) => {
+  const now = new Date();
+  const currentPeriodStart = getPeriodStart(now, period);
+  const periods = [];
+
+  let cursor = getPeriodStart(minDate, period);
+  while (cursor < currentPeriodStart) {
+    periods.push(new Date(cursor));
+    cursor = getPeriodEnd(cursor, period);
+  }
+
+  return periods;
+};
+
+// Convert a Date to a YYYY-MM-DD string (local time)
+const toDateString = (date) => {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+};
+
+// ---
+
 export function useMilestones(userId) {
   const [milestones, setMilestones] = useState({
     day: { goal: 10000000, enabled: true },
@@ -57,8 +130,7 @@ export function useMilestones(userId) {
       .from('milestone_history')
       .select('*')
       .eq('user_id', userId)
-      .order('achieved_at', { ascending: false })
-      .limit(50);
+      .order('period_start', { ascending: false });
 
     if (error) {
       console.error('Error fetching milestone history:', error);
@@ -115,12 +187,79 @@ export function useMilestones(userId) {
     return true;
   };
 
+  // Scans profitHistory to backfill milestone_history for all completed past periods.
+  // Safe to call repeatedly — skips periods already recorded.
+  const recordCompletedPeriods = async (profitHistory, currentMilestones) => {
+    if (!profitHistory || profitHistory.length === 0) return;
+
+    // Earliest entry date, capped at 1 year back
+    const entryDates = profitHistory.map(e => new Date(e.created_at).getTime());
+    const minDate = new Date(Math.min(...entryDates));
+    const oneYearAgo = new Date();
+    oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+    const effectiveMinDate = minDate < oneYearAgo ? oneYearAgo : minDate;
+
+    const periodTypes = ['day', 'week', 'month', 'year'];
+
+    for (const period of periodTypes) {
+      const goalAmount = currentMilestones[period]?.goal || 0;
+      const pastPeriods = generatePastPeriods(period, effectiveMinDate);
+      if (pastPeriods.length === 0) continue;
+
+      // Fetch already-recorded period_starts for this user+period
+      const { data: existing } = await supabase
+        .from('milestone_history')
+        .select('period_start')
+        .eq('user_id', userId)
+        .eq('period', period);
+
+      const existingStarts = new Set((existing || []).map(r => r.period_start));
+
+      const toInsert = [];
+      for (const periodStart of pastPeriods) {
+        const periodStartStr = toDateString(periodStart);
+        if (existingStarts.has(periodStartStr)) continue;
+
+        const periodEnd = getPeriodEnd(periodStart, period);
+
+        const actualAmount = profitHistory
+          .filter(entry => {
+            const d = new Date(entry.created_at);
+            return d >= periodStart && d < periodEnd && entry.profit_type !== 'bonds';
+          })
+          .reduce((sum, entry) => sum + entry.amount, 0);
+
+        toInsert.push({
+          user_id: userId,
+          period,
+          period_start: periodStartStr,
+          goal_amount: goalAmount,
+          actual_amount: actualAmount,
+          achieved_at: periodEnd.toISOString()
+        });
+      }
+
+      if (toInsert.length > 0) {
+        const { error } = await supabase
+          .from('milestone_history')
+          .upsert(toInsert, { onConflict: 'user_id,period,period_start', ignoreDuplicates: true });
+
+        if (error) {
+          console.error(`Error recording milestone history for ${period}:`, error);
+        }
+      }
+    }
+
+    await fetchMilestoneHistory();
+  };
+
   return {
     milestones,
     milestoneHistory,
     loading,
     updateMilestone,
     recordMilestoneAchievement,
+    recordCompletedPeriods,
     refetch: fetchMilestones,
     PRESET_GOALS
   };

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -11,6 +11,7 @@ export default function HomePage({
   milestoneProgress,
   onNavigateToTrade,
   onOpenMilestoneModal,
+  onOpenMilestoneHistory,
   profitHistory
 }) {
   // Use milestoneProgress for period profits (already calculated in MainApp)
@@ -309,6 +310,14 @@ export default function HomePage({
             style={{ width: '100%', marginTop: '1rem', justifyContent: 'center' }}
           >
             🎯 Edit Goals
+          </button>
+
+          <button
+            onClick={onOpenMilestoneHistory}
+            className="btn btn-secondary"
+            style={{ width: '100%', marginTop: '0.5rem', justifyContent: 'center' }}
+          >
+            📋 View History
           </button>
         </div>
       </div>


### PR DESCRIPTION
   ## Summary
   Automatically backfills `milestone_history` for all completed past periods (day/week/month/year) on load, excluding bonds profit. Adds a "View History" button on the HomePage Goals section that opens the milestone modal   
    directly into a history view, filtered by period tab.

   ## Changes
   - `useMilestones.js` — added period helpers (`getPeriodStart`, `getPeriodEnd`, `generatePastPeriods`) and `recordCompletedPeriods()` which backfills all completed past periods (up to 1 year) into `milestone_history`,      
   skipping already-recorded ones; removed 50-record limit on history fetch; orders by `period_start` desc
   - `MainApp.jsx` — calls `recordCompletedPeriods` after profit history loads; adds `milestoneInitialView` state to control whether the modal opens on the main or history view; passes `milestoneHistory` and `initialView`    
   to `MilestoneTrackerModal`
   - `MilestoneTrackerModal.jsx` — adds history view with back button, period tabs, and scrollable list showing date range, actual/goal amounts, and hit/missed badge; accepts `initialView` prop to open directly into
   history
   - `HomePage.jsx` — adds "📋 View History" button below "🎯 Edit Goals" in the Goals section