### PR TITLE
chore: remove export/backup and add JagexRach to jmod tracker

### DIFF
--- a/netlify/functions/jmod-comments-cache.js
+++ b/netlify/functions/jmod-comments-cache.js
@@ -6,7 +6,7 @@ const JMOD_USERNAMES = [
   'JagexAsh', 'JagexLight', 'JagexSarnie', 'JagexGoblin',
   'JagexAyiza', 'JagexFlippy', 'Mod_Kieren', 'JagexHusky',
   'JagexSween', 'Jagex_Wolf', 'JagexTyran', 'JagexRoq',
-  'JagexBlossom', 'JagexNin', 'JagexRice',
+  'JagexBlossom', 'JagexNin', 'JagexRice', 'JagexRach',
 ];
 
 const HEADERS = {

--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -1080,24 +1080,6 @@ export default function MainApp({ session, onLogout }) {
     setShowNotesModal(false);
   };
 
-  // xport operations
-  const exportData = () => {
-    const exportObj = {
-      stocks,
-      categories,
-      dumpProfit,
-      referralProfit,
-      bondsProfit,
-      stockNotes,
-      transactions
-    };
-    const blob = new Blob([JSON.stringify(exportObj, null, 2)], { type: 'application/json' });
-    const link = document.createElement('a');
-    link.href = URL.createObjectURL(blob);
-    link.download = `stock-backup-${new Date().toISOString().split('T')[0]}.json`;
-    link.click();
-  };
-
   // Drag and drop operations
   const handleCategoryDragStart = (e, category) => {
 
@@ -1482,12 +1464,6 @@ export default function MainApp({ session, onLogout }) {
                   onClick={() => { setShowSettingsModal(true); setUserMenuOpen(false); }}
                 >
                   ⚙️ Settings
-                </button>
-                <button
-                  className="user-dropdown-item"
-                  onClick={() => { exportData(); setUserMenuOpen(false); }}
-                >
-                  📥 Export Data
                 </button>
                 <a
                   href="https://buymeacoffee.com/osrsprofittracker"
@@ -2034,6 +2010,7 @@ export default function MainApp({ session, onLogout }) {
             PRESET_GOALS={PRESET_GOALS}
           />
         </ModalContainer>
+
 
       </div>
       <Footer />

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { Plus, Download, Upload, FolderPlus, LogOut } from 'lucide-react';
+import { Plus, FolderPlus, LogOut } from 'lucide-react';
 
 export default function Header({
-    onExport,
     onAddCategory,
     onAddStock,
     onOpenSettings,
@@ -54,9 +53,6 @@ export default function Header({
                     </button>
                     <button className="btn btn-secondary" onClick={onOpenSettings}>
                         ⚙️ Settings
-                    </button>
-                    <button className="btn btn-success" onClick={onExport}>
-                        Export
                     </button>
                     {onLogout && (
                         <button


### PR DESCRIPTION
## Summary
- Remove the `exportData()` backup function, the "Export Data" dropdown menu item, and the Header export button/prop
- Add `JagexRach` to the Jmod Reddit username list in the comment cache function

## Test plan
- [ ] Verify user dropdown no longer shows Export Data option
- [ ] Verify Header component renders without export button
- [ ] Verify Jmod comments cache picks up JagexRach comments after next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)