### PR TITLE
fix(notifications): prevent notification flood on new/switched accounts

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -264,7 +264,7 @@ export default function MainApp({ session, onLogout }) {
     markAllAsRead,
     dismissNotification,
     clearAll: clearAllNotifications,
-  } = useNotifications(notificationPreferences);
+  } = useNotifications(notificationPreferences, userId);
 
   const { newsItems } = useOSRSNews();
   const { jmodComments } = useJmodComments();
@@ -278,27 +278,27 @@ export default function MainApp({ session, onLogout }) {
   });
 
   // Track which timer notifications have already fired to avoid duplicates
-  const firedTimerNotifs = useRef(new Set(JSON.parse(localStorage.getItem('osrs_fired_limit_timers') || '[]')));
+  const firedTimerNotifs = useRef(new Set(JSON.parse(localStorage.getItem(`osrs_fired_limit_timers_${userId}`) || '[]')));
   const firedAltTimerNotif = useRef(false);
-  const firedMilestoneNotifs = useRef(new Set(JSON.parse(localStorage.getItem('osrs_fired_milestones') || '[]')));
-  const seenNewsGuids = useRef(new Set(JSON.parse(localStorage.getItem('osrs_seen_news') || '[]')));
-  const seenJmodIds = useRef(new Set(JSON.parse(localStorage.getItem('osrs_seen_jmod') || '[]')));
+  const firedMilestoneNotifs = useRef(new Set(JSON.parse(localStorage.getItem(`osrs_fired_milestones_${userId}`) || '[]')));
+  const seenNewsGuids = useRef(new Set(JSON.parse(localStorage.getItem(`osrs_seen_news_${userId}`) || '[]')));
+  const seenJmodIds = useRef(new Set(JSON.parse(localStorage.getItem(`osrs_seen_jmod_${userId}`) || '[]')));
   const timerNotifsInitialized = useRef(false);
   const altTimerNotifInitialized = useRef(false);
   const milestoneNotifsInitialized = useRef(false);
-  const newsNotifsInitialized = useRef(localStorage.getItem('osrs_news_initialized') === 'true');
-  const jmodNotifsInitialized = useRef(localStorage.getItem('osrs_jmod_initialized') === 'true');
+  const newsNotifsInitialized = useRef(localStorage.getItem(`osrs_news_initialized_${userId}`) === 'true');
+  const jmodNotifsInitialized = useRef(localStorage.getItem(`osrs_jmod_initialized_${userId}`) === 'true');
   const timerTimeoutsRef = useRef(new Map());
 
   // Helper to persist firedTimerNotifs to localStorage
   const saveFiredTimers = useCallback(() => {
-    localStorage.setItem('osrs_fired_limit_timers', JSON.stringify(Array.from(firedTimerNotifs.current)));
-  }, []);
+    localStorage.setItem(`osrs_fired_limit_timers_${userId}`, JSON.stringify(Array.from(firedTimerNotifs.current)));
+  }, [userId]);
 
   // Save when app closes
   useEffect(() => {
     const handleBeforeUnload = () => {
-      localStorage.setItem('osrs_last_closed', Date.now().toString());
+      localStorage.setItem(`osrs_last_closed_${userId}`, Date.now().toString());
       saveFiredTimers();
     };
     window.addEventListener('beforeunload', handleBeforeUnload);
@@ -323,11 +323,11 @@ export default function MainApp({ session, onLogout }) {
       timerNotifsInitialized.current = true;
 
       // Check if app was closed > 4 hours
-      const lastClosedTime = localStorage.getItem('osrs_last_closed');
+      const lastClosedTime = localStorage.getItem(`osrs_last_closed_${userId}`);
       const closedTimeMs = lastClosedTime ? parseInt(lastClosedTime) : 0;
       const closedDuration = closedTimeMs ? now - closedTimeMs : 0;
       const fourHours = 4 * 60 * 60 * 1000;
-      const shouldCheckExpiredTimers = closedDuration === 0 || closedDuration <= fourHours;
+      const shouldCheckExpiredTimers = closedTimeMs > 0 && closedDuration <= fourHours;
 
       // Notify only for timers that expired WHILE offline, not old expired timers
       if (shouldCheckExpiredTimers) {
@@ -641,7 +641,7 @@ export default function MainApp({ session, onLogout }) {
         }
       });
       if (changed) {
-        localStorage.setItem('osrs_fired_milestones', JSON.stringify([...firedMilestoneNotifs.current]));
+        localStorage.setItem(`osrs_fired_milestones_${userId}`, JSON.stringify([...firedMilestoneNotifs.current]));
       }
     } else {
       let changed = false;
@@ -658,7 +658,7 @@ export default function MainApp({ session, onLogout }) {
         }
       });
       if (changed) {
-        localStorage.setItem('osrs_fired_milestones', JSON.stringify([...firedMilestoneNotifs.current]));
+        localStorage.setItem(`osrs_fired_milestones_${userId}`, JSON.stringify([...firedMilestoneNotifs.current]));
       }
     }
 
@@ -673,9 +673,9 @@ export default function MainApp({ session, onLogout }) {
 
     if (!newsNotifsInitialized.current) {
       newsNotifsInitialized.current = true;
-      localStorage.setItem('osrs_news_initialized', 'true');
+      localStorage.setItem(`osrs_news_initialized_${userId}`, 'true');
       newsItems.forEach(item => seenNewsGuids.current.add(item.guid));
-      localStorage.setItem('osrs_seen_news', JSON.stringify([...seenNewsGuids.current]));
+      localStorage.setItem(`osrs_seen_news_${userId}`, JSON.stringify([...seenNewsGuids.current]));
       return;
     }
 
@@ -689,9 +689,9 @@ export default function MainApp({ session, onLogout }) {
     });
 
     if (changed) {
-      localStorage.setItem('osrs_seen_news', JSON.stringify([...seenNewsGuids.current]));
+      localStorage.setItem(`osrs_seen_news_${userId}`, JSON.stringify([...seenNewsGuids.current]));
     }
-  }, [newsItems, addNotification]);
+  }, [newsItems, addNotification, userId]);
 
   // Jmod Reddit notification effect
   useEffect(() => {
@@ -699,9 +699,9 @@ export default function MainApp({ session, onLogout }) {
 
     if (!jmodNotifsInitialized.current) {
       jmodNotifsInitialized.current = true;
-      localStorage.setItem('osrs_jmod_initialized', 'true');
+      localStorage.setItem(`osrs_jmod_initialized_${userId}`, 'true');
       jmodComments.forEach(c => seenJmodIds.current.add(c.id));
-      localStorage.setItem('osrs_seen_jmod', JSON.stringify([...seenJmodIds.current]));
+      localStorage.setItem(`osrs_seen_jmod_${userId}`, JSON.stringify([...seenJmodIds.current]));
       return;
     }
 
@@ -717,9 +717,9 @@ export default function MainApp({ session, onLogout }) {
     });
 
     if (changed) {
-      localStorage.setItem('osrs_seen_jmod', JSON.stringify([...seenJmodIds.current]));
+      localStorage.setItem(`osrs_seen_jmod_${userId}`, JSON.stringify([...seenJmodIds.current]));
     }
-  }, [jmodComments, addNotification]);
+  }, [jmodComments, addNotification, userId]);
 
   useEffect(() => {
     const storageKey = `lastSeenVersion_${userId}`;

--- a/src/components/NotificationCenter.jsx
+++ b/src/components/NotificationCenter.jsx
@@ -167,22 +167,30 @@ export default function NotificationCenter({
               {notifications.length > 0 && (
                 <div className="notification-inbox-filters">
                   {[
-                    { key: 'all', label: 'All' },
+                    { key: 'all', label: 'All', count: notifications.length },
                     { key: 'limitTimer', label: 'Timers' },
                     { key: 'altAccountTimer', label: 'Alt Timer' },
                     { key: 'milestone', label: 'Milestones' },
                     { key: 'osrsNews', label: 'News' },
                     { key: 'jmodReddit', label: 'Jmod' },
                     { key: 'priceAlert', label: 'Alerts' },
-                  ].map(f => (
-                    <button
-                      key={f.key}
-                      className={`notification-inbox-filter-chip ${inboxFilter === f.key ? 'notification-inbox-filter-chip-active' : ''}`}
-                      onClick={() => setInboxFilter(f.key)}
-                    >
-                      {f.label}
-                    </button>
-                  ))}
+                  ].map(f => {
+                    const count = f.count ?? (
+                      f.key === 'priceAlert'
+                        ? notifications.filter(n => n.type === 'priceAlert' || n.type === 'priceAlertHigh' || n.type === 'priceAlertLow').length
+                        : notifications.filter(n => n.type === f.key).length
+                    );
+                    return (
+                      <button
+                        key={f.key}
+                        className={`notification-inbox-filter-chip ${inboxFilter === f.key ? 'notification-inbox-filter-chip-active' : ''}`}
+                        onClick={() => setInboxFilter(f.key)}
+                      >
+                        {f.label}
+                        {count > 0 && <span className="notification-filter-chip-count">{count}</span>}
+                      </button>
+                    );
+                  })}
                 </div>
               )}
               {filteredNotifications.length === 0 ? (

--- a/src/hooks/useNotifications.js
+++ b/src/hooks/useNotifications.js
@@ -174,9 +174,10 @@ function sendBrowserNotification(message) {
 
 // --- Hook ---
 
-export function useNotifications(preferences) {
+export function useNotifications(preferences, userId) {
+  const storageKey = `osrs_notifications_${userId}`;
   const [notifications, setNotifications] = useState(() => {
-    const saved = localStorage.getItem('osrs_notifications');
+    const saved = localStorage.getItem(storageKey);
     return saved ? JSON.parse(saved) : [];
   });
   const prefsRef = useRef(preferences);
@@ -184,8 +185,8 @@ export function useNotifications(preferences) {
 
   // Persist notifications to localStorage whenever they change
   useEffect(() => {
-    localStorage.setItem('osrs_notifications', JSON.stringify(notifications));
-  }, [notifications]);
+    localStorage.setItem(storageKey, JSON.stringify(notifications));
+  }, [notifications, storageKey]);
 
   const unreadCount = useMemo(
     () => notifications.filter(n => !n.read).length,

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -2815,6 +2815,13 @@
   border-color: rgba(96, 165, 250, 0.3);
 }
 
+.notification-filter-chip-count {
+  margin-left: 0.25rem;
+  font-size: 0.6rem;
+  font-weight: 600;
+  opacity: 0.7;
+}
+
 /* News Sub-filter Bar */
 .notification-news-filter {
   display: flex;


### PR DESCRIPTION
## Summary
- Scope all notification localStorage keys by `userId` to isolate state between accounts — prevents stale seen-IDs from a previous account causing 50+ jmod/news notifications on login
- Fix timer init bug where missing `osrs_last_closed` (first session) caused all expired timers to fire
- Add notification counts to inbox filter chips

Closes #133

## Test plan
- [ ] Create a new account on a browser with a previous account — verify 0 jmod/news notification flood
- [ ] Switch between two accounts — verify independent notification state
- [ ] Verify filter chips show correct counts per notification type
- [ ] Verify timer notifications only fire for timers that expired within 4h of last close

🤖 Generated with [Claude Code](https://claude.com/claude-code)