### PR TITLE
feat(ui): add hover tooltips showing exact numbers on all numeric cells

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -23,5 +23,6 @@ Rules:
 - Scope should reflect the area of the codebase changed (e.g. `stocks`, `modals`, `hooks`, `ui`)
 - If changes span multiple unrelated areas, use multiple commits only if they are clearly separable; otherwise use the dominant type
 - Do not add a body unless the change is non-obvious
+- Make the Branch off origin/Develop
 
 Stage and commit in a single response. Do not ask for confirmation. Do not output anything besides the tool calls.

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -23,7 +23,9 @@
       "Bash(git push:*)",
       "Bash(where gh:*)",
       "Bash(git stash:*)",
-      "Bash(git add:*)"
+      "Bash(git add:*)",
+      "Bash(gh api:*)",
+      "WebFetch(domain:api.github.com)"
     ]
   }
 }

--- a/src/components/StockTable.jsx
+++ b/src/components/StockTable.jsx
@@ -171,52 +171,52 @@ function StockRow({
           <StatusBadge stock={stock} />
         </td>
       )}
-      <td style={{ padding: '0.5rem 0.75rem', textAlign: 'right', border: '1px solid rgb(51, 65, 85)' }}>
+      <td title={formatNumber(stock.shares, 'full')} style={{ padding: '0.5rem 0.75rem', textAlign: 'right', border: '1px solid rgb(51, 65, 85)' }}>
         {formatNumber(stock.shares, numberFormat)}
       </td>
-      <td style={{ padding: '0.5rem 0.5rem', textAlign: 'right', border: '1px solid rgb(51, 65, 85)', whiteSpace: 'nowrap' }}>
+      <td title={formatNumber(stock.totalCost, 'full')} style={{ padding: '0.5rem 0.5rem', textAlign: 'right', border: '1px solid rgb(51, 65, 85)', whiteSpace: 'nowrap' }}>
         {formatNumber(stock.totalCost, numberFormat)}
       </td>
       {visibleColumns.avgBuy && (
-        <td style={{ padding: '0.5rem 0.75rem', textAlign: 'right', color: 'rgb(134, 239, 172)', border: '1px solid rgb(51, 65, 85)' }}>
+        <td title={formatNumber(avgBuy, 'full')} style={{ padding: '0.5rem 0.75rem', textAlign: 'right', color: 'rgb(134, 239, 172)', border: '1px solid rgb(51, 65, 85)' }}>
           {formatAvgPrice(avgBuy, numberFormat)}
         </td>
       )}
-      <td style={{ padding: '0.5rem 0.75rem', textAlign: 'right', border: '1px solid rgb(51, 65, 85)' }}>
+      <td title={formatNumber(stock.sharesSold, 'full')} style={{ padding: '0.5rem 0.75rem', textAlign: 'right', border: '1px solid rgb(51, 65, 85)' }}>
         {formatNumber(stock.sharesSold, numberFormat)}
       </td>
-      <td style={{ padding: '0.5rem 0.75rem', textAlign: 'right', border: '1px solid rgb(51, 65, 85)' }}>
+      <td title={formatNumber(stock.totalCostSold, 'full')} style={{ padding: '0.5rem 0.75rem', textAlign: 'right', border: '1px solid rgb(51, 65, 85)' }}>
         {formatNumber(stock.totalCostSold, numberFormat)}
       </td>
       {visibleColumns.avgSell && (
-        <td style={{ padding: '0.5rem 0.75rem', textAlign: 'right', color: 'rgb(134, 239, 172)', border: '1px solid rgb(51, 65, 85)' }}>
+        <td title={formatNumber(avgSell, 'full')} style={{ padding: '0.5rem 0.75rem', textAlign: 'right', color: 'rgb(134, 239, 172)', border: '1px solid rgb(51, 65, 85)' }}>
           {formatAvgPrice(avgSell, numberFormat)}
         </td>
       )}
       {visibleColumns.profit && (
-        <td className={`td-base td-right ${profit >= 0 ? 'td-profit-positive' : 'td-profit-negative'}`}>
+        <td title={formatNumber(profit, 'full')} className={`td-base td-right ${profit >= 0 ? 'td-profit-positive' : 'td-profit-negative'}`}>
           {profit >= 0 ? '+' : ''}{formatNumber(profit, numberFormat)}
         </td>
       )}
       {visibleColumns.desiredStock !== false && (
-        <td style={{ padding: '0.5rem 0.75rem', textAlign: 'right', border: '1px solid rgb(51, 65, 85)' }}>
+        <td title={formatNumber(stock.needed, 'full')} style={{ padding: '0.5rem 0.75rem', textAlign: 'right', border: '1px solid rgb(51, 65, 85)' }}>
           {formatNumber(stock.needed, numberFormat)}
         </td>
       )}
       {visibleColumns.limit4h && (
-        <td style={{ padding: '0.5rem 0.75rem', textAlign: 'right', border: '1px solid rgb(51, 65, 85)' }}>
+        <td title={formatNumber(stock.limit4h, 'full')} style={{ padding: '0.5rem 0.75rem', textAlign: 'right', border: '1px solid rgb(51, 65, 85)' }}>
           {formatNumber(stock.limit4h, numberFormat)}
         </td>
       )}
       {visibleColumns.geHigh && (
-        <td style={{ padding: '0.5rem 0.75rem', textAlign: 'right', border: '1px solid rgb(51, 65, 85)', color: 'rgb(134, 239, 172)' }}>
+        <td title={stock.itemId && geData[stock.itemId]?.high != null ? formatNumber(geData[stock.itemId].high, 'full') : undefined} style={{ padding: '0.5rem 0.75rem', textAlign: 'right', border: '1px solid rgb(51, 65, 85)', color: 'rgb(134, 239, 172)' }}>
           {stock.itemId && geData[stock.itemId]?.high != null
             ? formatNumber(geData[stock.itemId].high, numberFormat)
             : 'NA'}
         </td>
       )}
       {visibleColumns.geLow && (
-        <td style={{ padding: '0.5rem 0.75rem', textAlign: 'right', border: '1px solid rgb(51, 65, 85)', color: 'rgb(134, 239, 172)' }}>
+        <td title={stock.itemId && geData[stock.itemId]?.low != null ? formatNumber(geData[stock.itemId].low, 'full') : undefined} style={{ padding: '0.5rem 0.75rem', textAlign: 'right', border: '1px solid rgb(51, 65, 85)', color: 'rgb(134, 239, 172)' }}>
           {stock.itemId && geData[stock.itemId]?.low != null
             ? formatNumber(geData[stock.itemId].low, numberFormat)
             : 'NA'}
@@ -226,7 +226,7 @@ function StockRow({
         const latestHigh = stock.itemId ? geData[stock.itemId]?.high : null;
         const unrealized = calculateUnrealizedProfit(stock, latestHigh, stock.itemId);
         return (
-          <td className={`td-base td-right ${unrealized == null ? '' : unrealized >= 0 ? 'td-profit-positive' : 'td-profit-negative'}`}>
+          <td title={unrealized != null ? formatNumber(unrealized, 'full') : undefined} className={`td-base td-right ${unrealized == null ? '' : unrealized >= 0 ? 'td-profit-positive' : 'td-profit-negative'}`}>
             {unrealized == null ? 'NA' : `${unrealized >= 0 ? '+' : ''}${formatNumber(unrealized, numberFormat)}`}
           </td>
         );

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -335,10 +335,10 @@ export default function HistoryPage({
                     {t.type.toUpperCase()}
                   </span>
                 </td>
-                <td className="history-cell history-cell--right">{t.shares.toLocaleString()}</td>
-                <td className="history-cell history-cell--right">{t.price.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
-                <td className="history-cell history-cell--right">{formatNumber(t.total, numberFormat)}</td>
-                <td className="history-cell history-cell--right">
+                <td className="history-cell history-cell--right" title={formatNumber(t.shares, 'full')}>{t.shares.toLocaleString()}</td>
+                <td className="history-cell history-cell--right" title={formatNumber(t.price, 'full')}>{t.price.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+                <td className="history-cell history-cell--right" title={formatNumber(t.total, 'full')}>{formatNumber(t.total, numberFormat)}</td>
+                <td className="history-cell history-cell--right" title={t.type === 'sell' && t.profit != null ? formatNumber(t.profit, 'full') : undefined}>
                   {t.type === 'sell' && t.profit != null
                     ? <span className={t.profit >= 0 ? 'history-total--buy' : 'history-total--sell'}>{formatNumber(t.profit, numberFormat)}</span>
                     : <span className="history-cell--muted">—</span>


### PR DESCRIPTION
 Summary

  - Add native browser tooltips (title attribute) to all numeric cells in StockTable and HistoryPage, showing the full unabbreviated number on hover
  - Covers all 12 numeric columns in StockTable (shares, costs, averages, profit, GE prices, unrealized profit) and 4 in HistoryPage (qty, price, total, profit)
  - No new components, state, or CSS — uses the existing formatNumber(value, 'full') formatter