### PR TITLE
feat(search): add global search bar with Ctrl+K command palette

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -50,6 +50,7 @@ import PriceAlertModal from './components/modals/PriceAlertModal';
 import { CURRENT_VERSION } from './data/changelog';
 import { usePriceAlerts } from './hooks/usePriceAlerts';
 import { usePriceAlertChecker } from './hooks/usePriceAlertChecker';
+import GlobalSearch from './components/GlobalSearch';
 
 import {
   STORAGE_KEY,
@@ -134,7 +135,13 @@ export default function MainApp({ session, onLogout }) {
     setCurrentPage(page);
     let url = PAGE_PATHS[page] || '/';
     if (options.query) {
-      url += '?' + new URLSearchParams(options.query).toString();
+      const params = new URLSearchParams(options.query);
+      url += '?' + params.toString();
+      if (page === 'graphs' && params.has('item')) {
+        setGraphItemId(params.get('item'));
+      }
+    } else if (page === 'graphs') {
+      setGraphItemId(null);
     }
     window.history.pushState({ page }, '', url);
   }, [refetch, fetchCategories, refetchGPStats, refetchProfitHistory]);
@@ -1425,8 +1432,16 @@ export default function MainApp({ session, onLogout }) {
             </a>
           </div>
 
-          {/* Right - Notifications + User dropdown */}
+          {/* Right - Search + Notifications + User dropdown */}
           <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <GlobalSearch
+            stocks={stocks}
+            categories={categories}
+            transactions={transactions}
+            geMapping={geMapping}
+            geIconMap={geIconMap}
+            navigateToPage={navigateToPage}
+          />
           <NotificationCenter
             notifications={notifications}
             unreadCount={unreadCount}

--- a/src/components/GlobalSearch.jsx
+++ b/src/components/GlobalSearch.jsx
@@ -1,0 +1,312 @@
+import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import { Search, Package, FolderOpen, ArrowLeftRight, BarChart3, X } from 'lucide-react';
+
+export default function GlobalSearch({
+  stocks = [],
+  categories = [],
+  transactions = [],
+  geMapping = [],
+  geIconMap = {},
+  navigateToPage
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const modalRef = useRef(null);
+  const inputRef = useRef(null);
+
+  // Ctrl+K / Cmd+K to open
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
+        e.preventDefault();
+        setIsOpen(prev => !prev);
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  // Focus input when opened
+  useEffect(() => {
+    if (isOpen) {
+      setQuery('');
+      setSelectedIndex(0);
+      setTimeout(() => inputRef.current?.focus(), 0);
+    }
+  }, [isOpen]);
+
+  // Click outside to close
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClick = (e) => {
+      if (modalRef.current && !modalRef.current.contains(e.target)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [isOpen]);
+
+  // Build search results
+  const results = useMemo(() => {
+    if (!query.trim()) return [];
+    const q = query.toLowerCase();
+
+    const matchedStocks = stocks
+      .filter(s => s.name.toLowerCase().includes(q))
+      .slice(0, 5)
+      .map(s => {
+        const parts = [s.category || 'Uncategorized'];
+        parts.push(`${s.shares ? formatGP(s.shares) : '0'} held`);
+        if (s.totalCost) parts.push(`${formatGP(s.totalCost)} invested`);
+        return {
+          type: 'stock',
+          id: `stock-${s.id}`,
+          name: s.name,
+          detail: parts.join(' · '),
+          data: s
+        };
+      });
+
+    const matchedCategories = categories
+      .filter(c => c.name.toLowerCase().includes(q))
+      .slice(0, 5)
+      .map(c => {
+        const count = stocks.filter(s => s.category === c.name).length;
+        return {
+          type: 'category',
+          id: `cat-${c.id}`,
+          name: c.name,
+          detail: `${count} item${count !== 1 ? 's' : ''}`,
+          data: c
+        };
+      });
+
+    const matchedTransactions = transactions
+      .filter(t => t.stockName.toLowerCase().includes(q))
+      .slice(0, 5)
+      .map(t => {
+        const date = new Date(t.date).toLocaleDateString('en-GB', {
+          day: 'numeric', month: 'short'
+        });
+        const parts = [date, `${formatGP(t.shares)} qty`, `${formatGP(t.price)} ea`, `${formatGP(t.total)} total`];
+        if (t.profit != null && t.type === 'sell') parts.push(`${t.profit >= 0 ? '+' : ''}${formatGP(t.profit)} profit`);
+        return {
+          type: 'transaction',
+          id: `tx-${t.id}`,
+          name: t.stockName,
+          detail: parts.join(' · '),
+          data: t
+        };
+      });
+
+    const matchedItems = (geMapping || [])
+      .filter(item => item.name.toLowerCase().includes(q))
+      .slice(0, 5)
+      .map(item => ({
+        type: 'ge-item',
+        id: `ge-${item.id}`,
+        name: item.name,
+        detail: 'View price chart',
+        data: item
+      }));
+
+    return [
+      ...matchedStocks,
+      ...matchedCategories,
+      ...matchedTransactions,
+      ...matchedItems
+    ];
+  }, [query, stocks, categories, transactions, geMapping]);
+
+  // Get section boundaries for display
+  const sections = useMemo(() => {
+    const groups = [];
+    const types = [
+      { key: 'stock', label: 'Stocks', icon: Package },
+      { key: 'category', label: 'Categories', icon: FolderOpen },
+      { key: 'transaction', label: 'Transactions', icon: ArrowLeftRight },
+      { key: 'ge-item', label: 'GE Items', icon: BarChart3 }
+    ];
+    for (const t of types) {
+      const items = results.filter(r => r.type === t.key);
+      if (items.length > 0) {
+        groups.push({ ...t, items });
+      }
+    }
+    return groups;
+  }, [results]);
+
+  // Reset selection when results change
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [results]);
+
+  const handleSelect = useCallback((item) => {
+    setIsOpen(false);
+    switch (item.type) {
+      case 'stock': {
+        const category = item.data.category || 'Uncategorized';
+        navigateToPage('trade');
+        setTimeout(() => {
+          const el = document.querySelector(`[data-category="${category}"]`);
+          if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }, 100);
+        break;
+      }
+      case 'category': {
+        navigateToPage('trade');
+        setTimeout(() => {
+          const el = document.querySelector(`[data-category="${item.data.name}"]`);
+          if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }, 100);
+        break;
+      }
+      case 'transaction': {
+        navigateToPage('history', { query: { search: item.data.stockName } });
+        break;
+      }
+      case 'ge-item': {
+        navigateToPage('graphs', { query: { item: item.data.id } });
+        break;
+      }
+    }
+  }, [navigateToPage]);
+
+  // Keyboard navigation
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        setIsOpen(false);
+        return;
+      }
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setSelectedIndex(prev => Math.min(prev + 1, results.length - 1));
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setSelectedIndex(prev => Math.max(prev - 1, 0));
+      }
+      if (e.key === 'Enter' && results[selectedIndex]) {
+        e.preventDefault();
+        handleSelect(results[selectedIndex]);
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, results, selectedIndex, handleSelect]);
+
+  // Track flat index for keyboard nav
+  let flatIndex = -1;
+
+  const iconForType = (type) => {
+    switch (type) {
+      case 'stock': return Package;
+      case 'category': return FolderOpen;
+      case 'transaction': return ArrowLeftRight;
+      case 'ge-item': return BarChart3;
+      default: return Search;
+    }
+  };
+
+  return (
+    <>
+      <button
+        className="global-search-trigger"
+        onClick={() => setIsOpen(true)}
+        title="Search (Ctrl+K)"
+      >
+        <Search size={18} />
+        <span className="global-search-shortcut">Ctrl+K</span>
+      </button>
+
+      {isOpen && (
+        <div className="global-search-overlay">
+          <div className="global-search-modal" ref={modalRef}>
+            <div className="global-search-input-wrapper">
+              <Search size={20} className="global-search-input-icon" />
+              <input
+                ref={inputRef}
+                type="text"
+                className="global-search-input"
+                placeholder="Search items, categories, transactions..."
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+              />
+              <button
+                className="global-search-close"
+                onClick={() => setIsOpen(false)}
+              >
+                <X size={16} />
+              </button>
+            </div>
+
+            <div className="global-search-results">
+              {query.trim() && results.length === 0 && (
+                <div className="global-search-empty">
+                  No results for "{query}"
+                </div>
+              )}
+
+              {!query.trim() && (
+                <div className="global-search-empty">
+                  Start typing to search across your portfolio
+                </div>
+              )}
+
+              {sections.map(section => {
+                const SectionIcon = section.icon;
+                return (
+                  <div key={section.key} className={`global-search-section global-search-section-${section.key}`}>
+                    <div className="global-search-section-header">
+                      <SectionIcon size={14} />
+                      <span>{section.label}</span>
+                    </div>
+                    {section.items.map(item => {
+                      flatIndex++;
+                      const currentIndex = flatIndex;
+                      const isSelected = currentIndex === selectedIndex;
+                      const ItemIcon = iconForType(item.type);
+                      return (
+                        <button
+                          key={item.id}
+                          className={`global-search-item ${isSelected ? 'global-search-item-selected' : ''}`}
+                          onClick={() => handleSelect(item)}
+                          onMouseEnter={() => setSelectedIndex(currentIndex)}
+                        >
+                          <ItemIcon size={16} className={`global-search-item-icon global-search-icon-${item.type}`} />
+                          <div className="global-search-item-content">
+                            <span className="global-search-item-name">{item.name}</span>
+                            <span className="global-search-item-detail">{item.detail}</span>
+                          </div>
+                          {item.type === 'transaction' && (
+                            <span className={`global-search-tx-badge global-search-tx-${item.data.type}`}>
+                              {item.data.type.toUpperCase()}
+                            </span>
+                          )}
+                        </button>
+                      );
+                    })}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+function formatGP(value) {
+  if (value == null) return '0';
+  const abs = Math.abs(value);
+  if (abs >= 1_000_000_000) return (value / 1_000_000_000).toFixed(1) + 'B';
+  if (abs >= 1_000_000) return (value / 1_000_000).toFixed(1) + 'M';
+  if (abs >= 1_000) return (value / 1_000).toFixed(1) + 'K';
+  return value.toLocaleString();
+}

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -3595,3 +3595,237 @@
 .graph-alert-btn-active:hover {
   background: rgb(71, 85, 105);
 }
+
+/* ── Global Search ─────────────────────────────────── */
+
+.global-search-trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: rgb(30, 41, 59);
+  border: 1px solid rgb(51, 65, 85);
+  border-radius: 0.5rem;
+  color: rgb(148, 163, 184);
+  cursor: pointer;
+  font-size: 0.8125rem;
+  transition: border-color 0.2s, color 0.2s;
+}
+
+.global-search-trigger:hover {
+  border-color: rgb(168, 85, 247);
+  color: rgb(192, 132, 252);
+  background: rgba(168, 85, 247, 0.1);
+}
+
+.global-search-shortcut {
+  font-size: 0.6875rem;
+  padding: 0.125rem 0.375rem;
+  background: rgb(51, 65, 85);
+  border-radius: 0.25rem;
+  color: rgb(148, 163, 184);
+  font-family: monospace;
+}
+
+.global-search-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 15vh;
+  z-index: 100;
+}
+
+.global-search-modal {
+  width: 100%;
+  max-width: 560px;
+  background: rgb(30, 41, 59);
+  border: 1px solid rgb(71, 85, 105);
+  border-top: 2px solid rgb(168, 85, 247);
+  border-radius: 0.75rem;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5), 0 0 40px -8px rgba(168, 85, 247, 0.15);
+  overflow: hidden;
+}
+
+.global-search-input-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.875rem 1rem;
+  border-bottom: 1px solid rgb(51, 65, 85);
+}
+
+.global-search-input-icon {
+  color: rgb(96, 165, 250);
+  flex-shrink: 0;
+}
+
+.global-search-input {
+  flex: 1;
+  background: none;
+  border: none;
+  outline: none;
+  color: white;
+  font-size: 1rem;
+}
+
+.global-search-input::placeholder {
+  color: rgb(100, 116, 139);
+}
+
+.global-search-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  background: rgb(51, 65, 85);
+  border: none;
+  border-radius: 0.25rem;
+  color: rgb(148, 163, 184);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.15s;
+}
+
+.global-search-close:hover {
+  background: rgb(71, 85, 105);
+  color: white;
+}
+
+.global-search-results {
+  max-height: 400px;
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+
+.global-search-empty {
+  padding: 2rem 1rem;
+  text-align: center;
+  color: rgb(100, 116, 139);
+  font-size: 0.875rem;
+}
+
+.global-search-section {
+  margin-bottom: 0.25rem;
+}
+
+.global-search-section-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.global-search-section-stock .global-search-section-header {
+  color: rgb(168, 85, 247);
+}
+
+.global-search-section-category .global-search-section-header {
+  color: rgb(96, 165, 250);
+}
+
+.global-search-section-transaction .global-search-section-header {
+  color: rgb(74, 222, 128);
+}
+
+.global-search-section-ge-item .global-search-section-header {
+  color: rgb(251, 146, 60);
+}
+
+.global-search-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.625rem 0.75rem;
+  background: none;
+  border: none;
+  border-radius: 0.5rem;
+  color: white;
+  cursor: pointer;
+  text-align: left;
+  font-size: 0.875rem;
+  transition: background 0.1s;
+}
+
+.global-search-item:hover,
+.global-search-item-selected {
+  background: rgb(51, 65, 85);
+}
+
+.global-search-item-selected {
+  border-left: 2px solid rgb(168, 85, 247);
+}
+
+.global-search-item-icon {
+  flex-shrink: 0;
+}
+
+.global-search-icon-stock {
+  color: rgb(168, 85, 247);
+}
+
+.global-search-icon-category {
+  color: rgb(96, 165, 250);
+}
+
+.global-search-icon-transaction {
+  color: rgb(74, 222, 128);
+}
+
+.global-search-icon-ge-item {
+  color: rgb(251, 146, 60);
+}
+
+.global-search-item-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  min-width: 0;
+}
+
+.global-search-item-name {
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.global-search-item-detail {
+  font-size: 0.75rem;
+  color: rgb(148, 163, 184);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.global-search-tx-badge {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+  flex-shrink: 0;
+}
+
+.global-search-tx-buy {
+  background: rgba(34, 197, 94, 0.15);
+  color: rgb(74, 222, 128);
+}
+
+.global-search-tx-sell {
+  background: rgba(239, 68, 68, 0.15);
+  color: rgb(252, 165, 165);
+}
+
+.global-search-tx-remove {
+  background: rgba(148, 163, 184, 0.15);
+  color: rgb(148, 163, 184);
+}


### PR DESCRIPTION
## Summary
- Add global search command palette (Ctrl+K) that searches across stocks, categories, transactions, and GE items
- Grouped results with color-coded sections: purple (stocks), blue (categories), green (transactions), orange (GE items)
- Keyboard navigation with arrow keys, Enter to select, Escape to close
- Navigates to the correct page on result click: Trade (scroll to item/category), History (pre-filtered), Graphs (loads item chart)
- Fix `navigateToPage` to properly set `graphItemId` when navigating to Graphs with an item query param

Closes #78

## Test plan
- [ ] Click search icon in top bar — modal opens
- [ ] Press Ctrl+K — modal opens, Escape closes
- [ ] Type a stock name — appears in Stocks section with formatted GP values
- [ ] Click stock result — navigates to Trade page, scrolls to category
- [ ] Click category result — navigates to Trade page, scrolls to category
- [ ] Click transaction result — navigates to History page with search pre-filled
- [ ] Click GE item result — navigates to Graphs page with that item's chart loaded
- [ ] Arrow keys move selection, Enter activates selected result
- [ ] Click outside modal closes it
- [ ] Stocks with 0 shares show "0 held" instead of blank

🤖 Generated with [Claude Code](https://claude.com/claude-code)