### PR TITLE
feat(notifications): add navigation when clicking notifications

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -274,7 +274,7 @@ export default function MainApp({ session, onLogout }) {
         !firedTimerNotifs.current.has(stock.id)
       ) {
         firedTimerNotifs.current.add(stock.id);
-        addNotification('limitTimer', `${stock.name} — GE buy limit has reset`);
+        addNotification('limitTimer', `${stock.name} — GE buy limit has reset`, { page: 'trade', stockId: stock.id });
       }
     });
   }, [currentTime, stocks, addNotification]);
@@ -294,7 +294,7 @@ export default function MainApp({ session, onLogout }) {
 
     if (altAccountTimer <= Date.now()) {
       firedAltTimerNotif.current = true;
-      addNotification('altAccountTimer', 'Alt account timer is ready');
+      addNotification('altAccountTimer', 'Alt account timer is ready', { page: 'trade' });
     }
   }, [currentTime, altAccountTimer, addNotification]);
 
@@ -507,7 +507,7 @@ export default function MainApp({ session, onLogout }) {
           const key = `${period}-${goal}`;
           if (!firedMilestoneNotifs.current.has(key)) {
             firedMilestoneNotifs.current.add(key);
-            addNotification('milestone', `${periodLabels[period]} milestone achieved!`);
+            addNotification('milestone', `${periodLabels[period]} milestone achieved!`, { page: 'home' });
           }
         }
       });
@@ -787,6 +787,23 @@ export default function MainApp({ session, onLogout }) {
       scrollToCategory();
     }
   };
+
+  const handleNotificationNavigate = useCallback((target) => {
+    if (!target) return;
+    navigateToPage(target.page);
+    if (target.stockId) {
+      setTimeout(() => {
+        const el = document.querySelector(`[data-stock-id="${target.stockId}"]`);
+        if (el) {
+          const topbarHeight = document.querySelector('.topbar')?.offsetHeight || 60;
+          const top = el.getBoundingClientRect().top + window.scrollY - topbarHeight - 16;
+          window.scrollTo({ top, behavior: 'smooth' });
+          el.classList.add('stock-row-highlight');
+          setTimeout(() => el.classList.remove('stock-row-highlight'), 1500);
+        }
+      }, 100);
+    }
+  }, [navigateToPage]);
 
   const handleSetAltTimer = async (days) => {
     const timerEndTime = Date.now() + (days * 24 * 60 * 60 * 1000);
@@ -1163,6 +1180,7 @@ export default function MainApp({ session, onLogout }) {
             onMarkAllAsRead={markAllAsRead}
             onDismiss={dismissNotification}
             onClearAll={clearAllNotifications}
+            onNavigate={handleNotificationNavigate}
           />
           <div className="user-dropdown-wrapper">
             <button

--- a/src/components/NotificationCenter.jsx
+++ b/src/components/NotificationCenter.jsx
@@ -45,6 +45,7 @@ export default function NotificationCenter({
   onMarkAllAsRead,
   onDismiss,
   onClearAll,
+  onNavigate,
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const wrapperRef = useRef(null);
@@ -106,8 +107,14 @@ export default function NotificationCenter({
               {notifications.map((n) => (
                 <div
                   key={n.id}
-                  className={`notification-item ${n.read ? 'notification-item-read' : 'notification-item-unread'}`}
-                  onClick={() => !n.read && onMarkAsRead(n.id)}
+                  className={`notification-item ${n.read ? 'notification-item-read' : 'notification-item-unread'} ${n.navigationTarget ? 'notification-item-clickable' : ''}`}
+                  onClick={() => {
+                    if (!n.read) onMarkAsRead(n.id);
+                    if (n.navigationTarget) {
+                      onNavigate?.(n.navigationTarget);
+                      setIsOpen(false);
+                    }
+                  }}
                 >
                   <div
                     className="notification-item-icon"

--- a/src/components/StockTable.jsx
+++ b/src/components/StockTable.jsx
@@ -179,6 +179,7 @@ function StockRow({
 
   return (
     <tr
+      data-stock-id={stock.id}
       className={`tr-base ${isHighlighted ? 'tr-highlighted' : (index % 2 ? 'tr-even' : 'tr-odd')}`}
       draggable
       onDragStart={(e) => onDragStart(e, stock.id, category)}

--- a/src/hooks/useNotifications.js
+++ b/src/hooks/useNotifications.js
@@ -179,7 +179,7 @@ export function useNotifications(preferences) {
     [notifications]
   );
 
-  const addNotification = useCallback((type, message) => {
+  const addNotification = useCallback((type, message, navigationTarget = null) => {
     const prefs = prefsRef.current;
     if (!prefs) return;
 
@@ -195,6 +195,7 @@ export function useNotifications(preferences) {
       message,
       timestamp: Date.now(),
       read: false,
+      navigationTarget,
     };
 
     setNotifications(prev => [notification, ...prev]);

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -2929,3 +2929,22 @@
   border-radius: 0.375rem;
   cursor: pointer;
 }
+
+/* Stock row highlight animation for notification navigation */
+.stock-row-highlight {
+  animation: stockHighlight 1.5s ease-out;
+}
+
+@keyframes stockHighlight {
+  0% {
+    background-color: rgba(124, 58, 237, 0.2);
+  }
+  100% {
+    background-color: transparent;
+  }
+}
+
+/* Notification items with navigation targets */
+.notification-item-clickable {
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
Users can now click on notifications to navigate to the relevant part of the app. Limit timer notifications navigate to the Trade page and scroll to the specific stock, milestone notifications navigate to the Home page, and alt timer notifications navigate to the Trade page.

## Changes
- Extended notification object to include optional `navigationTarget` property with page and stockId
- Added `handleNotificationNavigate` callback in MainApp to handle navigation and scrolling with highlight animation
- Updated notification triggers to include navigation targets for all three notification types
- Added `data-stock-id` attribute to stock table rows to enable DOM querying by stock
- Added CSS animations for visual feedback when navigating to a stock row
- Made notifications with navigation targets clickable with visual cursor feedback