### PR TITLE
feat(ui): add notification center shell to topbar

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -22,6 +22,7 @@ import Footer from './components/Footer';
 import EditCategoryModal from './components/modals/EditCategoryModal';
 import TimeCalculatorModal from './components/modals/TimeCalculatorModal';
 import Header from './components/Header';
+import NotificationCenter from './components/NotificationCenter';
 import PortfolioSummary from './components/PortfolioSummary';
 import ChartButtons from './components/ChartButtons';
 import CategorySection from './components/CategorySection';
@@ -1052,7 +1053,9 @@ export default function MainApp({ session, onLogout }) {
             </a>
           </div>
 
-          {/* Right - User dropdown */}
+          {/* Right - Notifications + User dropdown */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <NotificationCenter notifications={[]} />
           <div className="user-dropdown-wrapper">
             <button
               className="user-dropdown-trigger"
@@ -1095,6 +1098,7 @@ export default function MainApp({ session, onLogout }) {
                 </button>
               </div>
             )}
+          </div>
           </div>
         </div>
       </div>

--- a/src/components/NotificationCenter.jsx
+++ b/src/components/NotificationCenter.jsx
@@ -1,0 +1,47 @@
+import { useEffect, useRef, useState } from 'react';
+import { Bell } from 'lucide-react';
+
+export default function NotificationCenter({ notifications = [] }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const wrapperRef = useRef(null);
+
+  useEffect(() => {
+    function handleClickOutside(e) {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target)) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  return (
+    <div className="notification-bell-wrapper" ref={wrapperRef}>
+      <button
+        className="notification-bell-btn"
+        onClick={() => setIsOpen(prev => !prev)}
+        aria-label="Notifications"
+      >
+        <Bell size={18} />
+        {notifications.length > 0 && (
+          <span className="notification-badge">
+            {notifications.length > 99 ? '99+' : notifications.length}
+          </span>
+        )}
+      </button>
+
+      {isOpen && (
+        <div className="notification-panel">
+          <div className="notification-panel-header">Notifications</div>
+          {notifications.length === 0 ? (
+            <p className="notification-empty">No notifications</p>
+          ) : (
+            notifications.map((n, i) => (
+              <div key={i} className="notification-item">{n.message}</div>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -2456,3 +2456,86 @@
 .investment-date-wrapper:hover .investment-date-input {
   border-color: rgb(96, 165, 250);
 }
+
+/* Notification Center */
+.notification-bell-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.notification-bell-btn {
+  position: relative;
+  background: transparent;
+  border: none;
+  color: rgb(148, 163, 184);
+  cursor: pointer;
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  display: flex;
+  align-items: center;
+  transition: background 0.2s, color 0.2s;
+}
+
+.notification-bell-btn:hover {
+  background: rgba(148, 163, 184, 0.1);
+  color: white;
+}
+
+.notification-badge {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  background: rgb(220, 38, 38);
+  color: white;
+  font-size: 0.65rem;
+  font-weight: 700;
+  min-width: 16px;
+  height: 16px;
+  border-radius: 9999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 3px;
+  line-height: 1;
+}
+
+.notification-panel {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  min-width: 280px;
+  background: rgb(30, 41, 59);
+  border: 1px solid rgb(51, 65, 85);
+  border-radius: 0.5rem;
+  z-index: 200;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  animation: fadeIn 0.15s ease;
+}
+
+.notification-panel-header {
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: white;
+  border-bottom: 1px solid rgb(51, 65, 85);
+}
+
+.notification-empty {
+  padding: 1.5rem 1rem;
+  text-align: center;
+  color: rgb(100, 116, 139);
+  font-size: 0.875rem;
+  margin: 0;
+}
+
+.notification-item {
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  color: rgb(148, 163, 184);
+  border-bottom: 1px solid rgb(51, 65, 85);
+}
+
+.notification-item:last-child {
+  border-bottom: none;
+}


### PR DESCRIPTION
## Summary
  Adds a notification center entry point to the topbar — a bell icon that toggles a dropdown panel. This is the structural shell only; no notification logic is wired up yet.

  ## Changes
  - New `NotificationCenter` component with bell icon, click-outside-to-close, unread badge, and empty state
  - Placed in the topbar to the left of the user dropdown
  - Added all supporting CSS classes to `components.css`