### PR TITLE
fix(netlify): fix cache function response format and Reddit rate limiting

### DIFF
--- a/netlify/functions/jmod-comments-cache.js
+++ b/netlify/functions/jmod-comments-cache.js
@@ -66,9 +66,13 @@ exports.handler = async () => {
   try {
     const store = getJmodStore();
 
-    // Fetch all Jmod profiles in parallel
-    const results = await Promise.all(JMOD_USERNAMES.map(fetchUserComments));
-    const jmodComments = results.flat();
+    // Fetch Jmod profiles sequentially to avoid Reddit rate limiting
+    const jmodComments = [];
+    for (const username of JMOD_USERNAMES) {
+      const comments = await fetchUserComments(username);
+      jmodComments.push(...comments);
+      if (comments.length >= 0) await new Promise(r => setTimeout(r, 2000));
+    }
 
     // Read existing cache to merge
     let existing = [];

--- a/netlify/functions/osrs-news-cache.js
+++ b/netlify/functions/osrs-news-cache.js
@@ -72,15 +72,15 @@ exports.handler = async () => {
     const store = getNewsStore();
     await store.setJSON('cache', items);
 
-    return new Response(JSON.stringify({ success: true, count: items.length }), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    });
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ success: true, count: items.length }),
+    };
   } catch (error) {
-    return new Response(JSON.stringify({ error: error.message }), {
-      status: 502,
-      headers: { 'Content-Type': 'application/json' },
-    });
+    return {
+      statusCode: 502,
+      body: JSON.stringify({ error: error.message }),
+    };
   }
 };
 


### PR DESCRIPTION
## Summary
Fixes two issues with the Netlify cache functions that were causing 502 errors and empty Jmod comments.

## Changes
- Fix `osrs-news-cache.js` mixing `exports.handler` with `new Response()` by using `{ statusCode, body }` consistently
- Change `jmod-comments-cache.js` to fetch Reddit profiles sequentially with a 2s delay instead of all in parallel, to avoid Reddit rate limiting

🤖 Generated with [Claude Code](https://claude.com/claude-code)