### PR TITLE
feat(graphs): collapsible & reorderable favorites

### DIFF
--- a/src/hooks/useGraphPreferences.js
+++ b/src/hooks/useGraphPreferences.js
@@ -19,10 +19,23 @@ export function useGraphPreferences(userId) {
       setRecents([]);
     } else {
       const rows = data || [];
-      const favs = rows
+      let favs = rows
         .filter(r => r.is_favorite)
         .sort((a, b) => new Date(b.favorited_at) - new Date(a.favorited_at))
         .map(r => ({ itemId: r.item_id, itemName: r.item_name, lastViewedAt: r.last_viewed_at, favoritedAt: r.favorited_at }));
+
+      // Apply stored ordering from localStorage
+      try {
+        const storedOrder = JSON.parse(localStorage.getItem(`graphsFavoritesOrder_${userId}`) || '[]');
+        if (storedOrder.length > 0) {
+          const orderMap = new Map(storedOrder.map((id, i) => [id, i]));
+          favs.sort((a, b) => {
+            const aIdx = orderMap.has(a.itemId) ? orderMap.get(a.itemId) : Infinity;
+            const bIdx = orderMap.has(b.itemId) ? orderMap.get(b.itemId) : Infinity;
+            return aIdx - bIdx;
+          });
+        }
+      } catch (e) { /* ignore malformed localStorage */ }
       const recs = rows
         .filter(r => !r.is_favorite && r.last_viewed_at)
         .sort((a, b) => new Date(b.last_viewed_at) - new Date(a.last_viewed_at))
@@ -96,6 +109,11 @@ export function useGraphPreferences(userId) {
     if (existing) {
       // Remove from favorites
       setFavorites(prev => prev.filter(f => f.itemId !== item.id));
+      // Remove from stored order
+      try {
+        const storedOrder = JSON.parse(localStorage.getItem(`graphsFavoritesOrder_${userId}`) || '[]');
+        localStorage.setItem(`graphsFavoritesOrder_${userId}`, JSON.stringify(storedOrder.filter(id => id !== item.id)));
+      } catch (e) { /* ignore */ }
       // It becomes a recent if it has lastViewedAt
       if (existing.lastViewedAt) {
         setRecents(prev => {
@@ -117,6 +135,11 @@ export function useGraphPreferences(userId) {
     } else {
       // Add to favorites
       setFavorites(prev => [{ itemId: item.id, itemName: item.name, lastViewedAt: now, favoritedAt: now }, ...prev]);
+      // Prepend to stored order
+      try {
+        const storedOrder = JSON.parse(localStorage.getItem(`graphsFavoritesOrder_${userId}`) || '[]');
+        localStorage.setItem(`graphsFavoritesOrder_${userId}`, JSON.stringify([item.id, ...storedOrder.filter(id => id !== item.id)]));
+      } catch (e) { /* ignore */ }
       // Remove from recents since it's now a favorite
       setRecents(prev => prev.filter(r => r.itemId !== item.id));
 
@@ -138,9 +161,20 @@ export function useGraphPreferences(userId) {
     }
   };
 
+  const reorderFavorites = useCallback((orderedItemIds) => {
+    localStorage.setItem(`graphsFavoritesOrder_${userId}`, JSON.stringify(orderedItemIds));
+    setFavorites(prev => {
+      const map = new Map(prev.map(f => [f.itemId, f]));
+      const reordered = orderedItemIds.map(id => map.get(id)).filter(Boolean);
+      // Append any that weren't in the ordered list
+      const remaining = prev.filter(f => !orderedItemIds.includes(f.itemId));
+      return [...reordered, ...remaining];
+    });
+  }, [userId]);
+
   const isFavorite = useCallback((itemId) => {
     return favorites.some(f => f.itemId === itemId);
   }, [favorites]);
 
-  return { favorites, recents, loading, addRecent, toggleFavorite, isFavorite };
+  return { favorites, recents, loading, addRecent, toggleFavorite, isFavorite, reorderFavorites };
 }

--- a/src/pages/GraphsPage.jsx
+++ b/src/pages/GraphsPage.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useRef, useEffect } from 'react';
 import { createChart, LineSeries, HistogramSeries, CandlestickSeries } from 'lightweight-charts';
-import { Star, Clock, Search } from 'lucide-react';
+import { Star, Clock, Search, ChevronDown } from 'lucide-react';
 import { useTimeseries } from '../hooks/useTimeseries';
 import { useGraphPreferences } from '../hooks/useGraphPreferences';
 import { calculateGETax } from '../utils/taxUtils';
@@ -36,7 +36,12 @@ export default function GraphsPage({ mapping, prices, iconMap, mappingLoading, u
   const candleSeriesRef = useRef(null);
   const chartModeRef = useRef('line');
 
-  const { favorites, recents, addRecent, toggleFavorite, isFavorite } = useGraphPreferences(userId);
+  const { favorites, recents, addRecent, toggleFavorite, isFavorite, reorderFavorites } = useGraphPreferences(userId);
+
+  const [favoritesCollapsed, setFavoritesCollapsed] = useState(
+    () => localStorage.getItem(`graphsFavoritesCollapsed_${userId}`) === 'true'
+  );
+  const draggedFavRef = useRef(null);
 
   selectedItemRef.current = selectedItem;
   chartModeRef.current = chartMode;
@@ -428,6 +433,37 @@ export default function GraphsPage({ mapping, prices, iconMap, mappingLoading, u
     }
   }, [chartData, timeframe, selectedItem, chartMode, candlestickData]);
 
+  const toggleFavoritesCollapsed = () => {
+    setFavoritesCollapsed(prev => {
+      const next = !prev;
+      localStorage.setItem(`graphsFavoritesCollapsed_${userId}`, String(next));
+      return next;
+    });
+  };
+
+  const handleFavDragStart = (e, itemId) => {
+    draggedFavRef.current = itemId;
+    e.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleFavDragOver = (e) => {
+    e.preventDefault();
+  };
+
+  const handleFavDrop = (e, targetItemId) => {
+    e.preventDefault();
+    const draggedId = draggedFavRef.current;
+    draggedFavRef.current = null;
+    if (!draggedId || draggedId === targetItemId) return;
+    const ids = favorites.map(f => f.itemId);
+    const fromIdx = ids.indexOf(draggedId);
+    const toIdx = ids.indexOf(targetItemId);
+    if (fromIdx === -1 || toIdx === -1) return;
+    ids.splice(fromIdx, 1);
+    ids.splice(toIdx, 0, draggedId);
+    reorderFavorites(ids);
+  };
+
   const handleSelectItem = (item) => {
     setSelectedItem(item);
     setSearchQuery(item.name);
@@ -567,29 +603,42 @@ export default function GraphsPage({ mapping, prices, iconMap, mappingLoading, u
       </div>
 
       {favorites.length > 0 && (
-        <div className="graphs-quick-access">
-          {favorites.map(fav => {
-            const item = mapping.find(m => m.id === fav.itemId);
-            if (!item) return null;
-            return (
-              <button
-                key={fav.itemId}
-                className={`graphs-quick-access-item ${selectedItem?.id === fav.itemId ? 'graphs-quick-access-item--active' : ''}`}
-                onClick={() => handleSelectItem(item)}
-                title={fav.itemName}
-              >
-                {iconMap[fav.itemId] ? (
-                  <img
-                    src={iconMap[fav.itemId]}
-                    alt={fav.itemName}
-                    className="graphs-quick-access-icon"
-                  />
-                ) : (
-                  <span className="graphs-quick-access-fallback">{fav.itemName.charAt(0)}</span>
-                )}
-              </button>
-            );
-          })}
+        <div className="graphs-favorites-section">
+          <div className="graphs-favorites-header" onClick={toggleFavoritesCollapsed}>
+            <Star size={14} />
+            <span>Favorites ({favorites.length})</span>
+            <ChevronDown size={16} className={`graphs-favorites-chevron ${favoritesCollapsed ? 'graphs-favorites-chevron--collapsed' : ''}`} />
+          </div>
+          {!favoritesCollapsed && (
+            <div className="graphs-quick-access">
+              {favorites.map(fav => {
+                const item = mapping.find(m => m.id === fav.itemId);
+                if (!item) return null;
+                return (
+                  <button
+                    key={fav.itemId}
+                    className={`graphs-quick-access-item ${selectedItem?.id === fav.itemId ? 'graphs-quick-access-item--active' : ''}`}
+                    onClick={() => handleSelectItem(item)}
+                    title={fav.itemName}
+                    draggable
+                    onDragStart={(e) => handleFavDragStart(e, fav.itemId)}
+                    onDragOver={handleFavDragOver}
+                    onDrop={(e) => handleFavDrop(e, fav.itemId)}
+                  >
+                    {iconMap[fav.itemId] ? (
+                      <img
+                        src={iconMap[fav.itemId]}
+                        alt={fav.itemName}
+                        className="graphs-quick-access-icon"
+                      />
+                    ) : (
+                      <span className="graphs-quick-access-fallback">{fav.itemName.charAt(0)}</span>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          )}
         </div>
       )}
 

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -2235,11 +2235,41 @@
   flex-shrink: 0;
 }
 
+.graphs-favorites-section {
+  margin-bottom: 1.5rem;
+}
+
+.graphs-favorites-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  color: rgb(148, 163, 184);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.5rem;
+  user-select: none;
+}
+
+.graphs-favorites-header:hover {
+  color: rgb(203, 213, 225);
+}
+
+.graphs-favorites-chevron {
+  transition: transform 0.2s;
+  margin-left: auto;
+}
+
+.graphs-favorites-chevron--collapsed {
+  transform: rotate(-90deg);
+}
+
 .graphs-quick-access {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  margin-bottom: 1.5rem;
 }
 
 .graphs-quick-access-item {
@@ -2251,9 +2281,14 @@
   background: rgb(30, 41, 59);
   border: 1px solid rgb(51, 65, 85);
   border-radius: 0.5rem;
-  cursor: pointer;
+  cursor: grab;
   transition: all 0.15s;
   padding: 0;
+}
+
+.graphs-quick-access-item:active {
+  cursor: grabbing;
+  opacity: 0.6;
 }
 
 .graphs-quick-access-item:hover {


### PR DESCRIPTION
 ## Summary
  - Add a collapsible header to the favorites quick access bar with star icon, item count, and chevron toggle (persisted per user in localStorage)
  - Add drag-and-drop reordering for favorite items with localStorage-backed order persistence
  - All localStorage keys are scoped per userId to support multiple accounts in the same browser