### PR TITLE
feat: Jmod Reddit comment notifications

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -36,7 +36,8 @@
       "Bash(git pull:*)",
       "Skill(pr)",
       "Bash(git:*)",
-      "Bash(gh release:*)"
+      "Bash(gh release:*)",
+      "Bash(netlify:*)"
     ]
   }
 }

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,3 +15,7 @@
    [[scheduled-functions]]
      function = "osrs-news-cache"
      schedule = "*/1 * * * *"
+
+   [[scheduled-functions]]
+     function = "jmod-comments-cache"
+     schedule = "*/1 * * * *"

--- a/netlify/functions/jmod-comments-cache.js
+++ b/netlify/functions/jmod-comments-cache.js
@@ -1,0 +1,105 @@
+const { readFileSync } = require('fs');
+const { resolve } = require('path');
+const { getStore } = require('@netlify/blobs');
+
+const JMOD_USERNAMES = [
+  'JagexAsh', 'JagexLight', 'JagexSarnie', 'JagexGoblin',
+  'JagexAyiza', 'JagexFlippy', 'Mod_Kieren', 'JagexHusky',
+  'JagexSween', 'Jagex_Wolf', 'JagexTyran', 'JagexRoq',
+  'JagexBlossom', 'JagexNin', 'JagexRice',
+];
+
+const HEADERS = {
+  'User-Agent': 'OSRSProfitTracker/1.0 (osrsprofittracker@gmail.com)',
+};
+
+function loadEnvToken() {
+  try {
+    const envPath = resolve(process.cwd(), '.env');
+    const content = readFileSync(envPath, 'utf8');
+    const match = content.match(/^NETLIFY_AUTH_TOKEN=(.+)$/m);
+    return match?.[1]?.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function getJmodStore() {
+  const siteID = process.env.SITE_ID || process.env.NETLIFY_SITE_ID;
+  const token = process.env.NETLIFY_AUTH_TOKEN || loadEnvToken();
+  if (siteID && token) {
+    return getStore({ name: 'jmod-comments', siteID, token });
+  }
+  return getStore('jmod-comments');
+}
+
+function mapComment(c) {
+  const body = (c.data.body || '').replace(/[*_~\[\]()#>]/g, '');
+  return {
+    id: c.data.name,
+    author: c.data.author,
+    body: body.length > 300 ? body.slice(0, 300) + '...' : body,
+    permalink: c.data.permalink,
+    created_utc: c.data.created_utc,
+    link_title: c.data.link_title,
+    subreddit: c.data.subreddit,
+  };
+}
+
+async function fetchUserComments(username) {
+  try {
+    const res = await fetch(
+      `https://www.reddit.com/user/${username}/comments.json?limit=10&sort=new`,
+      { headers: HEADERS }
+    );
+    if (!res.ok) return [];
+    const json = await res.json();
+    return (json?.data?.children || [])
+      .filter(c => c.data.subreddit?.toLowerCase() === '2007scape')
+      .map(mapComment);
+  } catch {
+    return [];
+  }
+}
+
+exports.handler = async () => {
+  try {
+    const store = getJmodStore();
+
+    // Fetch all Jmod profiles in parallel
+    const results = await Promise.all(JMOD_USERNAMES.map(fetchUserComments));
+    const jmodComments = results.flat();
+
+    // Read existing cache to merge
+    let existing = [];
+    const cached = await store.get('cache', { type: 'json' });
+    if (cached) {
+      existing = cached;
+    }
+
+    // Merge and deduplicate
+    const byId = new Map();
+    for (const c of existing) byId.set(c.id, c);
+    for (const c of jmodComments) byId.set(c.id, c);
+
+    const merged = [...byId.values()]
+      .sort((a, b) => b.created_utc - a.created_utc)
+      .slice(0, 50);
+
+    await store.setJSON('cache', merged);
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ success: true, count: merged.length }),
+    };
+  } catch (error) {
+    return {
+      statusCode: 502,
+      body: JSON.stringify({ error: error.message }),
+    };
+  }
+};
+
+exports.config = {
+  schedule: '*/1 * * * *',
+};

--- a/netlify/functions/jmod-comments.js
+++ b/netlify/functions/jmod-comments.js
@@ -1,0 +1,46 @@
+const { readFileSync } = require('fs');
+const { resolve } = require('path');
+const { getStore } = require('@netlify/blobs');
+
+function loadEnvToken() {
+  try {
+    const envPath = resolve(process.cwd(), '.env');
+    const content = readFileSync(envPath, 'utf8');
+    const match = content.match(/^NETLIFY_AUTH_TOKEN=(.+)$/m);
+    return match?.[1]?.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function getJmodStore() {
+  const siteID = process.env.SITE_ID || process.env.NETLIFY_SITE_ID;
+  const token = process.env.NETLIFY_AUTH_TOKEN || loadEnvToken();
+  if (siteID && token) {
+    return getStore({ name: 'jmod-comments', siteID, token });
+  }
+  return getStore('jmod-comments');
+}
+
+exports.handler = async () => {
+  try {
+    const store = getJmodStore();
+    const cached = await store.get('cache', { type: 'json' });
+
+    return {
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      },
+      body: JSON.stringify(cached || []),
+    };
+  } catch (error) {
+    console.error('Error:', error.message);
+    return {
+      statusCode: 502,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: error.message }),
+    };
+  }
+};

--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -17,6 +17,7 @@ import { useProfitHistory } from './hooks/useProfitHistory';
 import { useGEPrices } from './hooks/useGEPrices';
 import { useNotifications } from './hooks/useNotifications';
 import { useOSRSNews } from './hooks/useOSRSNews';
+import { useJmodComments } from './hooks/useJmodComments';
 import CategoryQuickNav from './components/CategoryQuickNav';
 import MilestoneProgressBar from './components/MilestoneProgressBar';
 import MilestoneTrackerModal from './components/modals/MilestoneTrackerModal';
@@ -239,16 +240,19 @@ export default function MainApp({ session, onLogout }) {
   } = useNotifications(notificationPreferences);
 
   const { newsItems } = useOSRSNews();
+  const { jmodComments } = useJmodComments();
 
   // Track which timer notifications have already fired to avoid duplicates
   const firedTimerNotifs = useRef(new Set(JSON.parse(localStorage.getItem('osrs_fired_limit_timers') || '[]')));
   const firedAltTimerNotif = useRef(false);
   const firedMilestoneNotifs = useRef(new Set(JSON.parse(localStorage.getItem('osrs_fired_milestones') || '[]')));
   const seenNewsGuids = useRef(new Set(JSON.parse(localStorage.getItem('osrs_seen_news') || '[]')));
+  const seenJmodIds = useRef(new Set(JSON.parse(localStorage.getItem('osrs_seen_jmod') || '[]')));
   const timerNotifsInitialized = useRef(false);
   const altTimerNotifInitialized = useRef(false);
   const milestoneNotifsInitialized = useRef(false);
   const newsNotifsInitialized = useRef(localStorage.getItem('osrs_news_initialized') === 'true');
+  const jmodNotifsInitialized = useRef(localStorage.getItem('osrs_jmod_initialized') === 'true');
   const timerTimeoutsRef = useRef(new Map());
 
   // Helper to persist firedTimerNotifs to localStorage
@@ -653,6 +657,34 @@ export default function MainApp({ session, onLogout }) {
       localStorage.setItem('osrs_seen_news', JSON.stringify([...seenNewsGuids.current]));
     }
   }, [newsItems, addNotification]);
+
+  // Jmod Reddit notification effect
+  useEffect(() => {
+    if (!jmodComments || jmodComments.length === 0) return;
+
+    if (!jmodNotifsInitialized.current) {
+      jmodNotifsInitialized.current = true;
+      localStorage.setItem('osrs_jmod_initialized', 'true');
+      jmodComments.forEach(c => seenJmodIds.current.add(c.id));
+      localStorage.setItem('osrs_seen_jmod', JSON.stringify([...seenJmodIds.current]));
+      return;
+    }
+
+    let changed = false;
+    jmodComments.forEach(c => {
+      if (!seenJmodIds.current.has(c.id)) {
+        seenJmodIds.current.add(c.id);
+        changed = true;
+        addNotification('jmodReddit', `${c.author}: ${c.body.slice(0, 80)}`, {
+          externalUrl: `https://www.reddit.com${c.permalink}`,
+        });
+      }
+    });
+
+    if (changed) {
+      localStorage.setItem('osrs_seen_jmod', JSON.stringify([...seenJmodIds.current]));
+    }
+  }, [jmodComments, addNotification]);
 
   useEffect(() => {
     const storageKey = `lastSeenVersion_${userId}`;
@@ -1369,6 +1401,8 @@ export default function MainApp({ session, onLogout }) {
             onClearAll={clearAllNotifications}
             onNavigate={handleNotificationNavigate}
             newsItems={newsItems}
+            jmodComments={jmodComments}
+            newJmodCount={notifications.filter(n => n.type === 'jmodReddit' && !n.read).length}
           />
           <div className="user-dropdown-wrapper">
             <button

--- a/src/components/NotificationCenter.jsx
+++ b/src/components/NotificationCenter.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { Bell, Clock, Trophy, User, Check, X, CheckCheck, Trash2, Newspaper, ExternalLink } from 'lucide-react';
+import { Bell, Clock, Trophy, User, Check, X, CheckCheck, Trash2, Newspaper, ExternalLink, MessageSquare, Filter } from 'lucide-react';
 
 function getTimeAgo(timestamp) {
   const seconds = Math.floor((Date.now() - timestamp) / 1000);
@@ -22,6 +22,8 @@ function getTypeIcon(type) {
       return <Trophy size={16} />;
     case 'osrsNews':
       return <Newspaper size={16} />;
+    case 'jmodReddit':
+      return <MessageSquare size={16} />;
     default:
       return <Bell size={16} />;
   }
@@ -37,6 +39,8 @@ function getTypeColor(type) {
       return 'var(--notification-milestone-color, rgb(34, 197, 94))';
     case 'osrsNews':
       return 'var(--notification-news-color, rgb(14, 165, 233))';
+    case 'jmodReddit':
+      return 'var(--notification-jmod-color, rgb(255, 149, 0))';
     default:
       return 'rgb(148, 163, 184)';
   }
@@ -51,10 +55,18 @@ export default function NotificationCenter({
   onClearAll,
   onNavigate,
   newsItems = [],
+  jmodComments = [],
+  newJmodCount = 0,
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const [activeTab, setActiveTab] = useState('inbox');
+  const [newsFilter, setNewsFilter] = useState('osrsNews');
+  const [inboxFilter, setInboxFilter] = useState('all');
   const wrapperRef = useRef(null);
+
+  const filteredNotifications = inboxFilter === 'all'
+    ? notifications
+    : notifications.filter(n => n.type === inboxFilter);
 
   useEffect(() => {
     function handleClickOutside(e) {
@@ -97,6 +109,7 @@ export default function NotificationCenter({
                 onClick={() => setActiveTab('news')}
               >
                 News
+                {newJmodCount > 0 && <span className="notification-tab-badge">{newJmodCount > 99 ? '99+' : newJmodCount}</span>}
               </button>
             </div>
             {activeTab === 'inbox' && notifications.length > 0 && (
@@ -123,11 +136,31 @@ export default function NotificationCenter({
 
           {activeTab === 'inbox' && (
             <>
-              {notifications.length === 0 ? (
-                <p className="notification-empty">No notifications</p>
+              {notifications.length > 0 && (
+                <div className="notification-inbox-filters">
+                  {[
+                    { key: 'all', label: 'All' },
+                    { key: 'limitTimer', label: 'Timers' },
+                    { key: 'altAccountTimer', label: 'Alt Timer' },
+                    { key: 'milestone', label: 'Milestones' },
+                    { key: 'osrsNews', label: 'News' },
+                    { key: 'jmodReddit', label: 'Jmod' },
+                  ].map(f => (
+                    <button
+                      key={f.key}
+                      className={`notification-inbox-filter-chip ${inboxFilter === f.key ? 'notification-inbox-filter-chip-active' : ''}`}
+                      onClick={() => setInboxFilter(f.key)}
+                    >
+                      {f.label}
+                    </button>
+                  ))}
+                </div>
+              )}
+              {filteredNotifications.length === 0 ? (
+                <p className="notification-empty">{notifications.length === 0 ? 'No notifications' : 'No notifications in this category'}</p>
               ) : (
                 <div className="notification-list">
-                  {notifications.map((n) => (
+                  {filteredNotifications.map((n) => (
                     <div
                       key={n.id}
                       className={`notification-item ${n.read ? 'notification-item-read' : 'notification-item-unread'} ${n.navigationTarget ? 'notification-item-clickable' : ''}`}
@@ -149,8 +182,17 @@ export default function NotificationCenter({
                         <div className="notification-item-message">{n.message}</div>
                         <div className="notification-item-time">{getTimeAgo(n.timestamp)}</div>
                       </div>
+                      {!n.read && (
+                        <button
+                          className="notification-action-icon-btn"
+                          onClick={(e) => { e.stopPropagation(); onMarkAsRead(n.id); }}
+                          title="Mark as read"
+                        >
+                          <Check size={14} />
+                        </button>
+                      )}
                       <button
-                        className="notification-dismiss-btn"
+                        className="notification-action-icon-btn"
                         onClick={(e) => { e.stopPropagation(); onDismiss(n.id); }}
                         title="Dismiss"
                       >
@@ -165,25 +207,77 @@ export default function NotificationCenter({
 
           {activeTab === 'news' && (
             <>
-              {newsItems.length === 0 ? (
-                <p className="notification-empty">No news yet</p>
-              ) : (
-                <div className="notification-news-list">
-                  {newsItems.slice(0, 10).map((item) => (
-                    <div key={item.guid} className="notification-news-item">
-                      <h4 className="notification-news-title">{item.title}</h4>
-                      <div className="notification-news-meta">{getTimeAgo(new Date(item.pubDate).getTime())}</div>
-                      <a
-                        href={item.link}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="notification-news-link"
-                      >
-                        Read more <ExternalLink size={12} />
-                      </a>
+              <div className="notification-news-filter">
+                <button
+                  className={`notification-news-filter-btn ${newsFilter === 'osrsNews' ? 'notification-news-filter-btn-active' : ''}`}
+                  onClick={() => setNewsFilter('osrsNews')}
+                >
+                  <Newspaper size={14} /> OSRS News
+                </button>
+                <button
+                  className={`notification-news-filter-btn ${newsFilter === 'jmodReddit' ? 'notification-news-filter-btn-active' : ''}`}
+                  onClick={() => setNewsFilter('jmodReddit')}
+                >
+                  <MessageSquare size={14} /> Jmod Reddit
+                  {newJmodCount > 0 && <span className="notification-filter-badge">{newJmodCount}</span>}
+                </button>
+              </div>
+
+              {newsFilter === 'osrsNews' && (
+                <>
+                  {newsItems.length === 0 ? (
+                    <p className="notification-empty">No news yet</p>
+                  ) : (
+                    <div className="notification-news-list">
+                      {newsItems.slice(0, 10).map((item) => (
+                        <div key={item.guid} className="notification-news-item">
+                          <h4 className="notification-news-title">{item.title}</h4>
+                          <div className="notification-news-meta">{getTimeAgo(new Date(item.pubDate).getTime())}</div>
+                          <a
+                            href={item.link}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="notification-news-link"
+                          >
+                            Read more <ExternalLink size={12} />
+                          </a>
+                        </div>
+                      ))}
                     </div>
-                  ))}
-                </div>
+                  )}
+                </>
+              )}
+
+              {newsFilter === 'jmodReddit' && (
+                <>
+                  {jmodComments.length === 0 ? (
+                    <p className="notification-empty">No Jmod comments yet</p>
+                  ) : (
+                    <div className="notification-news-list">
+                      {jmodComments.slice(0, 15).map((comment) => (
+                        <a
+                          key={comment.id}
+                          href={`https://www.reddit.com${comment.permalink}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="notification-jmod-item"
+                        >
+                          <div className="notification-jmod-header">
+                            <span className="notification-jmod-author">{comment.author}</span>
+                            <span className="notification-news-meta">
+                              {getTimeAgo(comment.created_utc * 1000)}
+                            </span>
+                          </div>
+                          <div className="notification-jmod-context">{comment.link_title}</div>
+                          <div className="notification-jmod-body">{comment.body}</div>
+                          <span className="notification-news-link">
+                            View on Reddit <ExternalLink size={12} />
+                          </span>
+                        </a>
+                      ))}
+                    </div>
+                  )}
+                </>
               )}
             </>
           )}

--- a/src/components/modals/SettingsModal.jsx
+++ b/src/components/modals/SettingsModal.jsx
@@ -386,6 +386,7 @@ const NOTIFICATION_TYPES = [
   { key: 'altAccountTimer', label: 'Alt Account Timer', description: 'Get notified when your alt account timer is ready' },
   { key: 'milestones', label: 'Milestones', description: 'Get notified when you reach a profit milestone' },
   { key: 'osrsNews', label: 'OSRS News', description: 'Get notified when new OSRS blog posts are published' },
+  { key: 'jmodReddit', label: 'Jmod Reddit', description: 'Get notified when a Jagex Moderator comments on r/2007scape' },
 ];
 
 function NotificationsTab({ notificationPreferences, onNotificationTypeChange }) {

--- a/src/hooks/useJmodComments.js
+++ b/src/hooks/useJmodComments.js
@@ -1,0 +1,40 @@
+import { useState, useEffect } from 'react';
+
+const POLL_INTERVAL = 5 * 60 * 1000;
+
+export function useJmodComments() {
+  const [jmodComments, setJmodComments] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const fetchComments = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await fetch('/api/jmod-comments');
+      if (!response.ok) throw new Error(`Failed: ${response.status}`);
+      const data = await response.json();
+      setJmodComments(data);
+    } catch (err) {
+      setError(err.message);
+      console.error('Error fetching Jmod comments:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchComments();
+    const interval = setInterval(fetchComments, POLL_INTERVAL);
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') fetchComments();
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, []);
+
+  return { jmodComments, loading, error };
+}

--- a/src/hooks/useNotificationSettings.js
+++ b/src/hooks/useNotificationSettings.js
@@ -1,13 +1,14 @@
 import { useState, useEffect, useCallback } from 'react';
 import { supabase } from '../lib/supabase';
 
-const NOTIFICATION_TYPES = ['limitTimer', 'altAccountTimer', 'milestones', 'osrsNews'];
+const NOTIFICATION_TYPES = ['limitTimer', 'altAccountTimer', 'milestones', 'osrsNews', 'jmodReddit'];
 
 const DEFAULT_TYPE_SETTINGS = {
   limitTimer: { enabled: false, browserPush: false, sound: false, soundChoice: 'chime', customSoundUri: null },
   altAccountTimer: { enabled: true, browserPush: false, sound: false, soundChoice: 'chime', customSoundUri: null },
   milestones: { enabled: true, browserPush: false, sound: false, soundChoice: 'chime', customSoundUri: null },
   osrsNews: { enabled: true, browserPush: false, sound: false, soundChoice: 'chime', customSoundUri: null },
+  jmodReddit: { enabled: true, browserPush: false, sound: false, soundChoice: 'chime', customSoundUri: null },
 };
 
 function rowToPrefs(row) {

--- a/src/hooks/useNotifications.js
+++ b/src/hooks/useNotifications.js
@@ -7,6 +7,7 @@ const TYPE_PREF_KEY = {
   altAccountTimer: 'altAccountTimer',
   milestone: 'milestones',
   osrsNews: 'osrsNews',
+  jmodReddit: 'jmodReddit',
 };
 
 // --- WAV generation helpers ---

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -2659,6 +2659,21 @@
   color: rgb(220, 38, 38);
 }
 
+.notification-action-icon-btn {
+  background: transparent;
+  border: none;
+  color: rgb(100, 116, 139);
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 0.25rem;
+  flex-shrink: 0;
+  transition: color 0.15s;
+}
+
+.notification-action-icon-btn:hover {
+  color: rgb(226, 232, 240);
+}
+
 /* Notification Tabs */
 .notification-tab-bar {
   display: flex;
@@ -2754,6 +2769,133 @@
 
 .notification-news-link:hover {
   color: rgb(147, 197, 253);
+}
+
+/* Inbox Filter Chips */
+.notification-inbox-filters {
+  display: flex;
+  gap: 0.35rem;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid rgb(51, 65, 85);
+  flex-wrap: wrap;
+}
+
+.notification-inbox-filter-chip {
+  padding: 0.2rem 0.5rem;
+  font-size: 0.65rem;
+  font-weight: 500;
+  color: rgb(148, 163, 184);
+  background: rgba(148, 163, 184, 0.1);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.notification-inbox-filter-chip:hover {
+  color: rgb(226, 232, 240);
+  background: rgba(148, 163, 184, 0.15);
+}
+
+.notification-inbox-filter-chip-active {
+  color: rgb(96, 165, 250);
+  background: rgba(96, 165, 250, 0.15);
+  border-color: rgba(96, 165, 250, 0.3);
+}
+
+/* News Sub-filter Bar */
+.notification-news-filter {
+  display: flex;
+  border-bottom: 1px solid rgb(51, 65, 85);
+  padding: 0 0.5rem;
+}
+
+.notification-news-filter-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: rgb(148, 163, 184);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.notification-news-filter-btn:hover {
+  color: rgb(226, 232, 240);
+}
+
+.notification-news-filter-btn-active {
+  color: rgb(226, 232, 240);
+  border-bottom-color: rgb(96, 165, 250);
+}
+
+.notification-filter-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgb(239, 68, 68);
+  color: white;
+  font-size: 0.6rem;
+  font-weight: 700;
+  border-radius: 50%;
+  width: 16px;
+  height: 16px;
+  margin-left: 0.25rem;
+}
+
+/* Jmod Comment Items */
+.notification-jmod-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid rgb(51, 65, 85);
+  text-decoration: none;
+  color: inherit;
+  transition: background 0.15s;
+  cursor: pointer;
+}
+
+.notification-jmod-item:hover {
+  background: rgba(148, 163, 184, 0.05);
+}
+
+.notification-jmod-item:last-child {
+  border-bottom: none;
+}
+
+.notification-jmod-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.notification-jmod-author {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: rgb(255, 149, 0);
+}
+
+.notification-jmod-context {
+  font-size: 0.7rem;
+  color: rgb(100, 116, 139);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.notification-jmod-body {
+  font-size: 0.8rem;
+  color: rgb(203, 213, 225);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 /* Settings Modal */


### PR DESCRIPTION
## Summary
Closes #111

- Add Netlify serverless functions that poll 15 Jmod Reddit profiles every minute and cache r/2007scape comments in Netlify Blobs
- Add "Jmod Reddit" sub-filter in the News tab with comment cards linking to Reddit
- Add inbox notification type `jmodReddit` with full settings (enabled/browser push/sound)
- Add inbox filter chips to filter notifications by type
- Add always-visible mark-as-read and dismiss buttons on notification items

## Test plan
- [ ] Verify `jmod-comments-cache` cron populates Netlify Blobs with real Jmod comments after deploy
- [ ] Verify `/api/jmod-comments` returns cached comments
- [ ] Open News tab > Jmod Reddit — confirm comments render with author, post title, body, and time
- [ ] Click a Jmod comment — confirm it opens Reddit permalink in new tab
- [ ] Check Settings > Notifications — confirm "Jmod Reddit" type appears with all toggles
- [ ] Wait for a new Jmod comment — confirm inbox notification fires
- [ ] Test inbox filter chips (All, Timers, Alt Timer, Milestones, News, Jmod)
- [ ] Test mark-as-read (check icon) and dismiss (X icon) on notification items

🤖 Generated with [Claude Code](https://claude.com/claude-code)