### PR TITLE
feat(graphs): add notes from graph page

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -1559,6 +1559,9 @@ export default function MainApp({ session, onLogout }) {
             navigateToPage={navigateToPage}
             priceAlerts={priceAlerts}
             onPriceAlert={handleOpenPriceAlert}
+            stocks={stocks}
+            stockNotes={stockNotes}
+            onSaveNote={saveNote}
           />
         ) : (
           <>

--- a/src/pages/GraphsPage.jsx
+++ b/src/pages/GraphsPage.jsx
@@ -1,9 +1,11 @@
 import React, { useState, useMemo, useRef, useEffect } from 'react';
 import { createChart, LineSeries, HistogramSeries, CandlestickSeries } from 'lightweight-charts';
-import { Star, Clock, Search, ChevronDown, Bell, BellRing } from 'lucide-react';
+import { Star, Clock, Search, ChevronDown, Bell, BellRing, StickyNote } from 'lucide-react';
 import { useTimeseries } from '../hooks/useTimeseries';
 import { useGraphPreferences } from '../hooks/useGraphPreferences';
 import { calculateGETax } from '../utils/taxUtils';
+import ModalContainer from '../components/modals/ModalContainer';
+import NotesModal from '../components/modals/NotesModal';
 
 const TIMEFRAMES = [
   { label: '1D', timestep: '5m', filterDays: 1 },
@@ -14,12 +16,14 @@ const TIMEFRAMES = [
   { label: '1Y', timestep: '24h', filterDays: 365 },
 ];
 
-export default function GraphsPage({ mapping, prices, iconMap, mappingLoading, userId, initialItemId, navigateToPage, priceAlerts = {}, onPriceAlert }) {
+export default function GraphsPage({ mapping, prices, iconMap, mappingLoading, userId, initialItemId, navigateToPage, priceAlerts = {}, onPriceAlert, stocks = [], stockNotes = {}, onSaveNote }) {
   const [searchQuery, setSearchQuery] = useState('');
   const [showDropdown, setShowDropdown] = useState(false);
   const [selectedItem, setSelectedItem] = useState(null);
   const [timeframe, setTimeframe] = useState('1D');
   const [chartMode, setChartMode] = useState('line');
+  const [showNotesModal, setShowNotesModal] = useState(false);
+  const [notesStock, setNotesStock] = useState(null);
 
   const searchRef = useRef(null);
   const dropdownRef = useRef(null);
@@ -536,6 +540,23 @@ export default function GraphsPage({ mapping, prices, iconMap, mappingLoading, u
     };
   }, [selectedItem, currentPrice, rawData, tf]);
 
+  const matchingStocks = useMemo(() => {
+    if (!selectedItem) return [];
+    return stocks.filter(s => s.itemId === selectedItem.id);
+  }, [selectedItem, stocks]);
+
+  const handleOpenNotes = (stock) => {
+    setNotesStock(stock);
+    setShowNotesModal(true);
+  };
+
+  const handleSaveNote = async (noteText) => {
+    if (!onSaveNote || !notesStock) return;
+    await onSaveNote(notesStock.id, noteText);
+    setShowNotesModal(false);
+    setNotesStock(null);
+  };
+
   const formatPrice = (val) => {
     if (val == null) return '—';
     return val.toLocaleString();
@@ -700,6 +721,26 @@ export default function GraphsPage({ mapping, prices, iconMap, mappingLoading, u
                 {priceAlerts[selectedItem.id]?.isActive ? <BellRing size={14} /> : <Bell size={14} />}
                 {priceAlerts[selectedItem.id]?.isActive ? 'Edit Alert' : 'Set Alert'}
               </button>
+            )}
+            {matchingStocks.length === 1 && (
+              <button
+                className={`graph-alert-btn ${stockNotes[matchingStocks[0].id] ? 'graph-notes-btn-active' : ''}`}
+                onClick={() => handleOpenNotes(matchingStocks[0])}
+              >
+                <StickyNote size={14} />
+                {stockNotes[matchingStocks[0].id] ? 'Edit Note' : 'Add Note'}
+              </button>
+            )}
+            {matchingStocks.length > 1 && (
+              <div className="graph-notes-multi">
+                <button
+                  className={`graph-alert-btn ${matchingStocks.some(s => stockNotes[s.id]) ? 'graph-notes-btn-active' : ''}`}
+                  onClick={() => setShowNotesModal(true)}
+                >
+                  <StickyNote size={14} />
+                  Notes
+                </button>
+              </div>
             )}
           </div>
           <div className="graphs-info-stats">
@@ -883,6 +924,41 @@ export default function GraphsPage({ mapping, prices, iconMap, mappingLoading, u
         )}
       </div>
       <div className="graphs-volume-container" ref={volumeContainerRef}></div>
+
+      <ModalContainer isOpen={showNotesModal && notesStock != null}>
+        <NotesModal
+          stock={notesStock || {}}
+          notes={stockNotes[notesStock?.id] || ''}
+          onConfirm={handleSaveNote}
+          onCancel={() => { setShowNotesModal(false); setNotesStock(null); }}
+        />
+      </ModalContainer>
+
+      <ModalContainer isOpen={showNotesModal && notesStock == null && matchingStocks.length > 1}>
+        <div className="graph-notes-picker">
+          <h2 className="graph-notes-picker-title">Select Stock</h2>
+          <p className="graph-notes-picker-subtitle">This item is linked to multiple stocks. Which one?</p>
+          <div className="graph-notes-picker-list">
+            {matchingStocks.map(stock => (
+              <button
+                key={stock.id}
+                className="graph-notes-picker-item"
+                onClick={() => handleOpenNotes(stock)}
+              >
+                <span>{stock.category}</span>
+                {stock.isInvestment && <span className="graphs-note-investment-tag">Investment</span>}
+                {stockNotes[stock.id] && <span className="graph-notes-picker-has-note">Has note</span>}
+              </button>
+            ))}
+          </div>
+          <button
+            className="graph-notes-picker-cancel"
+            onClick={() => setShowNotesModal(false)}
+          >
+            Cancel
+          </button>
+        </div>
+      </ModalContainer>
     </div>
   );
 }

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -3667,6 +3667,90 @@
   background: rgb(71, 85, 105);
 }
 
+/* ── Graph Notes ──────────────────────────────────── */
+
+.graph-notes-btn-active {
+  border-color: rgb(168, 85, 247);
+  color: rgb(216, 180, 254);
+}
+
+.graphs-note-investment-tag {
+  font-size: 0.6875rem;
+  padding: 0.125rem 0.375rem;
+  background: rgb(88, 28, 135);
+  color: rgb(216, 180, 254);
+  border-radius: 0.25rem;
+}
+
+.graph-notes-picker {
+  background: rgb(30, 41, 59);
+  padding: 1.5rem;
+  border-radius: 0.75rem;
+  width: 20rem;
+  border: 1px solid rgb(51, 65, 85);
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+}
+
+.graph-notes-picker-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: white;
+  margin: 0 0 0.25rem;
+}
+
+.graph-notes-picker-subtitle {
+  font-size: 0.8125rem;
+  color: rgb(148, 163, 184);
+  margin: 0 0 1rem;
+}
+
+.graph-notes-picker-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.graph-notes-picker-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 0.75rem;
+  background: rgb(15, 23, 42);
+  border: 1px solid rgb(51, 65, 85);
+  border-radius: 0.5rem;
+  color: white;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: border-color 0.2s;
+}
+
+.graph-notes-picker-item:hover {
+  border-color: rgb(168, 85, 247);
+}
+
+.graph-notes-picker-has-note {
+  margin-left: auto;
+  font-size: 0.75rem;
+  color: rgb(168, 85, 247);
+}
+
+.graph-notes-picker-cancel {
+  width: 100%;
+  padding: 0.5rem;
+  background: rgb(51, 65, 85);
+  border: none;
+  border-radius: 0.375rem;
+  color: white;
+  font-size: 0.8125rem;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.graph-notes-picker-cancel:hover {
+  background: rgb(71, 85, 105);
+}
+
 /* ── Global Search ─────────────────────────────────── */
 
 .global-search-trigger {


### PR DESCRIPTION
## Summary
- Adds "Add Note" / "Edit Note" button to graph page header when the viewed item is linked to a stock in the portfolio
- Single matching stock: button opens NotesModal directly
- Multiple matching stocks (e.g. regular + investment): button opens a picker modal to select which stock before editing notes

Closes #146

## Test plan
- [ ] View an item on graph page that is linked to a single stock — verify "Add Note" button appears
- [ ] Add/edit a note and confirm it persists
- [ ] View an item linked to multiple stocks (e.g. one regular, one investment) — verify "Notes" button opens picker
- [ ] Select a stock from picker, add a note, verify correct stock is updated
- [ ] View an item not in portfolio — verify no notes button appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)