### PR TITLE
fix(netlify): use correct scheduled function syntax

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,10 +12,8 @@
      to = "/index.html"
      status = 200
 
-   [[scheduled-functions]]
-     function = "osrs-news-cache"
-     schedule = "*/1 * * * *"
+   [functions."osrs-news-cache"]
+   schedule = "*/1 * * * *"
 
-   [[scheduled-functions]]
-     function = "jmod-comments-cache"
-     schedule = "*/1 * * * *"
+   [functions."jmod-comments-cache"]
+   schedule = "*/1 * * * *"


### PR DESCRIPTION
## Summary
Fixes the netlify.toml config so both scheduled functions (osrs-news-cache and jmod-comments-cache) are registered correctly. The `[[scheduled-functions]]` syntax was invalid and has been replaced with the correct `[functions."name"]` syntax.

## Changes
- Replace invalid `[[scheduled-functions]]` blocks with `[functions."osrs-news-cache"]` and `[functions."jmod-comments-cache"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)