### PR TITLE
Add hover tooltips to column headers and summary cards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,3 +79,6 @@ All data lives in Supabase. Each hook wraps a Supabase table and is called from 
 
 - Dont use inline CSS
 - Keep using the same color codes as already there
+
+### Rules
+- Do not ouse the classic - that ai agents use

--- a/src/components/CategorySection.jsx
+++ b/src/components/CategorySection.jsx
@@ -254,9 +254,18 @@ export default function CategorySection({
   );
 }
 
+const statTooltips = {
+  'Total Cost': 'GP spent buying items in this category',
+  'Total Shares': 'Items currently held in this category',
+  'Total Profit': 'Profit from sold items in this category',
+  'Sold Shares': 'Items sold in this category',
+  'Sold Cost': 'GP received from sales in this category',
+  'Unreal. Profit': 'Estimated profit if sold at GE high (after 2% tax)'
+};
+
 function StatItem({ label, value, color }) {
   return (
-    <div className="stat-item">
+    <div className="stat-item" title={statTooltips[label]}>
       <div className="stat-label">{label}</div>
       <div className="stat-value" style={{ color }}>{value}</div>
     </div>

--- a/src/components/PortfolioSummary.jsx
+++ b/src/components/PortfolioSummary.jsx
@@ -41,6 +41,7 @@ export default function PortfolioSummary({
           label="Total Portfolio:"
           value={formatNumber(totalPortfolio)}
           color="rgb(96, 165, 250)"
+          tooltip="GP invested across all items you hold"
         />
 
         {/* Total Shares */}
@@ -48,6 +49,7 @@ export default function PortfolioSummary({
           label="Total Stock:"
           value={formatNumber(totalShares)}
           color="rgb(251, 146, 60)"
+          tooltip="Total items you currently hold"
         />
 
         {/* Total Sales */}
@@ -55,6 +57,7 @@ export default function PortfolioSummary({
           label="Total Revenue:"
           value={formatNumber(totalSales)}
           color="rgb(168, 85, 247)"
+          tooltip="GP received from all sales"
         />
 
         {/* Total Profit */}
@@ -62,6 +65,7 @@ export default function PortfolioSummary({
           label="Total Profit:"
           value={formatNumber(totalProfit)}
           color={totalProfit >= 0 ? 'rgb(52, 211, 153)' : 'rgb(248, 113, 113)'}
+          tooltip="Stocks + dumps + referrals + bonds profit combined"
         />
       </div>
 
@@ -72,6 +76,7 @@ export default function PortfolioSummary({
           label="Stock Profit:"
           value={formatNumber(stocksProfit)}
           color={stocksProfit >= 0 ? 'rgb(52, 211, 153)' : 'rgb(248, 113, 113)'}
+          tooltip="Profit from flipping items"
         />
 
         {/* Dump Profit */}
@@ -80,6 +85,7 @@ export default function PortfolioSummary({
             label="Dump Profit:"
             value={formatNumber(dumpProfit)}
             color="rgb(52, 211, 153)"
+            tooltip="Profit from item dumps"
             button={{
               onClick: onAddDumpProfit,
               color: 'rgb(5, 150, 105)',
@@ -94,6 +100,7 @@ export default function PortfolioSummary({
             label="Referral Profit:"
             value={formatNumber(referralProfit)}
             color="rgb(168, 85, 247)"
+            tooltip="Profit from referrals"
             button={{
               onClick: onAddReferralProfit,
               color: 'rgb(126, 34, 206)',
@@ -108,6 +115,7 @@ export default function PortfolioSummary({
             label="Bonds Profit:"
             value={formatNumber(bondsProfit)}
             color="rgb(234, 179, 8)"
+            tooltip="Profit from bond flips"
             button={{
               onClick: onAddBondsProfit,
               color: 'rgb(161, 98, 7)',
@@ -122,6 +130,7 @@ export default function PortfolioSummary({
             label="Unrealised Profit:"
             value={`${totalUnrealised >= 0 ? '+' : ''}${formatNumber(totalUnrealised, numberFormat)}`}
             color={totalUnrealised >= 0 ? 'rgb(52, 211, 153)' : 'rgb(248, 113, 113)'}
+            tooltip="Estimated profit if sold at GE high (after 2% tax)"
           />
         )}
       </div>
@@ -129,9 +138,9 @@ export default function PortfolioSummary({
   );
 }
 
-function SummaryCard({ label, value, color, button }) {
+function SummaryCard({ label, value, color, button, tooltip }) {
   return (
-    <div style={{
+    <div title={tooltip} style={{
       display: 'flex',
       alignItems: 'center',
       gap: '1rem',

--- a/src/components/StockTable.jsx
+++ b/src/components/StockTable.jsx
@@ -72,22 +72,22 @@ export default function StockTable({
 
 function TableHeader({ sortConfig, onSort, visibleColumns }) {
   const columns = [
-    { label: 'Name', key: 'name', visible: true },
-    { label: 'Status', key: null, visible: visibleColumns.status },
-    { label: 'In Stock', key: 'shares', visible: true },
-    { label: 'Total Cost', key: 'totalCost', visible: true },
-    { label: 'Avg Buy', key: 'avgBuy', visible: visibleColumns.avgBuy },
-    { label: 'Stock Sold', key: 'sharesSold', visible: true },
-    { label: 'Total Sold Price', key: 'totalCostSold', visible: true },
-    { label: 'Avg Sell', key: 'avgSell', visible: visibleColumns.avgSell },
-    { label: 'Profit', key: 'profit', visible: visibleColumns.profit },
-    { label: 'Desired Stock', key: 'needed', visible: visibleColumns.desiredStock },
-    { label: '4H Limit', key: 'limit4h', visible: visibleColumns.limit4h },
-    { label: 'GE High', key: null, visible: visibleColumns.geHigh },
-    { label: 'GE Low', key: null, visible: visibleColumns.geLow },
-    { label: 'Unreal. Profit', key: null, visible: visibleColumns.unrealizedProfit },
-    { label: 'Notes', key: null, visible: visibleColumns.notes },
-    { label: 'Actions', key: null, visible: true }
+    { label: 'Name', key: 'name', visible: true, tooltip: 'Item name' },
+    { label: 'Status', key: null, visible: visibleColumns.status, tooltip: 'Shows if the 4h GE buy limit has reset' },
+    { label: 'In Stock', key: 'shares', visible: true, tooltip: 'How many you currently hold' },
+    { label: 'Total Cost', key: 'totalCost', visible: true, tooltip: 'Total GP spent buying this item' },
+    { label: 'Avg Buy', key: 'avgBuy', visible: visibleColumns.avgBuy, tooltip: 'Average price paid per item' },
+    { label: 'Stock Sold', key: 'sharesSold', visible: true, tooltip: 'How many you have sold' },
+    { label: 'Total Sold Price', key: 'totalCostSold', visible: true, tooltip: 'Total GP received from sales' },
+    { label: 'Avg Sell', key: 'avgSell', visible: visibleColumns.avgSell, tooltip: 'Average sell price per item' },
+    { label: 'Profit', key: 'profit', visible: visibleColumns.profit, tooltip: 'Realized profit from sold items' },
+    { label: 'Desired Stock', key: 'needed', visible: visibleColumns.desiredStock, tooltip: 'How many you want to hold' },
+    { label: '4H Limit', key: 'limit4h', visible: visibleColumns.limit4h, tooltip: 'GE 4-hour buy limit' },
+    { label: 'GE High', key: null, visible: visibleColumns.geHigh, tooltip: 'Live GE highest buy price' },
+    { label: 'GE Low', key: null, visible: visibleColumns.geLow, tooltip: 'Live GE lowest sell price' },
+    { label: 'Unreal. Profit', key: null, visible: visibleColumns.unrealizedProfit, tooltip: 'Estimated profit if sold at GE high (after 2% tax)' },
+    { label: 'Notes', key: null, visible: visibleColumns.notes, tooltip: 'Your notes for this item' },
+    { label: 'Actions', key: null, visible: true, tooltip: 'Buy, sell, adjust, calculate, archive, or delete' }
   ];
 
   return (
@@ -99,6 +99,7 @@ function TableHeader({ sortConfig, onSort, visibleColumns }) {
             key={col.label}
             onClick={() => col.key && onSort(col.key)}
             className={`th-base ${col.key ? 'th-sortable' : ''}`}
+            title={col.tooltip}
           >
             <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
               {col.label}

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -288,34 +288,34 @@ export default function HistoryPage({
         <table className="history-table">
           <thead>
             <tr>
-              <th className="history-th--sortable" onClick={() => handleSort('date')}>
+              <th className="history-th--sortable" onClick={() => handleSort('date')} title="When this trade happened">
                 Date <SortIcon col="date" />
               </th>
-              <th className="history-th--sortable" onClick={() => handleSort('stockName')}>
+              <th className="history-th--sortable" onClick={() => handleSort('stockName')} title="Item that was traded">
                 Item <SortIcon col="stockName" />
               </th>
-              <th className="history-th--sortable" onClick={() => handleSort('type')}>
+              <th className="history-th--sortable" onClick={() => handleSort('type')} title="Buy, sell, or adjust">
                 Type <SortIcon col="type" />
               </th>
-              <th className="history-th--right history-th--sortable" onClick={() => handleSort('shares')}>
+              <th className="history-th--right history-th--sortable" onClick={() => handleSort('shares')} title="Number of items traded">
                 Qty <SortIcon col="shares" />
               </th>
-              <th className="history-th--right history-th--sortable" onClick={() => handleSort('price')}>
+              <th className="history-th--right history-th--sortable" onClick={() => handleSort('price')} title="Price per item">
                 Price Each <SortIcon col="price" />
               </th>
-              <th className="history-th--right history-th--sortable" onClick={() => handleSort('total')}>
+              <th className="history-th--right history-th--sortable" onClick={() => handleSort('total')} title="Total GP for this trade">
                 Total <SortIcon col="total" />
               </th>
-              <th className="history-th--right history-th--sortable" onClick={() => handleSort('profit')}>
+              <th className="history-th--right history-th--sortable" onClick={() => handleSort('profit')} title="Profit made on this sale">
                 Profit <SortIcon col="profit" />
               </th>
-              <th className="history-th--right history-th--sortable" onClick={() => handleSort('margin')}>
+              <th className="history-th--right history-th--sortable" onClick={() => handleSort('margin')} title="Profit margin %">
                 Margin <SortIcon col="margin" />
               </th>
-              <th className="history-th--sortable" onClick={() => handleSort('category')}>
+              <th className="history-th--sortable" onClick={() => handleSort('category')} title="Category this item is in">
                 Category <SortIcon col="category" />
               </th>
-              <th>Undo</th>
+              <th title="Undo this trade">Undo</th>
             </tr>
           </thead>
           <tbody>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -184,12 +184,12 @@ export default function HomePage({
               <table className="table-base">
                 <thead className="thead-base">
                   <tr>
-                    <th className="th-base">Date</th>
-                    <th className="th-base">Action</th>
-                    <th className="th-base">Item</th>
-                    <th className="th-base td-right">Qty</th>
-                    <th className="th-base td-right">GP</th>
-                    <th className="th-base td-right">Profit</th>
+                    <th className="th-base" title="When this trade happened">Date</th>
+                    <th className="th-base" title="Buy, sell, or adjust">Action</th>
+                    <th className="th-base" title="Item that was traded">Item</th>
+                    <th className="th-base td-right" title="Number of items traded">Qty</th>
+                    <th className="th-base td-right" title="Total GP for this trade">GP</th>
+                    <th className="th-base td-right" title="Profit made on this trade">Profit</th>
                   </tr>
                 </thead>
                 <tbody>


### PR DESCRIPTION
## Summary
  - Added hover tooltips to StockTable column headers explaining what each column means
  - Added tooltips to HistoryPage and HomePage table headers
  - Added tooltips to CategorySection stat items
  - Added tooltips to PortfolioSummary cards