### PR TITLE
fix(sidebar): expand quick-nav panel and fix vertical reach

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1087,8 +1087,8 @@
 .quick-nav-wrapper {
   position: fixed;
   left: 0;
-  top: 20%;
-  height: 60%;
+  top: 0;
+  height: 100%;
   width: 12px;
   z-index: 100;
   display: flex;
@@ -1142,7 +1142,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  min-width: 160px;
+  min-width: 200px;
   box-shadow: 4px 0 20px rgba(0, 0, 0, 0.4);
   opacity: 0;
   pointer-events: none;
@@ -1184,7 +1184,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 150px;
+  max-width: 184px;
 }
 
 .quick-nav-item:hover {


### PR DESCRIPTION
## Summary
The category sidebar was clipping long category names mid-character and breaking hover access at the top/bottom of long lists. This fixes both issues by expanding the panel width and extending the hover wrapper to cover the full viewport height.

## Changes
- Expand `.quick-nav-panel` min-width from 160px to 200px to accommodate longer names
- Adjust `.quick-nav-item` max-width to 184px to match content area and enable proper ellipsis
- Extend `.quick-nav-wrapper` from top:20% height:60% to top:0 height:100% for full vertical hover coverage