### PR TITLE
feat(remove-modal): display precise GP amounts

### DIFF
--- a/src/components/modals/RemoveStockModal.jsx
+++ b/src/components/modals/RemoveStockModal.jsx
@@ -77,7 +77,7 @@ export default function RemoveStockModal({ stock, onConfirm, onCancel, isSubmitt
               Avg Buy Price:
             </span>
             <span style={{ fontSize: '0.875rem', fontWeight: '600', color: 'white' }}>
-              {formatNumber(avgBuy)}
+              {formatNumber(avgBuy, 'full')}
             </span>
           </div>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
@@ -85,7 +85,7 @@ export default function RemoveStockModal({ stock, onConfirm, onCancel, isSubmitt
               Cost Basis Removed:
             </span>
             <span style={{ fontSize: '0.875rem', fontWeight: '600', color: 'rgb(248, 113, 113)' }}>
-              {formatNumber(costToRemove)}
+              {formatNumber(costToRemove, 'full')}
             </span>
           </div>
         </div>


### PR DESCRIPTION
## Summary
Updated the Remove Stock modal to display precise GP amounts instead of compact abbreviated format. This allows users to see exact cost basis values when removing stock.

## Changes
- Changed Avg Buy Price display to use 'full' number format (e.g. `150,432` instead of `150 K`)
- Changed Cost Basis Removed display to use 'full' number format for clarity
- Issue #127