### PR TITLE
feat(notifications): add global volume slider for notification sounds

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -37,7 +37,9 @@
       "Skill(pr)",
       "Bash(git:*)",
       "Bash(gh release:*)",
-      "Bash(netlify:*)"
+      "Bash(netlify:*)",
+      "Bash(find /c/Users/daan_/source/repos/OSRS-Bulk -name .env* -o -name *.env)",
+      "Bash(find /c/Users/daan_/source/repos/OSRS-Bulk -name *.sql -o -name *schema* -o -name *migration*)"
     ]
   }
 }

--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -112,7 +112,7 @@ export default function MainApp({ session, onLogout }) {
 
   // Destructure settings
   const { numberFormat, visibleColumns, visibleProfits, altAccountTimer, showCategoryStats,
-          showUnrealisedProfitStats, showCategoryUnrealisedProfit } = settings;
+          showUnrealisedProfitStats, showCategoryUnrealisedProfit, notificationVolume } = settings;
   // Local UI state
   const [collapsedCategories, setCollapsedCategories] = useState(() => {
     // Load collapsed state from localStorage on initial render
@@ -271,7 +271,7 @@ export default function MainApp({ session, onLogout }) {
     markAllAsRead,
     dismissNotification,
     clearAll: clearAllNotifications,
-  } = useNotifications(notificationPreferences, userId);
+  } = useNotifications(notificationPreferences, userId, notificationVolume);
 
   const { newsItems } = useOSRSNews();
   const { jmodComments } = useJmodComments();
@@ -1902,6 +1902,8 @@ export default function MainApp({ session, onLogout }) {
             onShowCategoryUnrealisedProfitChange={(v) => updateSettings({ showCategoryUnrealisedProfit: v })}
             notificationPreferences={notificationPreferences}
             onNotificationTypeChange={updateNotificationPreference}
+            notificationVolume={notificationVolume}
+            onNotificationVolumeChange={(v) => updateSettings({ notificationVolume: v })}
             onCancel={() => setShowSettingsModal(false)}
             onChangePassword={() => {
               setShowSettingsModal(false);

--- a/src/components/modals/SettingsModal.jsx
+++ b/src/components/modals/SettingsModal.jsx
@@ -286,7 +286,7 @@ function GeneralTab({
   );
 }
 
-function SoundPicker({ soundChoice, onChange }) {
+function SoundPicker({ soundChoice, onChange, volume = 0.7 }) {
   return (
     <div className="sound-picker">
       <div className="sound-picker-grid">
@@ -297,7 +297,7 @@ function SoundPicker({ soundChoice, onChange }) {
             className={`sound-picker-option ${soundChoice === preset.id ? 'sound-picker-option-active' : ''}`}
             onClick={() => {
               onChange({ soundChoice: preset.id });
-              playPresetPreview(preset.id);
+              playPresetPreview(preset.id, volume);
             }}
           >
             <span className="sound-picker-option-label">{preset.label}</span>
@@ -306,7 +306,7 @@ function SoundPicker({ soundChoice, onChange }) {
               className="sound-picker-play-btn"
               onClick={(e) => {
                 e.stopPropagation();
-                playPresetPreview(preset.id);
+                playPresetPreview(preset.id, volume);
               }}
               title={`Preview ${preset.label}`}
             >
@@ -319,7 +319,7 @@ function SoundPicker({ soundChoice, onChange }) {
   );
 }
 
-function NotificationTypeSettings({ typePrefs, onChange }) {
+function NotificationTypeSettings({ typePrefs, onChange, volume = 0.7 }) {
   const handleBrowserPushChange = async (enabled) => {
     if (enabled && Notification.permission === 'default') {
       const permission = await Notification.requestPermission();
@@ -374,6 +374,7 @@ function NotificationTypeSettings({ typePrefs, onChange }) {
             <SoundPicker
               soundChoice={typePrefs.soundChoice}
               onChange={({ soundChoice }) => onChange({ ...typePrefs, soundChoice })}
+              volume={volume}
             />
           )}
         </>
@@ -391,8 +392,9 @@ const NOTIFICATION_TYPES = [
   { key: 'priceAlert', label: 'Price Alerts', description: 'Get notified when a tracked item crosses your price threshold' },
 ];
 
-function NotificationsTab({ notificationPreferences, onNotificationTypeChange }) {
+function NotificationsTab({ notificationPreferences, onNotificationTypeChange, notificationVolume, onNotificationVolumeChange }) {
   const [selectedKey, setSelectedKey] = useState(NOTIFICATION_TYPES[0].key);
+  const volume = (notificationVolume ?? 70) / 100;
 
   const handleTypeChange = (key, updatedTypePrefs) => {
     onNotificationTypeChange(key, updatedTypePrefs);
@@ -402,6 +404,23 @@ function NotificationsTab({ notificationPreferences, onNotificationTypeChange })
   const selectedPrefs = notificationPreferences[selectedKey];
 
   return (
+    <>
+      <div className="notif-volume-section">
+        <div className="notif-volume-row">
+          <span className="notif-volume-label">Volume</span>
+          <input
+            type="range"
+            className="notif-volume-slider"
+            min="0"
+            max="100"
+            value={notificationVolume ?? 70}
+            onChange={(e) => onNotificationVolumeChange(Number(e.target.value))}
+            onMouseUp={() => playPresetPreview('chime', (notificationVolume ?? 70) / 100)}
+            onTouchEnd={() => playPresetPreview('chime', (notificationVolume ?? 70) / 100)}
+          />
+          <span className="notif-volume-value">{notificationVolume ?? 70}%</span>
+        </div>
+      </div>
     <div className="notif-settings-pane">
       <div className="notif-sidebar">
         {NOTIFICATION_TYPES.map((type) => {
@@ -426,9 +445,11 @@ function NotificationsTab({ notificationPreferences, onNotificationTypeChange })
         <NotificationTypeSettings
           typePrefs={selectedPrefs}
           onChange={(updated) => handleTypeChange(selectedKey, updated)}
+          volume={volume}
         />
       </div>
     </div>
+    </>
   );
 }
 
@@ -447,6 +468,8 @@ export default function SettingsModal({
   onShowCategoryUnrealisedProfitChange,
   notificationPreferences,
   onNotificationTypeChange,
+  notificationVolume,
+  onNotificationVolumeChange,
   onCancel,
   onChangePassword
 }) {
@@ -495,6 +518,8 @@ export default function SettingsModal({
           <NotificationsTab
             notificationPreferences={notificationPreferences}
             onNotificationTypeChange={onNotificationTypeChange}
+            notificationVolume={notificationVolume}
+            onNotificationVolumeChange={onNotificationVolumeChange}
           />
         )}
       </div>

--- a/src/hooks/useNotifications.js
+++ b/src/hooks/useNotifications.js
@@ -137,7 +137,7 @@ function getPresetUri(id) {
 
 // --- Playback ---
 
-export function playNotificationSound(soundChoice, customSoundUri) {
+export function playNotificationSound(soundChoice, customSoundUri, volume = 0.7) {
   try {
     let uri;
     if (soundChoice === 'custom' && customSoundUri) {
@@ -147,7 +147,7 @@ export function playNotificationSound(soundChoice, customSoundUri) {
     }
     if (!uri) return;
     const audio = new Audio(uri);
-    audio.volume = 0.7;
+    audio.volume = Math.max(0, Math.min(1, volume));
     return audio.play().catch((err) => {
       console.warn('Notification sound blocked:', err);
     });
@@ -156,11 +156,11 @@ export function playNotificationSound(soundChoice, customSoundUri) {
   }
 }
 
-export function playPresetPreview(presetId) {
+export function playPresetPreview(presetId, volume = 0.7) {
   const uri = getPresetUri(presetId);
   if (!uri) return;
   const audio = new Audio(uri);
-  audio.volume = 0.7;
+  audio.volume = Math.max(0, Math.min(1, volume));
   audio.play().catch(() => {});
 }
 
@@ -174,7 +174,7 @@ function sendBrowserNotification(message) {
 
 // --- Hook ---
 
-export function useNotifications(preferences, userId) {
+export function useNotifications(preferences, userId, notificationVolume = 70) {
   const storageKey = `osrs_notifications_${userId}`;
   const [notifications, setNotifications] = useState(() => {
     const saved = localStorage.getItem(storageKey);
@@ -182,6 +182,8 @@ export function useNotifications(preferences, userId) {
   });
   const prefsRef = useRef(preferences);
   prefsRef.current = preferences;
+  const volumeRef = useRef(notificationVolume);
+  volumeRef.current = notificationVolume;
 
   // Persist notifications to localStorage whenever they change
   useEffect(() => {
@@ -215,7 +217,7 @@ export function useNotifications(preferences, userId) {
     setNotifications(prev => [notification, ...prev]);
 
     if (typePrefs.sound) {
-      playNotificationSound(typePrefs.soundChoice, typePrefs.customSoundUri);
+      playNotificationSound(typePrefs.soundChoice, typePrefs.customSoundUri, volumeRef.current / 100);
     }
 
     if (typePrefs.browserPush) {

--- a/src/hooks/useSettings.js
+++ b/src/hooks/useSettings.js
@@ -29,6 +29,7 @@ export function useSettings(userId) {
     showCategoryStats: false,
     showUnrealisedProfitStats: false,
     showCategoryUnrealisedProfit: true,
+    notificationVolume: 70,
   });
   const [loading, setLoading] = useState(true);
 
@@ -72,6 +73,7 @@ export function useSettings(userId) {
         showCategoryStats: data.show_category_stats || false,
         showUnrealisedProfitStats: data.show_unrealised_profit_stats ?? false,
         showCategoryUnrealisedProfit: data.show_category_unrealised_profit ?? true,
+        notificationVolume: data.notification_volume ?? 70,
       });
     } else {
       const { error: insertError } = await supabase
@@ -82,7 +84,8 @@ export function useSettings(userId) {
           visible_columns: DEFAULT_VISIBLE_COLUMNS,
           visible_profits: DEFAULT_VISIBLE_PROFITS,
           alt_account_timer: null,
-          show_category_stats: false
+          show_category_stats: false,
+          notification_volume: 70
         }], { onConflict: 'user_id', ignoreDuplicates: true });
 
       if (insertError && insertError.code !== '23505') {
@@ -107,6 +110,7 @@ export function useSettings(userId) {
       show_category_stats: newSettings.showCategoryStats,
       show_unrealised_profit_stats: newSettings.showUnrealisedProfitStats,
       show_category_unrealised_profit: newSettings.showCategoryUnrealisedProfit,
+      notification_volume: newSettings.notificationVolume,
     };
 
     const { error } = await supabase

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -3119,6 +3119,64 @@
   display: none;
 }
 
+/* Notification volume slider */
+.notif-volume-section {
+  margin-bottom: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: rgb(30, 41, 59);
+  border: 1px solid rgb(71, 85, 105);
+  border-radius: 0.5rem;
+}
+
+.notif-volume-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.notif-volume-label {
+  color: rgb(209, 213, 219);
+  font-size: 0.875rem;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.notif-volume-slider {
+  flex: 1;
+  height: 6px;
+  appearance: none;
+  background: rgb(51, 65, 85);
+  border-radius: 3px;
+  outline: none;
+  cursor: pointer;
+}
+
+.notif-volume-slider::-webkit-slider-thumb {
+  appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: rgb(96, 165, 250);
+  cursor: pointer;
+  border: none;
+}
+
+.notif-volume-slider::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: rgb(96, 165, 250);
+  cursor: pointer;
+  border: none;
+}
+
+.notif-volume-value {
+  color: rgb(148, 163, 184);
+  font-size: 0.8125rem;
+  min-width: 2.5rem;
+  text-align: right;
+}
+
 /* Two-pane notification settings */
 .notif-settings-pane {
   display: flex;


### PR DESCRIPTION
## Summary
- Add a volume slider (0-100%) to the Notifications tab in Settings that controls all notification sound playback
- Volume is stored as `notification_volume` in the `user_settings` table (requires DB migration)
- Preset sound previews and actual notification sounds both respect the volume setting

## DB Migration Required
```sql
ALTER TABLE user_settings ADD COLUMN IF NOT EXISTS notification_volume integer NOT NULL DEFAULT 70;
```

## Test plan
- [ ] Run the DB migration in Supabase SQL editor
- [ ] Open Settings > Notifications tab, verify volume slider appears above the notification type list
- [ ] Drag slider and release, verify preview chime plays at the set volume
- [ ] Select a notification type with sound enabled, click preset preview buttons, verify they play at set volume
- [ ] Trigger an actual notification (e.g. limit timer), verify sound plays at set volume
- [ ] Refresh page, verify volume setting persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)