### PR TITLE
fix(ui): remove nav item width constraints causing text clipping

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1208,9 +1208,6 @@
   cursor: pointer;
   transition: color 0.15s, background 0.15s;
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 184px;
 }
 
 .quick-nav-item:hover {


### PR DESCRIPTION
## Summary
- Removes `max-width: 184px`, `overflow: hidden`, and `text-overflow: ellipsis` from `.quick-nav-item` so category names display fully instead of being clipped on smaller windows

Closes #148

## Test plan
- [ ] Hover the left edge tab to open the CategoryQuickNav panel
- [ ] Resize the browser window to various widths above 768px
- [ ] Verify all category names (especially longer ones like "Allotment Seeds", "Common Ranged") display without truncation
- [ ] Confirm the panel still hides at 768px and below

🤖 Generated with [Claude Code](https://claude.com/claude-code)