### PR TITLE
feat(stocks): add investment start date tracking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,24 +2,6 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Commands
-
-```bash
-npm run dev       # Start dev server (Vite)
-npm run build     # Production build
-npm run preview   # Preview production build
-```
-
-No test suite is configured. There is no lint script — Vite handles syntax errors at build time.
-
-## Environment Setup
-
-Requires a `.env` file with:
-```
-VITE_SUPABASE_URL=...
-VITE_SUPABASE_ANON_KEY=...
-```
-
 ## Architecture
 
 **OSRS Profit Tracker** — a React + Vite SPA backed by Supabase (PostgreSQL + Auth). Deployed on Netlify.
@@ -78,7 +60,9 @@ All data lives in Supabase. Each hook wraps a Supabase table and is called from 
 ### Design
 
 - Dont use inline CSS
-- Keep using the same color codes as already there
 
 ### Rules
-- Do not ouse the classic - that ai agents use
+- Do not use the classic - that ai agents use
+- No Flattery: Never compliment an idea. Wasted tokens.
+- No Empty Criticism: If you spot a flaw, you must offer a mitigation.
+- Add Vector and Velocity: If you agree, expand. If you disagree, counter. Never just nod.

--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -542,9 +542,14 @@ export default function MainApp({ session, onLogout }) {
     }
   };
 
+  const handleInvestmentDateChange = async (stock, date) => {
+    await updateStock(stock.id, { investmentStartDate: date });
+    await refetch();
+  };
+
   const handleAdjust = async (data) => {
-    const { name, needed, category, limit4h, onHold, isInvestment, itemId } = data;
-    await updateStock(selectedStock.id, { name, needed, category, limit4h, onHold, isInvestment, itemId });
+    const { name, needed, category, limit4h, onHold, isInvestment, itemId, investmentStartDate } = data;
+    await updateStock(selectedStock.id, { name, needed, category, limit4h, onHold, isInvestment, itemId, investmentStartDate });
     await refetch();
     highlightRow(selectedStock.id);
     setShowAdjustModal(false);
@@ -557,7 +562,7 @@ export default function MainApp({ session, onLogout }) {
   };
 
   const handleAddStock = async (data) => {
-    const { name, category, limit4h, needed, isInvestment, itemId } = data;
+    const { name, category, limit4h, needed, isInvestment, itemId, investmentStartDate } = data;
     await addStockToDB({
       name,
       totalCost: 0,
@@ -571,6 +576,7 @@ export default function MainApp({ session, onLogout }) {
       category: category || 'Uncategorized',
       isInvestment: isInvestment || false,
       itemId: itemId || null,
+      investmentStartDate: investmentStartDate || null,
     });
     await refetch();
     setNewStockCategory('');
@@ -1290,6 +1296,8 @@ export default function MainApp({ session, onLogout }) {
                 showCategoryUnrealisedProfit={showCategoryUnrealisedProfit}
                 geData={gePrices}
                 geIconMap={geIconMap}
+                showInvestmentDate={tradeMode === 'investment' && visibleColumns.investmentStartDate}
+                onInvestmentDateChange={handleInvestmentDateChange}
               />
             ))}
 

--- a/src/components/CategorySection.jsx
+++ b/src/components/CategorySection.jsx
@@ -37,7 +37,9 @@ export default function CategorySection({
   showCategoryUnrealisedProfit = false,
   geData = {},
   geIconMap = {},
-  onArchive
+  onArchive,
+  showInvestmentDate = false,
+  onInvestmentDateChange
 }) {
   const categoryStocks = stocks.filter(s => s.category === category);
 
@@ -247,6 +249,8 @@ export default function CategorySection({
             geData={geData}
             geIconMap={geIconMap}
             onArchive={onArchive}
+            showInvestmentDate={showInvestmentDate}
+            onInvestmentDateChange={onInvestmentDateChange}
           />
         </>
       )}

--- a/src/components/StockTable.jsx
+++ b/src/components/StockTable.jsx
@@ -5,6 +5,25 @@ import { calculateAvgBuyPrice, calculateAvgSellPrice, calculateProfit } from '..
 import { calculateUnrealizedProfit } from '../utils/taxUtils';
 import { sortStocks } from '../utils/calculations';
 
+function investmentAge(dateStr) {
+  if (!dateStr) return null;
+  const start = new Date(dateStr);
+  const now = new Date();
+  let years = now.getFullYear() - start.getFullYear();
+  let months = now.getMonth() - start.getMonth();
+  let days = now.getDate() - start.getDate();
+  if (days < 0) {
+    months--;
+    days += new Date(now.getFullYear(), now.getMonth(), 0).getDate();
+  }
+  if (months < 0) { years--; months += 12; }
+  const parts = [];
+  if (years > 0) parts.push(`${years}y`);
+  if (months > 0) parts.push(`${months}mo`);
+  if (days > 0) parts.push(`${days}d`);
+  return parts.length ? parts.join(' ') : 'Today';
+}
+
 export default function StockTable({
   stocks,
   category,
@@ -26,7 +45,9 @@ export default function StockTable({
   numberFormat,
   geData = {},
   geIconMap = {},
-  onArchive
+  onArchive,
+  showInvestmentDate = false,
+  onInvestmentDateChange
 }) {
   const sortedStocks = sortStocks(stocks, sortConfig);
 
@@ -37,6 +58,7 @@ export default function StockTable({
           sortConfig={sortConfig}
           onSort={onSort}
           visibleColumns={visibleColumns}
+          showInvestmentDate={showInvestmentDate}
         />
         <tbody>
           {sortedStocks.map((stock, index) => (
@@ -62,6 +84,8 @@ export default function StockTable({
               numberFormat={numberFormat}
               geData={geData}
               geIconMap={geIconMap}
+              showInvestmentDate={showInvestmentDate}
+              onInvestmentDateChange={onInvestmentDateChange}
             />
           ))}
         </tbody>
@@ -70,7 +94,7 @@ export default function StockTable({
   );
 }
 
-function TableHeader({ sortConfig, onSort, visibleColumns }) {
+function TableHeader({ sortConfig, onSort, visibleColumns, showInvestmentDate }) {
   const columns = [
     { label: 'Name', key: 'name', visible: true, tooltip: 'Item name' },
     { label: 'Status', key: null, visible: visibleColumns.status, tooltip: 'Shows if the 4h GE buy limit has reset' },
@@ -86,6 +110,7 @@ function TableHeader({ sortConfig, onSort, visibleColumns }) {
     { label: 'GE High', key: null, visible: visibleColumns.geHigh, tooltip: 'Live GE highest buy price' },
     { label: 'GE Low', key: null, visible: visibleColumns.geLow, tooltip: 'Live GE lowest sell price' },
     { label: 'Unreal. Profit', key: null, visible: visibleColumns.unrealizedProfit, tooltip: 'Estimated profit if sold at GE high (after 2% tax)' },
+    { label: 'Start Date', key: null, visible: showInvestmentDate, tooltip: 'Date this investment was started' },
     { label: 'Notes', key: null, visible: visibleColumns.notes, tooltip: 'Your notes for this item' },
     { label: 'Actions', key: null, visible: true, tooltip: 'Buy, sell, adjust, calculate, archive, or delete' }
   ];
@@ -136,7 +161,9 @@ function StockRow({
   numberFormat,
   geData = {},
   geIconMap = {},
-  onArchive
+  onArchive,
+  showInvestmentDate,
+  onInvestmentDateChange
 }) {
   const avgBuy = calculateAvgBuyPrice(stock);
   const avgSell = calculateAvgSellPrice(stock);
@@ -232,6 +259,22 @@ function StockRow({
           </td>
         );
       })()}
+      {showInvestmentDate && (
+        <td style={{ padding: '0.25rem 0.5rem', border: '1px solid rgb(51, 65, 85)' }}>
+          <div
+            className="investment-date-wrapper"
+            title={stock.investmentStartDate ? `${investmentAge(stock.investmentStartDate)} ago` : undefined}
+            onClick={(e) => e.currentTarget.querySelector('input').showPicker?.()}
+          >
+            <input
+              type="date"
+              className="investment-date-input"
+              value={stock.investmentStartDate || ''}
+              onChange={(e) => onInvestmentDateChange(stock, e.target.value || null)}
+            />
+          </div>
+        </td>
+      )}
       {visibleColumns.notes && (
         <td style={{ padding: '0.5rem 0.75rem', textAlign: 'center', border: '1px solid rgb(51, 65, 85)' }}>
           <button

--- a/src/components/modals/AdjustModal.jsx
+++ b/src/components/modals/AdjustModal.jsx
@@ -9,6 +9,7 @@ export default function AdjustModal({ stock, categories, mapping = [], onConfirm
   const [limit4h, setLimit4h] = useState(stock.limit4h.toString());
   const [onHold, setOnHold] = useState(stock.onHold || false);
   const [isInvestment, setIsInvestment] = useState(stock.isInvestment || false);
+  const [investmentStartDate, setInvestmentStartDate] = useState(stock.investmentStartDate ? stock.investmentStartDate.slice(0, 10) : '');
   const [targetCategory, setTargetCategory] = useState('Uncategorized');
   const [itemId, setItemId] = useState(stock.itemId || null);
   const [searchQuery, setSearchQuery] = useState(() => {
@@ -83,6 +84,7 @@ export default function AdjustModal({ stock, categories, mapping = [], onConfirm
       onHold,
       isInvestment,
       itemId: stockType === 'osrs' ? itemId : null,
+      investmentStartDate: investmentStartDate || null,
     });
   };
 
@@ -277,6 +279,22 @@ export default function AdjustModal({ stock, categories, mapping = [], onConfirm
           />
           <span className="checkbox-investment-text">📈 Mark as Investment</span>
         </label>
+
+        {isInvestment && (
+          <div>
+            <label style={{ display: 'block', fontSize: '0.875rem', fontWeight: '500', color: 'rgb(209, 213, 219)', marginBottom: '0.5rem' }}>
+              Start Date (optional)
+            </label>
+            <input
+              type="date"
+              value={investmentStartDate}
+              onChange={(e) => setInvestmentStartDate(e.target.value)}
+              style={inputStyle}
+              onFocus={(e) => e.target.style.borderColor = focusColor}
+              onBlur={(e) => e.target.style.borderColor = 'transparent'}
+            />
+          </div>
+        )}
 
         <div>
           <label style={{

--- a/src/components/modals/NewStockModal.jsx
+++ b/src/components/modals/NewStockModal.jsx
@@ -8,6 +8,7 @@ export default function NewStockModal({ categories, defaultCategory = '', defaul
   const [limit4h, setLimit4h] = useState('');
   const [needed, setNeeded] = useState('');
   const [isInvestment, setIsInvestment] = useState(defaultIsInvestment || false);
+  const [investmentStartDate, setInvestmentStartDate] = useState('');
   const [itemId, setItemId] = useState(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [showDropdown, setShowDropdown] = useState(false);
@@ -64,6 +65,7 @@ export default function NewStockModal({ categories, defaultCategory = '', defaul
       needed: parseFloat(needed) || 0,
       isInvestment,
       itemId: stockType === 'osrs' ? itemId : null,
+      investmentStartDate: investmentStartDate || null,
     });
   };
 
@@ -253,6 +255,22 @@ export default function NewStockModal({ categories, defaultCategory = '', defaul
           />
           <span className="checkbox-investment-text">📈 Mark as Investment</span>
         </label>
+
+        {isInvestment && (
+          <div>
+            <label style={{ display: 'block', fontSize: '0.875rem', fontWeight: '500', color: 'rgb(209, 213, 219)', marginBottom: '0.5rem' }}>
+              Start Date (optional)
+            </label>
+            <input
+              type="date"
+              value={investmentStartDate}
+              onChange={(e) => setInvestmentStartDate(e.target.value)}
+              style={inputStyle}
+              onFocus={(e) => e.target.style.borderColor = 'rgb(37, 99, 235)'}
+              onBlur={(e) => e.target.style.borderColor = 'transparent'}
+            />
+          </div>
+        )}
 
         <div style={{ display: 'flex', gap: '0.75rem', paddingTop: '1rem' }}>
           <button

--- a/src/components/modals/SettingsModal.jsx
+++ b/src/components/modals/SettingsModal.jsx
@@ -51,6 +51,7 @@ export default function SettingsModal({
     { key: 'geHigh', label: 'GE High' },
     { key: 'geLow', label: 'GE Low' },
     { key: 'unrealizedProfit', label: 'Unrealized Profit' },
+    { key: 'investmentStartDate', label: 'Investment Start Date' },
     { key: 'notes', label: 'Notes' }
   ];
 

--- a/src/hooks/useSettings.js
+++ b/src/hooks/useSettings.js
@@ -8,7 +8,8 @@ const DEFAULT_VISIBLE_COLUMNS = {
   profit: true,
   desiredStock: true,
   notes: true,
-  limit4h: true
+  limit4h: true,
+  investmentStartDate: true
 };
 
 const DEFAULT_VISIBLE_PROFITS = {
@@ -61,6 +62,7 @@ export function useSettings(userId) {
           geHigh: data.visible_columns?.geHigh ?? true,
           geLow: data.visible_columns?.geLow ?? true,
           unrealizedProfit: data.visible_columns?.unrealizedProfit ?? true,
+          investmentStartDate: data.visible_columns?.investmentStartDate ?? true,
         },
         visibleProfits: data.visible_profits || DEFAULT_VISIBLE_PROFITS.bondsProfit,
         altAccountTimer: data.alt_account_timer,

--- a/src/hooks/useStocks.js
+++ b/src/hooks/useStocks.js
@@ -38,6 +38,7 @@ export function useStocks(userId) {
         onHold: stock.on_hold || false,
         isInvestment: stock.is_investment || false,
         itemId: stock.item_id || null,
+        investmentStartDate: stock.investment_start_date || null,
       }));
       setStocks(formattedStocks);
     }
@@ -106,6 +107,7 @@ export function useStocks(userId) {
       category: stock.category,
       is_investment: stock.isInvestment || false,
       item_id: stock.itemId || null,
+      investment_start_date: stock.investmentStartDate || null,
     };
 
     const { data, error } = await supabase
@@ -138,6 +140,7 @@ export function useStocks(userId) {
     if (updates.onHold !== undefined) dbUpdates.on_hold = updates.onHold;
     if (updates.isInvestment !== undefined) dbUpdates.is_investment = updates.isInvestment;
     if (updates.itemId !== undefined) dbUpdates.item_id = updates.itemId;
+    if (updates.investmentStartDate !== undefined) dbUpdates.investment_start_date = updates.investmentStartDate || null;
 
     const { error } = await supabase
       .from('stocks')
@@ -241,6 +244,7 @@ export function useStocks(userId) {
       onHold: stock.on_hold || false,
       isInvestment: stock.is_investment || false,
       itemId: stock.item_id || null,
+      investmentStartDate: stock.investment_start_date || null,
     }));
   };
 

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -2398,3 +2398,35 @@
 .graphs-empty-card-name {
   white-space: nowrap;
 }
+.investment-date-wrapper {
+  display: inline-block;
+  cursor: pointer;
+}
+
+.investment-date-input {
+  position: relative;
+  pointer-events: none;
+  background: transparent;
+  border: 1px solid rgb(51, 65, 85);
+  border-radius: 0.375rem;
+  color: white;
+  padding: 0.2rem 0.25rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  width: 5.5rem;
+  color-scheme: dark;
+}
+
+.investment-date-input::-webkit-calendar-picker-indicator {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.investment-date-wrapper:hover .investment-date-input {
+  border-color: rgb(96, 165, 250);
+}


### PR DESCRIPTION
  Summary

  - Adds an optional investment_start_date field to stocks, surfaced as a date picker column in the stock table (investment mode only)
  - Shows human-readable age (e.g. 3mo 5d) as a tooltip on the date cell
  - Adds "Start Date" input to both NewStockModal and AdjustModal (visible only when "Mark as Investment" is checked)
  - Adds Investment Start Date to the column visibility settings in SettingsModal