### PR TITLE
feat(search): auto-filter history page when clicking transaction in search

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -63,6 +63,13 @@ import {
 
 const PAGE_PATHS = { home: '/', trade: '/trade', history: '/history', graphs: '/graphs' };
 
+const HISTORY_EMPTY_FILTERS = {
+  type: 'all', mode: 'all', stockName: '', category: '',
+  dateFrom: '', dateTo: '', gpMin: '', gpMax: '',
+  priceMin: '', priceMax: '', profitMin: '', profitMax: '',
+  qtyMin: '', qtyMax: '', marginMin: '', marginMax: ''
+};
+
 function getPageFromURL() {
   const path = window.location.pathname;
   if (path === '/trade') return 'trade';
@@ -140,11 +147,16 @@ export default function MainApp({ session, onLogout }) {
       if (page === 'graphs' && params.has('item')) {
         setGraphItemId(params.get('item'));
       }
+      if (page === 'history' && params.has('search')) {
+        applyFilters({ ...HISTORY_EMPTY_FILTERS, stockName: params.get('search') });
+      }
     } else if (page === 'graphs') {
       setGraphItemId(null);
+    } else if (page === 'history') {
+      applyFilters({ ...HISTORY_EMPTY_FILTERS });
     }
     window.history.pushState({ page }, '', url);
-  }, [refetch, fetchCategories, refetchGPStats, refetchProfitHistory]);
+  }, [refetch, fetchCategories, refetchGPStats, refetchProfitHistory, applyFilters]);
 
   // Replace initial history entry so back button works correctly
   useEffect(() => {
@@ -166,11 +178,19 @@ export default function MainApp({ session, onLogout }) {
         refetchProfitHistory();
       }
       setCurrentPage(page);
-      setGraphItemId(new URLSearchParams(window.location.search).get('item'));
+      const searchParams = new URLSearchParams(window.location.search);
+      setGraphItemId(searchParams.get('item'));
+      if (page === 'history') {
+        const searchName = searchParams.get('search');
+        applyFilters(searchName
+          ? { ...HISTORY_EMPTY_FILTERS, stockName: searchName }
+          : { ...HISTORY_EMPTY_FILTERS }
+        );
+      }
     };
     window.addEventListener('popstate', handlePopState);
     return () => window.removeEventListener('popstate', handlePopState);
-  }, [refetch, fetchCategories, refetchGPStats, refetchProfitHistory]);
+  }, [refetch, fetchCategories, refetchGPStats, refetchProfitHistory, applyFilters]);
   const [sortConfig, setSortConfig] = useState({ key: null, direction: 'asc' });
   const [highlightedRows, setHighlightedRows] = useState({});
   const [currentTime, setCurrentTime] = useState(Date.now());

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -39,6 +39,12 @@ export default function HistoryPage({
   const [appliedFilters, setAppliedFilters] = useState({ ...EMPTY_FILTERS, ...filters });
   const [showFilters, setShowFilters] = useState(false);
 
+  useEffect(() => {
+    setLocalFilters({ ...EMPTY_FILTERS, ...filters });
+    setAppliedFilters({ ...EMPTY_FILTERS, ...filters });
+    if (filters.stockName) setShowFilters(true);
+  }, [filters.stockName]);
+
   const [confirmUndo, setConfirmUndo] = useState(null); // holds transaction to undo
   const [undoWarning, setUndoWarning] = useState(null); // holds warning type
 


### PR DESCRIPTION
## Summary
Closes #150. When clicking a transaction in the global search results, the app now navigates to the History page and automatically applies a filter for that item — previously the navigation worked but the filter was never applied.

## Changes
- `MainApp.jsx`: calls `applyFilters` with the item's stock name when navigating to history via search (and resets filters when navigating to history without a search param); handles browser back/forward via `popstate` the same way
- `HistoryPage.jsx`: adds a `useEffect` that syncs local filter state and opens the filter panel when `filters.stockName` is set externally