### PR TITLE
Add favorites and recents to Graph page

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -1089,6 +1089,7 @@ export default function MainApp({ session, onLogout }) {
             prices={gePrices}
             iconMap={geIconMap}
             mappingLoading={mappingLoading}
+            userId={userId}
           />
         ) : (
           <>

--- a/src/hooks/useGraphPreferences.js
+++ b/src/hooks/useGraphPreferences.js
@@ -1,0 +1,146 @@
+import { useState, useEffect, useCallback } from 'react';
+import { supabase } from '../lib/supabase';
+
+export function useGraphPreferences(userId) {
+  const [favorites, setFavorites] = useState([]);
+  const [recents, setRecents] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchPreferences = useCallback(async () => {
+    if (!userId) return;
+    const { data, error } = await supabase
+      .from('graph_preferences')
+      .select('*')
+      .eq('user_id', userId);
+
+    if (error) {
+      console.error('Error fetching graph preferences:', error);
+      setFavorites([]);
+      setRecents([]);
+    } else {
+      const rows = data || [];
+      const favs = rows
+        .filter(r => r.is_favorite)
+        .sort((a, b) => new Date(b.favorited_at) - new Date(a.favorited_at))
+        .map(r => ({ itemId: r.item_id, itemName: r.item_name, lastViewedAt: r.last_viewed_at, favoritedAt: r.favorited_at }));
+      const recs = rows
+        .filter(r => !r.is_favorite && r.last_viewed_at)
+        .sort((a, b) => new Date(b.last_viewed_at) - new Date(a.last_viewed_at))
+        .slice(0, 10)
+        .map(r => ({ itemId: r.item_id, itemName: r.item_name, lastViewedAt: r.last_viewed_at }));
+      setFavorites(favs);
+      setRecents(recs);
+    }
+    setLoading(false);
+  }, [userId]);
+
+  useEffect(() => {
+    if (!userId) return;
+    let cancelled = false;
+    const load = async () => {
+      await fetchPreferences();
+      if (cancelled) return;
+    };
+    load();
+    return () => { cancelled = true; };
+  }, [userId, fetchPreferences]);
+
+  const addRecent = async (item) => {
+    if (!userId || !item) return;
+    const now = new Date().toISOString();
+
+    // Optimistic update
+    setRecents(prev => {
+      const filtered = prev.filter(r => r.itemId !== item.id);
+      return [{ itemId: item.id, itemName: item.name, lastViewedAt: now }, ...filtered].slice(0, 10);
+    });
+    // Also update lastViewedAt if it's a favorite
+    setFavorites(prev => prev.map(f => f.itemId === item.id ? { ...f, lastViewedAt: now } : f));
+
+    const { error } = await supabase
+      .from('graph_preferences')
+      .upsert({
+        user_id: userId,
+        item_id: item.id,
+        item_name: item.name,
+        last_viewed_at: now,
+      }, { onConflict: 'user_id,item_id' });
+
+    if (error) {
+      console.error('Error adding recent:', error);
+      return;
+    }
+
+    // Cleanup: delete oldest non-favorite rows beyond 10
+    const { data: nonFavs } = await supabase
+      .from('graph_preferences')
+      .select('id')
+      .eq('user_id', userId)
+      .eq('is_favorite', false)
+      .order('last_viewed_at', { ascending: false });
+
+    if (nonFavs && nonFavs.length > 10) {
+      const idsToDelete = nonFavs.slice(10).map(r => r.id);
+      await supabase
+        .from('graph_preferences')
+        .delete()
+        .in('id', idsToDelete);
+    }
+  };
+
+  const toggleFavorite = async (item) => {
+    if (!userId || !item) return;
+    const existing = favorites.find(f => f.itemId === item.id);
+    const now = new Date().toISOString();
+
+    if (existing) {
+      // Remove from favorites
+      setFavorites(prev => prev.filter(f => f.itemId !== item.id));
+      // It becomes a recent if it has lastViewedAt
+      if (existing.lastViewedAt) {
+        setRecents(prev => {
+          const filtered = prev.filter(r => r.itemId !== item.id);
+          return [{ itemId: item.id, itemName: item.itemName, lastViewedAt: existing.lastViewedAt }, ...filtered].slice(0, 10);
+        });
+      }
+
+      const { error } = await supabase
+        .from('graph_preferences')
+        .update({ is_favorite: false, favorited_at: null })
+        .eq('user_id', userId)
+        .eq('item_id', item.id);
+
+      if (error) {
+        console.error('Error removing favorite:', error);
+        fetchPreferences();
+      }
+    } else {
+      // Add to favorites
+      setFavorites(prev => [{ itemId: item.id, itemName: item.name, lastViewedAt: now, favoritedAt: now }, ...prev]);
+      // Remove from recents since it's now a favorite
+      setRecents(prev => prev.filter(r => r.itemId !== item.id));
+
+      const { error } = await supabase
+        .from('graph_preferences')
+        .upsert({
+          user_id: userId,
+          item_id: item.id,
+          item_name: item.name,
+          is_favorite: true,
+          favorited_at: now,
+          last_viewed_at: now,
+        }, { onConflict: 'user_id,item_id' });
+
+      if (error) {
+        console.error('Error adding favorite:', error);
+        fetchPreferences();
+      }
+    }
+  };
+
+  const isFavorite = useCallback((itemId) => {
+    return favorites.some(f => f.itemId === itemId);
+  }, [favorites]);
+
+  return { favorites, recents, loading, addRecent, toggleFavorite, isFavorite };
+}

--- a/src/pages/GraphsPage.jsx
+++ b/src/pages/GraphsPage.jsx
@@ -1,6 +1,8 @@
 import React, { useState, useMemo, useRef, useEffect } from 'react';
 import { createChart, LineSeries, HistogramSeries } from 'lightweight-charts';
+import { Star, Clock, Search } from 'lucide-react';
 import { useTimeseries } from '../hooks/useTimeseries';
+import { useGraphPreferences } from '../hooks/useGraphPreferences';
 import { calculateGETax } from '../utils/taxUtils';
 
 const TIMEFRAMES = [
@@ -12,7 +14,7 @@ const TIMEFRAMES = [
   { label: '1Y', timestep: '24h', filterDays: 365 },
 ];
 
-export default function GraphsPage({ mapping, prices, iconMap, mappingLoading }) {
+export default function GraphsPage({ mapping, prices, iconMap, mappingLoading, userId }) {
   const [searchQuery, setSearchQuery] = useState('');
   const [showDropdown, setShowDropdown] = useState(false);
   const [selectedItem, setSelectedItem] = useState(null);
@@ -30,6 +32,8 @@ export default function GraphsPage({ mapping, prices, iconMap, mappingLoading })
   const sellVolSeriesRef = useRef(null);
   const selectedItemRef = useRef(null);
   const chartDataRef = useRef([]);
+
+  const { favorites, recents, addRecent, toggleFavorite, isFavorite } = useGraphPreferences(userId);
 
   selectedItemRef.current = selectedItem;
 
@@ -57,6 +61,41 @@ export default function GraphsPage({ mapping, prices, iconMap, mappingLoading })
     const q = searchQuery.toLowerCase();
     return mapping.filter(item => item.name.toLowerCase().includes(q)).slice(0, 50);
   }, [searchQuery, mapping]);
+
+  // Build dropdown sections
+  const dropdownSections = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    const sections = [];
+
+    // Helper to find full mapping item from a preference
+    const findMappingItem = (pref) => mapping.find(m => m.id === pref.itemId);
+
+    if (!q) {
+      // Empty search: show recents then favorites
+      if (recents.length > 0) {
+        sections.push({
+          label: 'Recent',
+          icon: 'clock',
+          items: recents.map(r => findMappingItem(r)).filter(Boolean),
+        });
+      }
+      if (favorites.length > 0) {
+        sections.push({
+          label: 'Favorites',
+          icon: 'star',
+          items: favorites.map(f => findMappingItem(f)).filter(Boolean),
+        });
+      }
+    } else {
+      // Searching: show all results in one flat list (stars indicate favorites)
+      if (filteredItems.length > 0) {
+        sections.push({ label: 'Results', icon: 'search', items: filteredItems });
+      }
+    }
+    return sections;
+  }, [searchQuery, favorites, recents, filteredItems, mapping]);
+
+  const hasDropdownContent = dropdownSections.some(s => s.items.length > 0);
 
   // Click outside to close dropdown
   useEffect(() => {
@@ -140,7 +179,6 @@ export default function GraphsPage({ mapping, prices, iconMap, mappingLoading })
         toolEl.style.display = 'none';
         return;
       }
-      // Find the nearest data point in chartData for this timestamp
       const time = param.time;
       const data = chartDataRef.current;
       let nearest = null;
@@ -293,6 +331,15 @@ export default function GraphsPage({ mapping, prices, iconMap, mappingLoading })
   useEffect(() => {
     if (!highSeriesRef.current || !lowSeriesRef.current) return;
 
+    // Clear charts when no item is selected
+    if (!selectedItem) {
+      highSeriesRef.current.setData([]);
+      lowSeriesRef.current.setData([]);
+      if (buyVolSeriesRef.current) buyVolSeriesRef.current.setData([]);
+      if (sellVolSeriesRef.current) sellVolSeriesRef.current.setData([]);
+      return;
+    }
+
     const highData = chartData
       .filter(d => d.avgHighPrice != null)
       .map(d => ({ time: d.timestamp, value: d.avgHighPrice }));
@@ -330,12 +377,13 @@ export default function GraphsPage({ mapping, prices, iconMap, mappingLoading })
       });
       volumeChartRef.current.timeScale().fitContent();
     }
-  }, [chartData, timeframe]);
+  }, [chartData, timeframe, selectedItem]);
 
   const handleSelectItem = (item) => {
     setSelectedItem(item);
     setSearchQuery(item.name);
     setShowDropdown(false);
+    addRecent(item);
   };
 
   const handleSearchChange = (e) => {
@@ -344,6 +392,11 @@ export default function GraphsPage({ mapping, prices, iconMap, mappingLoading })
     if (!e.target.value.trim()) {
       setSelectedItem(null);
     }
+  };
+
+  const handleFavoriteClick = (e, item) => {
+    e.stopPropagation();
+    toggleFavorite(item);
   };
 
   const currentPrice = selectedItem && prices?.[selectedItem.id];
@@ -396,6 +449,41 @@ export default function GraphsPage({ mapping, prices, iconMap, mappingLoading })
     return `${days}d ${hours % 24}h ago`;
   };
 
+  const renderDropdownItem = (item, showFavStar) => (
+    <div
+      key={item.id}
+      className="graphs-dropdown-item"
+      onClick={() => handleSelectItem(item)}
+    >
+      {iconMap[item.id] && (
+        <img
+          src={iconMap[item.id]}
+          alt=""
+          className="graphs-dropdown-icon"
+        />
+      )}
+      <span className="graphs-dropdown-name">{item.name}</span>
+      {item.limit && (
+        <span className="graphs-dropdown-limit">Limit: {item.limit.toLocaleString()}</span>
+      )}
+      {showFavStar && (
+        <button
+          className={`graphs-favorite-star ${isFavorite(item.id) ? 'graphs-favorite-star--active' : ''}`}
+          onClick={(e) => handleFavoriteClick(e, item)}
+          title={isFavorite(item.id) ? 'Remove from favorites' : 'Add to favorites'}
+        >
+          <Star size={14} fill={isFavorite(item.id) ? 'currentColor' : 'none'} />
+        </button>
+      )}
+    </div>
+  );
+
+  const sectionIcon = (type) => {
+    if (type === 'star') return <Star size={12} />;
+    if (type === 'clock') return <Clock size={12} />;
+    return <Search size={12} />;
+  };
+
   return (
     <div className="graphs-page">
       <div className="graphs-header">
@@ -411,33 +499,50 @@ export default function GraphsPage({ mapping, prices, iconMap, mappingLoading })
           placeholder={mappingLoading ? 'Loading items...' : 'Search for an item...'}
           value={searchQuery}
           onChange={handleSearchChange}
-          onFocus={() => { if (searchQuery) setShowDropdown(true); }}
+          onFocus={() => setShowDropdown(true)}
           disabled={mappingLoading}
         />
-        {showDropdown && filteredItems.length > 0 && (
+        {showDropdown && hasDropdownContent && (
           <div className="graphs-dropdown" ref={dropdownRef}>
-            {filteredItems.map(item => (
-              <div
-                key={item.id}
-                className="graphs-dropdown-item"
-                onClick={() => handleSelectItem(item)}
-              >
-                {iconMap[item.id] && (
-                  <img
-                    src={iconMap[item.id]}
-                    alt=""
-                    style={{ width: 24, height: 24, marginRight: 8, imageRendering: 'pixelated' }}
-                  />
-                )}
-                <span>{item.name}</span>
-                {item.limit && (
-                  <span className="graphs-dropdown-limit">Limit: {item.limit.toLocaleString()}</span>
-                )}
+            {dropdownSections.map(section => (
+              <div key={section.label}>
+                <div className="graphs-dropdown-section-header">
+                  {sectionIcon(section.icon)}
+                  <span>{section.label}</span>
+                </div>
+                {section.items.map(item => renderDropdownItem(item, section.icon !== 'star'))}
               </div>
             ))}
           </div>
         )}
       </div>
+
+      {favorites.length > 0 && (
+        <div className="graphs-quick-access">
+          {favorites.map(fav => {
+            const item = mapping.find(m => m.id === fav.itemId);
+            if (!item) return null;
+            return (
+              <button
+                key={fav.itemId}
+                className={`graphs-quick-access-item ${selectedItem?.id === fav.itemId ? 'graphs-quick-access-item--active' : ''}`}
+                onClick={() => handleSelectItem(item)}
+                title={fav.itemName}
+              >
+                {iconMap[fav.itemId] ? (
+                  <img
+                    src={iconMap[fav.itemId]}
+                    alt={fav.itemName}
+                    className="graphs-quick-access-icon"
+                  />
+                ) : (
+                  <span className="graphs-quick-access-fallback">{fav.itemName.charAt(0)}</span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
 
       {selectedItem && (
         <div className="graphs-info-panel">
@@ -450,6 +555,13 @@ export default function GraphsPage({ mapping, prices, iconMap, mappingLoading })
               />
             )}
             <h3 className="graphs-info-name">{selectedItem.name}</h3>
+            <button
+              className={`graphs-favorite-star graphs-favorite-star--header ${isFavorite(selectedItem.id) ? 'graphs-favorite-star--active' : ''}`}
+              onClick={() => toggleFavorite(selectedItem)}
+              title={isFavorite(selectedItem.id) ? 'Remove from favorites' : 'Add to favorites'}
+            >
+              <Star size={18} fill={isFavorite(selectedItem.id) ? 'currentColor' : 'none'} />
+            </button>
             <a
               className="graphs-info-wiki-link"
               href={`https://oldschool.runescape.wiki/w/${encodeURIComponent(selectedItem.name.replace(/ /g, '_'))}`}
@@ -552,7 +664,72 @@ export default function GraphsPage({ mapping, prices, iconMap, mappingLoading })
       <div className="graphs-chart-container" ref={chartContainerRef}>
         {!selectedItem && (
           <div className="graphs-empty-state">
-            Search for an item above to view its price chart
+            {(favorites.length > 0 || recents.length > 0) ? (
+              <div className="graphs-empty-cards">
+                {recents.length > 0 && (
+                  <div className="graphs-empty-section">
+                    <div className="graphs-empty-section-header">
+                      <Clock size={14} />
+                      <span>Recent</span>
+                    </div>
+                    <div className="graphs-empty-grid">
+                      {recents.map(rec => {
+                        const item = mapping.find(m => m.id === rec.itemId);
+                        if (!item) return null;
+                        return (
+                          <button
+                            key={rec.itemId}
+                            className="graphs-empty-card"
+                            onClick={() => handleSelectItem(item)}
+                          >
+                            {iconMap[rec.itemId] && (
+                              <img
+                                src={iconMap[rec.itemId]}
+                                alt=""
+                                className="graphs-empty-card-icon"
+                              />
+                            )}
+                            <span className="graphs-empty-card-name">{rec.itemName}</span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+                {favorites.length > 0 && (
+                  <div className="graphs-empty-section">
+                    <div className="graphs-empty-section-header">
+                      <Star size={14} />
+                      <span>Favorites</span>
+                    </div>
+                    <div className="graphs-empty-grid">
+                      {favorites.map(fav => {
+                        const item = mapping.find(m => m.id === fav.itemId);
+                        if (!item) return null;
+                        return (
+                          <button
+                            key={fav.itemId}
+                            className="graphs-empty-card"
+                            onClick={() => handleSelectItem(item)}
+                          >
+                            {iconMap[fav.itemId] && (
+                              <img
+                                src={iconMap[fav.itemId]}
+                                alt=""
+                                className="graphs-empty-card-icon"
+                              />
+                            )}
+                            <span className="graphs-empty-card-name">{fav.itemName}</span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+              </div>
+            ) : (
+              'Search for an item above to view its price chart'
+            )}
           </div>
         )}
         {loading && (

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1956,9 +1956,9 @@
 }
 
 .graphs-dropdown-limit {
-  margin-left: auto;
   color: rgb(100, 116, 139);
   font-size: 0.75rem;
+  margin-right: 0.5rem;
 }
 
 .graphs-info-panel {
@@ -2161,4 +2161,171 @@
   background: rgba(52, 211, 153, 0.15);
   color: rgb(52, 211, 153);
   border: 1px solid rgba(52, 211, 153, 0.3);
+}
+
+.graphs-dropdown-icon {
+  width: 24px;
+  height: 24px;
+  margin-right: 8px;
+  image-rendering: pixelated;
+}
+
+.graphs-dropdown-section-header {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgb(100, 116, 139);
+  border-bottom: 1px solid rgb(51, 65, 85);
+}
+
+.graphs-dropdown-section-header:not(:first-child) {
+  border-top: 1px solid rgb(51, 65, 85);
+}
+
+.graphs-favorite-star {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: rgb(100, 116, 139);
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 0.25rem;
+  transition: all 0.15s;
+  flex-shrink: 0;
+}
+
+.graphs-favorite-star:hover {
+  color: rgb(234, 179, 8);
+  background: rgba(234, 179, 8, 0.1);
+}
+
+.graphs-favorite-star--active {
+  color: rgb(234, 179, 8);
+}
+
+.graphs-favorite-star--active:hover {
+  color: rgb(202, 138, 4);
+}
+
+.graphs-favorite-star--header {
+  padding: 0.375rem;
+  border-radius: 0.375rem;
+}
+
+.graphs-dropdown-name {
+  flex: 1;
+  min-width: 0;
+}
+
+.graphs-dropdown-item .graphs-favorite-star {
+  flex-shrink: 0;
+}
+
+.graphs-quick-access {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.graphs-quick-access-item {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  background: rgb(30, 41, 59);
+  border: 1px solid rgb(51, 65, 85);
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: all 0.15s;
+  padding: 0;
+}
+
+.graphs-quick-access-item:hover {
+  border-color: rgb(96, 165, 250);
+  background: rgb(51, 65, 85);
+}
+
+.graphs-quick-access-item--active {
+  border-color: rgb(96, 165, 250);
+  background: rgba(96, 165, 250, 0.15);
+}
+
+.graphs-quick-access-icon {
+  width: 32px;
+  height: 32px;
+  image-rendering: pixelated;
+}
+
+.graphs-quick-access-fallback {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: rgb(148, 163, 184);
+}
+
+.graphs-empty-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem;
+  width: 100%;
+}
+
+.graphs-empty-section {
+  width: 100%;
+}
+
+.graphs-empty-section-header {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgb(100, 116, 139);
+  margin-bottom: 0.75rem;
+}
+
+.graphs-empty-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.graphs-empty-card {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: rgb(30, 41, 59);
+  border: 1px solid rgb(51, 65, 85);
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: all 0.15s;
+  color: rgb(203, 213, 225);
+  font-size: 0.8125rem;
+}
+
+.graphs-empty-card:hover {
+  border-color: rgb(96, 165, 250);
+  background: rgb(51, 65, 85);
+}
+
+.graphs-empty-card-icon {
+  width: 24px;
+  height: 24px;
+  image-rendering: pixelated;
+}
+
+.graphs-empty-card-name {
+  white-space: nowrap;
 }


### PR DESCRIPTION
Summary

  - Add ability to favorite items and track recently viewed items on the Graphs page, persisted via a new graph_preferences Supabase table
  - Enhanced search dropdown shows Recent and Favorites sections when focused with empty search; typing shows a flat result list with star indicators
  - Quick-access icon bar below search for fast navigation to favorited items
  - Star toggle button in the item info header and in search result rows
  - Empty state displays clickable Recent/Favorites cards instead of plain text
  - Charts fully reset when clearing the search input