### PR TITLE
feat(modals): add instant K/M shorthand parsing to all numeric inputs

### DIFF
--- a/src/components/modals/AdjustModal.jsx
+++ b/src/components/modals/AdjustModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo, useRef, useEffect } from 'react';
+import { handleMKInput } from '../../utils/formatters';
 
 export default function AdjustModal({ stock, categories, mapping = [], onConfirm, onCancel }) {
   const [stockType, setStockType] = useState(stock.itemId ? 'osrs' : 'custom');
@@ -223,10 +224,10 @@ export default function AdjustModal({ stock, categories, mapping = [], onConfirm
             4H Limit
           </label>
           <input
-            type="number"
+            type="text"
             value={limit4h}
-            onChange={(e) => setLimit4h(e.target.value)}
-            placeholder="Enter 4h limit"
+            onChange={(e) => handleMKInput(e.target.value, setLimit4h)}
+            placeholder="Enter 4h limit (e.g. 10k)"
             style={inputStyle}
             onFocus={(e) => e.target.style.borderColor = focusColor}
             onBlur={(e) => e.target.style.borderColor = 'transparent'}
@@ -239,10 +240,10 @@ export default function AdjustModal({ stock, categories, mapping = [], onConfirm
             Desired Stock
           </label>
           <input
-            type="number"
+            type="text"
             value={needed}
-            onChange={(e) => setNeeded(e.target.value)}
-            placeholder="Enter desired stock"
+            onChange={(e) => handleMKInput(e.target.value, setNeeded)}
+            placeholder="Enter desired stock (e.g. 100k)"
             style={inputStyle}
             onFocus={(e) => e.target.style.borderColor = focusColor}
             onBlur={(e) => e.target.style.borderColor = 'transparent'}

--- a/src/components/modals/BuyModal.jsx
+++ b/src/components/modals/BuyModal.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { formatNumber, parseMK } from '../../utils/formatters';
+import { formatNumber, parseMK, handleMKInput } from '../../utils/formatters';
 
 export default function BuyModal({ stock, onConfirm, onCancel, geData = {}, isSubmitting = false }) {
   const [shares, setShares] = useState((stock.limit4h * 1).toString());
@@ -170,8 +170,8 @@ export default function BuyModal({ stock, onConfirm, onCancel, geData = {}, isSu
           <input
             type="text"
             value={shares}
-            onChange={(e) => setShares(e.target.value)}
-            placeholder="Number of shares"
+            onChange={(e) => handleMKInput(e.target.value, setShares)}
+            placeholder="Number of shares (e.g. 10k)"
             style={{
               width: '100%',
               padding: '0.5rem 1rem',
@@ -258,10 +258,31 @@ export default function BuyModal({ stock, onConfirm, onCancel, geData = {}, isSu
             </button>
           </div>
           <input
-            type={useTotal ? "text" : "number"}
+            type="text"
             value={useTotal ? formatTotalInput(totalAmount) : price}
-            onChange={(e) => useTotal ? handleTotalInputChange(e.target.value) : handlePriceChange(e.target.value)}
-            placeholder={useTotal ? 'Total cost' : 'Price per share'}
+            onChange={(e) => {
+              const val = e.target.value;
+              if (useTotal) {
+                const lower = val.toLowerCase();
+                if (lower.endsWith('k') || lower.endsWith('m')) {
+                  const parsed = parseMK(val.replace(/\./g, ''));
+                  if (parsed !== val) {
+                    setTotalAmount(parsed);
+                    if (shares && parsed) {
+                      setPrice((parseFloat(parsed) / parseFloat(shares)).toFixed(2));
+                    }
+                    return;
+                  }
+                }
+                handleTotalInputChange(val);
+              } else {
+                const parsed = handleMKInput(val, setPrice);
+                if (shares && parsed) {
+                  setTotalAmount((parseFloat(shares) * parseFloat(parsed)).toFixed(0));
+                }
+              }
+            }}
+            placeholder={useTotal ? 'Total cost (e.g. 10m)' : 'Price per share (e.g. 1.5k)'}
             style={{
               width: '100%',
               padding: '0.5rem 1rem',

--- a/src/components/modals/MilestoneTrackerModal.jsx
+++ b/src/components/modals/MilestoneTrackerModal.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { X } from 'lucide-react';
-import { formatNumber } from '../../utils/formatters';
+import { formatNumber, handleMKInput } from '../../utils/formatters';
 
 const formatPeriodRange = (periodStart, period) => {
   // Parse as local date (YYYY-MM-DD) to avoid UTC shift issues
@@ -370,10 +370,10 @@ export default function MilestoneTrackerModal({
                 </label>
                 <div style={{ display: 'flex', gap: '0.5rem' }}>
                   <input
-                    type="number"
+                    type="text"
                     value={customGoal}
-                    onChange={(e) => setCustomGoal(e.target.value)}
-                    placeholder="Enter custom goal"
+                    onChange={(e) => handleMKInput(e.target.value, setCustomGoal)}
+                    placeholder="Enter custom goal (e.g. 10m)"
                     style={{
                       flex: 1,
                       padding: '0.75rem',

--- a/src/components/modals/NewStockModal.jsx
+++ b/src/components/modals/NewStockModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo, useRef, useEffect } from 'react';
+import { handleMKInput } from '../../utils/formatters';
 
 export default function NewStockModal({ categories, defaultCategory = '', defaultIsInvestment = false, mapping = [], archivedStocks = [], onConfirm, onCancel, onRestoreFromArchive }) {
   const [stockType, setStockType] = useState('osrs'); // 'osrs' | 'custom'
@@ -210,10 +211,10 @@ export default function NewStockModal({ categories, defaultCategory = '', defaul
 
         {/* 4H Limit */}
         <input
-          type="number"
+          type="text"
           value={limit4h}
-          onChange={(e) => setLimit4h(e.target.value)}
-          placeholder="4H Limit"
+          onChange={(e) => handleMKInput(e.target.value, setLimit4h)}
+          placeholder="4H Limit (e.g. 10k)"
           style={inputStyle}
           onFocus={(e) => e.target.style.borderColor = 'rgb(37, 99, 235)'}
           onBlur={(e) => e.target.style.borderColor = 'transparent'}
@@ -221,10 +222,10 @@ export default function NewStockModal({ categories, defaultCategory = '', defaul
 
         {/* Desired Stock */}
         <input
-          type="number"
+          type="text"
           value={needed}
-          onChange={(e) => setNeeded(e.target.value)}
-          placeholder="Desired stock"
+          onChange={(e) => handleMKInput(e.target.value, setNeeded)}
+          placeholder="Desired stock (e.g. 100k)"
           style={inputStyle}
           onFocus={(e) => e.target.style.borderColor = 'rgb(37, 99, 235)'}
           onBlur={(e) => e.target.style.borderColor = 'transparent'}

--- a/src/components/modals/ProfitModal.jsx
+++ b/src/components/modals/ProfitModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { handleMKInput } from '../../utils/formatters';
 
 export default function ProfitModal({ type, onConfirm, onCancel }) {
   const [amount, setAmount] = useState('');
@@ -40,10 +41,10 @@ export default function ProfitModal({ type, onConfirm, onCancel }) {
       <h2 style={{ fontSize: '1.5rem', fontWeight: 'bold', marginBottom: '1rem' }}>{title}</h2>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
         <input
-          type="number"
+          type="text"
           value={amount}
-          onChange={(e) => setAmount(e.target.value)}
-          placeholder="Enter profit amount"
+          onChange={(e) => handleMKInput(e.target.value, setAmount)}
+          placeholder="Enter profit amount (e.g. 10m, 500k)"
           style={{
             width: '100%',
             padding: '0.5rem 1rem',

--- a/src/components/modals/SellModal.jsx
+++ b/src/components/modals/SellModal.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { formatNumber, parseMK } from '../../utils/formatters';
+import { formatNumber, parseMK, handleMKInput } from '../../utils/formatters';
 
 export default function SellModal({ stock, onConfirm, onCancel, geData = {}, isSubmitting = false }) {
   const [shares, setShares] = useState('');
@@ -217,8 +217,8 @@ export default function SellModal({ stock, onConfirm, onCancel, geData = {}, isS
           <input
             type="text"
             value={shares}
-            onChange={(e) => setShares(e.target.value)}
-            placeholder="Number of shares"
+            onChange={(e) => handleMKInput(e.target.value, setShares)}
+            placeholder="Number of shares (e.g. 10k)"
             style={{
               width: '100%',
               padding: '0.5rem 1rem',
@@ -305,10 +305,31 @@ export default function SellModal({ stock, onConfirm, onCancel, geData = {}, isS
             </button>
           </div>
           <input
-            type={useTotal ? "text" : "number"}
+            type="text"
             value={useTotal ? formatTotalInput(totalAmount) : price}
-            onChange={(e) => useTotal ? handleTotalInputChange(e.target.value) : handlePriceChange(e.target.value)}
-            placeholder={useTotal ? 'Total revenue' : 'Price per share'}
+            onChange={(e) => {
+              const val = e.target.value;
+              if (useTotal) {
+                const lower = val.toLowerCase();
+                if (lower.endsWith('k') || lower.endsWith('m')) {
+                  const parsed = parseMK(val.replace(/\./g, ''));
+                  if (parsed !== val) {
+                    setTotalAmount(parsed);
+                    if (shares && parsed) {
+                      setPrice((parseFloat(parsed) / parseFloat(shares)).toFixed(2));
+                    }
+                    return;
+                  }
+                }
+                handleTotalInputChange(val);
+              } else {
+                const parsed = handleMKInput(val, setPrice);
+                if (shares && parsed) {
+                  setTotalAmount((parseFloat(shares) * parseFloat(parsed)).toFixed(0));
+                }
+              }
+            }}
+            placeholder={useTotal ? 'Total revenue (e.g. 10m)' : 'Price per share (e.g. 1.5k)'}
             style={{
               width: '100%',
               padding: '0.5rem 1rem',

--- a/src/components/modals/TimeCalculatorModal.jsx
+++ b/src/components/modals/TimeCalculatorModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { handleMKInput } from '../../utils/formatters';
 
 export default function TimeCalculatorModal({ stock, onClose }) {
   const [targetAmount, setTargetAmount] = useState(stock.needed.toString());
@@ -36,10 +37,10 @@ export default function TimeCalculatorModal({ stock, onClose }) {
             Target Amount
           </label>
           <input
-            type="number"
+            type="text"
             value={targetAmount}
-            onChange={(e) => setTargetAmount(e.target.value)}
-            placeholder="Enter target amount"
+            onChange={(e) => handleMKInput(e.target.value, setTargetAmount)}
+            placeholder="Enter target amount (e.g. 100k)"
             autoFocus
             style={{
               width: '100%',
@@ -61,11 +62,10 @@ export default function TimeCalculatorModal({ stock, onClose }) {
             Number of Accounts
           </label>
           <input
-            type="number"
+            type="text"
             value={accountCount}
-            onChange={(e) => setAccountCount(e.target.value)}
+            onChange={(e) => handleMKInput(e.target.value, setAccountCount)}
             placeholder="Enter number of accounts"
-            min="1"
             style={{
               width: '100%',
               padding: '0.5rem 1rem',

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -11,6 +11,19 @@ export const parseMK = (value) => {
   return value;
 };
 
+export const handleMKInput = (value, setter) => {
+  const lower = value.toLowerCase();
+  if (lower.endsWith('k') || lower.endsWith('m')) {
+    const parsed = parseMK(value);
+    if (parsed !== value) {
+      setter(parsed);
+      return parsed;
+    }
+  }
+  setter(value);
+  return value;
+};
+
 export const formatNumber = (num, numberFormat = 'compact') => {
   if (num == null || isNaN(num)) return '-';
 


### PR DESCRIPTION
Summary

  - Added handleMKInput utility that instantly converts K/M shorthand (e.g. 10k → 10000, 1.5m → 1500000) as the user types, replacing the previous blur-based approach
  - Extended K/M shorthand support to all numeric input fields across the app — previously only worked on shares in Buy/Sell modals