### PR TITLE
feat(trade): make item names clickable to open price graph

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -1728,6 +1728,7 @@ export default function MainApp({ session, onLogout }) {
                 onInvestmentDateChange={handleInvestmentDateChange}
                 onPriceAlert={handleOpenPriceAlert}
                 priceAlerts={priceAlerts}
+                onViewGraph={(stock) => stock.itemId && navigateToPage('graphs', { query: { item: stock.itemId } })}
               />
             ))}
 

--- a/src/components/CategorySection.jsx
+++ b/src/components/CategorySection.jsx
@@ -45,6 +45,7 @@ export default function CategorySection({
   onInvestmentDateChange,
   onPriceAlert,
   priceAlerts = {},
+  onViewGraph,
 }) {
   const categoryStocks = stocks.filter(s => s.category === category);
 
@@ -261,6 +262,7 @@ export default function CategorySection({
             onInvestmentDateChange={onInvestmentDateChange}
             onPriceAlert={onPriceAlert}
             priceAlerts={priceAlerts}
+            onViewGraph={onViewGraph}
           />
         </>
       )}

--- a/src/components/StockTable.jsx
+++ b/src/components/StockTable.jsx
@@ -53,6 +53,7 @@ export default function StockTable({
   onInvestmentDateChange,
   onPriceAlert,
   priceAlerts = {},
+  onViewGraph,
 }) {
   const sortedStocks = sortStocks(stocks, sortConfig);
 
@@ -96,6 +97,7 @@ export default function StockTable({
               onInvestmentDateChange={onInvestmentDateChange}
               onPriceAlert={onPriceAlert}
               priceAlerts={priceAlerts}
+              onViewGraph={onViewGraph}
             />
           ))}
         </tbody>
@@ -179,6 +181,7 @@ function StockRow({
   onInvestmentDateChange,
   onPriceAlert,
   priceAlerts = {},
+  onViewGraph,
 }) {
   const avgBuy = calculateAvgBuyPrice(stock);
   const avgSell = calculateAvgSellPrice(stock);
@@ -215,7 +218,17 @@ function StockRow({
               title={membershipMap[stock.itemId] ? 'Members item' : 'Free-to-play item'}
             />
           )}
-          {stock.name}
+          {stock.itemId && onViewGraph ? (
+            <span
+              className="stock-name-link"
+              onClick={(e) => { e.stopPropagation(); onViewGraph(stock); }}
+              title="View price graph"
+            >
+              {stock.name}
+            </span>
+          ) : (
+            stock.name
+          )}
           {stock.itemId && onPriceAlert && (
             <button
               className={`stock-name-bell ${priceAlerts[stock.itemId]?.isActive ? 'stock-name-bell-active' : ''}`}

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -3411,6 +3411,16 @@
   color: rgb(248, 113, 113);
 }
 
+/* ===== Clickable stock name → graph link ===== */
+
+.stock-name-link {
+  cursor: pointer;
+}
+
+.stock-name-link:hover {
+  text-decoration: underline;
+}
+
 /* ===== Alerts tab in NotificationCenter ===== */
 
 .notification-alerts-list {


### PR DESCRIPTION
## Summary
- Clicking an item name in the stock table navigates to the Graphs page with that item pre-selected
- Only items linked to a GE item ID are clickable; others remain plain text
- Hover shows underline to indicate interactivity

Closes #139

## Test plan
- [ ] Click an item name in the stock table and verify it opens the Graphs page with the correct item loaded
- [ ] Verify items without a GE item ID are not clickable
- [ ] Confirm no visual changes to the table layout or colors (only cursor + underline on hover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)