### PR TITLE
fix(transactions): restore profit and margin in history page

### DIFF
--- a/src/hooks/useTransactions.js
+++ b/src/hooks/useTransactions.js
@@ -45,7 +45,7 @@ export function useTransactions(userId) {
     const to = from + size - 1;
 
     let query = supabase
-      .from('transactions')
+      .from('transactions_view')
       .select('*', { count: 'exact' })
       .eq('user_id', userId)
       .range(from, to);


### PR DESCRIPTION
## Summary
- Switch `useTransactions` query back from raw `transactions` table to `transactions_view`
- The view computes `profit`, `margin`, and `category` via JOINs to `stocks` and `profit_history`
- A previous commit switched to the raw table thinking the view filtered out `remove` transactions, but the view has no type filter -- the remove transactions simply didn't exist yet
- A merge conflict later re-introduced the raw table query despite a revert

## Test plan
- [ ] Navigate to History page
- [ ] Verify sell transactions display profit and margin values instead of dashes
- [ ] Verify profit/margin filters and sorting work

🤖 Generated with [Claude Code](https://claude.com/claude-code)