### PR TITLE
feat: bulk buy modal for multiple items at once

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -33,6 +33,7 @@ import CategorySection from './components/CategorySection';
 import ChangePasswordModal from './components/modals/ChangePasswordModal';
 import ModalContainer from './components/modals/ModalContainer';
 import BuyModal from './components/modals/BuyModal';
+import BulkBuyModal from './components/modals/BulkBuyModal';
 import SellModal from './components/modals/SellModal';
 import RemoveStockModal from './components/modals/RemoveStockModal';
 import AdjustModal from './components/modals/AdjustModal';
@@ -198,6 +199,7 @@ export default function MainApp({ session, onLogout }) {
 
   // Modal states
   const [showBuyModal, setShowBuyModal] = useState(false);
+  const [showBulkBuyModal, setShowBulkBuyModal] = useState(false);
   const [showSellModal, setShowSellModal] = useState(false);
   const [showRemoveModal, setShowRemoveModal] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -827,6 +829,64 @@ export default function MainApp({ session, onLogout }) {
       }
       highlightRow(selectedStock.id);
       setShowBuyModal(false);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleBulkBuy = async (items) => {
+    if (isSubmitting) return;
+    setIsSubmitting(true);
+
+    try {
+      for (const item of items) {
+        const { stock, shares, price, startTimer } = item;
+        const total = shares * price;
+        const newShares = stock.shares + shares;
+
+        let timerEndTime;
+        let newOnHold = stock.onHold;
+
+        if (startTimer) {
+          timerEndTime = Date.now() + (4 * 60 * 60 * 1000);
+          newOnHold = false;
+        } else {
+          timerEndTime = stock.timerEndTime;
+        }
+
+        const timerJustEnded = stock.timerEndTime && stock.timerEndTime <= Date.now();
+        if (timerJustEnded && newShares < stock.needed && stock.onHold) {
+          newOnHold = true;
+        } else if (newShares >= stock.needed) {
+          newOnHold = false;
+        }
+
+        await updateStock(stock.id, {
+          totalCost: stock.totalCost + total,
+          shares: newShares,
+          timerEndTime,
+        });
+
+        await addTransaction({
+          stockId: stock.id,
+          stockName: stock.name,
+          type: 'buy',
+          shares,
+          price,
+          total,
+          date: new Date().toISOString(),
+        });
+
+        if (startTimer) {
+          firedTimerNotifs.current.delete(stock.id);
+        }
+
+        highlightRow(stock.id);
+      }
+
+      saveFiredTimers();
+      await refetch();
+      setShowBulkBuyModal(false);
     } finally {
       setIsSubmitting(false);
     }
@@ -1657,6 +1717,12 @@ export default function MainApp({ session, onLogout }) {
                 + Add Stock
               </button>
               <button
+                onClick={() => setShowBulkBuyModal(true)}
+                className="btn btn-success"
+              >
+                Bulk Buy
+              </button>
+              <button
                 onClick={handleOpenArchive}
                 className="btn btn-secondary"
               >
@@ -1745,6 +1811,19 @@ export default function MainApp({ session, onLogout }) {
                 onConfirm={handleBuy}
                 onCancel={() => setShowBuyModal(false)}
                 geData={gePrices}
+                isSubmitting={isSubmitting}
+              />
+            </ModalContainer>
+
+            <ModalContainer isOpen={showBulkBuyModal}>
+              <BulkBuyModal
+                stocks={stocks}
+                categories={categories}
+                tradeMode={tradeMode}
+                gePrices={gePrices}
+                geIconMap={geIconMap}
+                onConfirm={handleBulkBuy}
+                onCancel={() => setShowBulkBuyModal(false)}
                 isSubmitting={isSubmitting}
               />
             </ModalContainer>

--- a/src/components/modals/BulkBuyModal.jsx
+++ b/src/components/modals/BulkBuyModal.jsx
@@ -1,0 +1,415 @@
+import React, { useState, useMemo } from 'react';
+import { formatNumber, parseMK, handleMKInput } from '../../utils/formatters';
+
+export default function BulkBuyModal({ stocks, categories = [], tradeMode = 'trade', gePrices = {}, geIconMap = {}, onConfirm, onCancel, isSubmitting = false }) {
+  const [mode, setMode] = useState('perItem');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedItems, setSelectedItems] = useState({});
+  const [budget, setBudget] = useState('');
+
+  // Build grouped stocks in category order (matching main trade screen)
+  const groupedStocks = useMemo(() => {
+    const filtered = stocks.filter(s =>
+      tradeMode === 'investment' ? s.isInvestment : !s.isInvestment
+    );
+    const filteredCats = categories.filter(c =>
+      tradeMode === 'investment' ? c.isInvestment : !c.isInvestment
+    );
+    const catNames = filteredCats.map(c => c.name);
+
+    const groups = [];
+    for (const cat of filteredCats) {
+      const catStocks = filtered.filter(s => s.category === cat.name);
+      if (catStocks.length > 0) {
+        groups.push({ name: cat.name, stocks: catStocks });
+      }
+    }
+
+    const uncategorized = filtered.filter(s =>
+      s.category === 'Uncategorized' || !s.category || !catNames.includes(s.category)
+    );
+    if (uncategorized.length > 0 && !filteredCats.some(c => c.name === 'Uncategorized')) {
+      groups.push({ name: 'Uncategorized', stocks: uncategorized });
+    }
+
+    return groups;
+  }, [stocks, categories, tradeMode]);
+
+  // Filtered groups for search
+  const filteredGroups = useMemo(() => {
+    if (!searchQuery.trim()) return groupedStocks;
+    const q = searchQuery.toLowerCase();
+    return groupedStocks
+      .map(g => ({ ...g, stocks: g.stocks.filter(s => s.name.toLowerCase().includes(q)) }))
+      .filter(g => g.stocks.length > 0);
+  }, [groupedStocks, searchQuery]);
+
+  const toggleItem = (stock) => {
+    setSelectedItems(prev => {
+      const next = { ...prev };
+      if (next[stock.id]) {
+        delete next[stock.id];
+      } else {
+        const geLow = stock.itemId ? gePrices[stock.itemId]?.low : null;
+        const avgBuy = stock.shares > 0 ? Math.round(stock.totalCost / stock.shares) : 0;
+        const defaultPrice = avgBuy || geLow || '';
+        next[stock.id] = {
+          stock,
+          shares: stock.limit4h ? stock.limit4h.toString() : '',
+          price: defaultPrice ? defaultPrice.toString() : '',
+          startTimer: true,
+        };
+      }
+      return next;
+    });
+  };
+
+  const removeItem = (stockId) => {
+    setSelectedItems(prev => {
+      const next = { ...prev };
+      delete next[stockId];
+      return next;
+    });
+  };
+
+  const updateItem = (stockId, field, value) => {
+    setSelectedItems(prev => ({
+      ...prev,
+      [stockId]: { ...prev[stockId], [field]: value },
+    }));
+  };
+
+  const handleSharesInput = (stockId, value) => {
+    handleMKInput(value, (v) => updateItem(stockId, 'shares', v));
+  };
+
+  const handlePriceInput = (stockId, value) => {
+    handleMKInput(value, (v) => updateItem(stockId, 'price', v));
+  };
+
+  const selectedEntries = Object.entries(selectedItems);
+  const selectedCount = selectedEntries.length;
+
+  // Per-item totals and grand total
+  const perItemTotals = useMemo(() => {
+    const totals = {};
+    let grand = 0;
+    for (const [id, item] of selectedEntries) {
+      const s = parseFloat(item.shares) || 0;
+      const p = parseFloat(item.price) || 0;
+      const t = s * p;
+      totals[id] = t;
+      grand += t;
+    }
+    return { totals, grand };
+  }, [selectedItems]);
+
+  // Budget split calculations - uses custom price per item
+  const budgetCalc = useMemo(() => {
+    if (mode !== 'budgetSplit' || !budget) return null;
+    const totalBudget = parseFloat(budget) || 0;
+    if (totalBudget <= 0 || selectedCount === 0) return null;
+
+    const eligible = selectedEntries.filter(([, item]) => {
+      const price = parseFloat(item.price) || 0;
+      return price > 0;
+    });
+
+    if (eligible.length === 0) return { allocations: {}, remainder: totalBudget, totalSpent: 0 };
+
+    const perItem = Math.floor(totalBudget / eligible.length);
+    const allocations = {};
+    let totalSpent = 0;
+
+    for (const [id, item] of eligible) {
+      const price = parseFloat(item.price);
+      const shares = Math.floor(perItem / price);
+      const spent = shares * price;
+      totalSpent += spent;
+      allocations[id] = { shares, price, allocated: perItem, spent };
+    }
+
+    return { allocations, remainder: totalBudget - totalSpent, totalSpent };
+  }, [mode, budget, selectedItems]);
+
+  const canConfirm = useMemo(() => {
+    if (selectedCount === 0) return false;
+    if (mode === 'perItem') {
+      return selectedEntries.every(([, item]) => {
+        const s = parseFloat(item.shares);
+        const p = parseFloat(item.price);
+        return s > 0 && p > 0;
+      });
+    }
+    if (mode === 'budgetSplit') {
+      return budgetCalc && budgetCalc.totalSpent > 0;
+    }
+    return false;
+  }, [mode, selectedItems, budgetCalc]);
+
+  const handleConfirm = () => {
+    if (!canConfirm || isSubmitting) return;
+
+    let items;
+    if (mode === 'perItem') {
+      items = selectedEntries.map(([, item]) => ({
+        stock: item.stock,
+        shares: parseFloat(item.shares),
+        price: parseFloat(item.price),
+        startTimer: item.startTimer,
+      }));
+    } else {
+      items = selectedEntries
+        .filter(([id]) => budgetCalc?.allocations[id]?.shares > 0)
+        .map(([id, item]) => ({
+          stock: item.stock,
+          shares: budgetCalc.allocations[id].shares,
+          price: budgetCalc.allocations[id].price,
+          startTimer: item.startTimer,
+        }));
+    }
+
+    onConfirm(items);
+  };
+
+  return (
+    <div className="bulk-buy-modal">
+      {/* Header */}
+      <div className="bulk-buy-header">
+        <h2>Bulk Buy</h2>
+        <div className="bulk-buy-mode-toggle">
+          <button
+            className={`bulk-buy-mode-btn ${mode === 'perItem' ? 'active' : ''}`}
+            onClick={() => setMode('perItem')}
+          >
+            Per-Item
+          </button>
+          <button
+            className={`bulk-buy-mode-btn ${mode === 'budgetSplit' ? 'active' : ''}`}
+            onClick={() => setMode('budgetSplit')}
+          >
+            Budget Split
+          </button>
+        </div>
+      </div>
+
+      {/* Body: two panels */}
+      <div className="bulk-buy-body">
+        {/* Left: Item Picker */}
+        <div className="bulk-buy-picker">
+          <div className="bulk-buy-search">
+            <input
+              type="text"
+              placeholder="Search stocks..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+          </div>
+          <div className="bulk-buy-item-list">
+            {filteredGroups.map(group => (
+              <React.Fragment key={group.name}>
+                <div className="bulk-buy-category-label">{group.name}</div>
+                {group.stocks.map(stock => {
+                  const isSelected = !!selectedItems[stock.id];
+                  const geLow = stock.itemId ? gePrices[stock.itemId]?.low : null;
+                  const geHigh = stock.itemId ? gePrices[stock.itemId]?.high : null;
+                  const iconUrl = stock.itemId ? geIconMap[stock.itemId] : null;
+
+                  return (
+                    <div
+                      key={stock.id}
+                      className={`bulk-buy-item-row ${isSelected ? 'selected' : ''}`}
+                      onClick={() => toggleItem(stock)}
+                    >
+                      {iconUrl && <img className="item-icon" src={iconUrl} alt="" />}
+                      <div className="item-info">
+                        <div className="item-name">{stock.name}</div>
+                        <div className="item-meta">
+                          {formatNumber(stock.shares)} held
+                          {geLow ? ` | GE: ${formatNumber(geLow)}` : ''}
+                          {geHigh ? ` / ${formatNumber(geHigh)}` : ''}
+                        </div>
+                      </div>
+                      {isSelected && <span className="item-check">&#10003;</span>}
+                    </div>
+                  );
+                })}
+              </React.Fragment>
+            ))}
+            {filteredGroups.length === 0 && (
+              <div className="bulk-buy-empty-config">No stocks found</div>
+            )}
+          </div>
+        </div>
+
+        {/* Right: Config */}
+        <div className="bulk-buy-config">
+          <div className="bulk-buy-config-header">
+            {selectedCount} item{selectedCount !== 1 ? 's' : ''} selected
+          </div>
+
+          {mode === 'budgetSplit' && (
+            <div className="bulk-buy-budget-row">
+              <label>Total Budget (GP)</label>
+              <input
+                type="text"
+                value={budget}
+                onChange={(e) => handleMKInput(e.target.value, setBudget)}
+                placeholder="e.g. 100m"
+              />
+            </div>
+          )}
+
+          {selectedCount === 0 ? (
+            <div className="bulk-buy-empty-config">
+              Select items from the left panel to get started
+            </div>
+          ) : (
+            <div className="bulk-buy-selected-list">
+              {selectedEntries.map(([id, item]) => {
+                const { stock } = item;
+                const iconUrl = stock.itemId ? geIconMap[stock.itemId] : null;
+                const geLow = stock.itemId ? gePrices[stock.itemId]?.low : null;
+                const geHigh = stock.itemId ? gePrices[stock.itemId]?.high : null;
+                const allocation = budgetCalc?.allocations[id];
+
+                return (
+                  <div key={id} className="bulk-buy-selected-item">
+                    <div className="item-header">
+                      {iconUrl && <img className="item-icon" src={iconUrl} alt="" />}
+                      <span className="item-name">{stock.name}</span>
+                      <button className="remove-btn" onClick={() => removeItem(stock.id)}>&times;</button>
+                    </div>
+
+                    {mode === 'perItem' ? (
+                      <>
+                        <div className="item-inputs">
+                          <input
+                            type="text"
+                            value={item.shares}
+                            onChange={(e) => handleSharesInput(id, e.target.value)}
+                            placeholder="Shares"
+                          />
+                          <input
+                            type="text"
+                            value={item.price}
+                            onChange={(e) => handlePriceInput(id, e.target.value)}
+                            placeholder="Price"
+                          />
+                        </div>
+                        {(geLow || geHigh) && (
+                          <div className="ge-btns">
+                            {geLow && (
+                              <button
+                                className="bulk-buy-ge-btn low"
+                                onClick={() => updateItem(id, 'price', geLow.toString())}
+                              >
+                                Low: {formatNumber(geLow)}
+                              </button>
+                            )}
+                            {geHigh && (
+                              <button
+                                className="bulk-buy-ge-btn high"
+                                onClick={() => updateItem(id, 'price', geHigh.toString())}
+                              >
+                                High: {formatNumber(geHigh)}
+                              </button>
+                            )}
+                          </div>
+                        )}
+                        {perItemTotals.totals[id] > 0 && (
+                          <div className="item-subtotal">
+                            Total: {formatNumber(perItemTotals.totals[id], 'full')} GP
+                          </div>
+                        )}
+                      </>
+                    ) : (
+                      <>
+                        <div className="item-inputs">
+                          <input
+                            type="text"
+                            value={item.price}
+                            onChange={(e) => handlePriceInput(id, e.target.value)}
+                            placeholder="Buy price"
+                          />
+                        </div>
+                        {(geLow || geHigh) && (
+                          <div className="ge-btns">
+                            {geLow && (
+                              <button
+                                className="bulk-buy-ge-btn low"
+                                onClick={() => updateItem(id, 'price', geLow.toString())}
+                              >
+                                Low: {formatNumber(geLow)}
+                              </button>
+                            )}
+                            {geHigh && (
+                              <button
+                                className="bulk-buy-ge-btn high"
+                                onClick={() => updateItem(id, 'price', geHigh.toString())}
+                              >
+                                High: {formatNumber(geHigh)}
+                              </button>
+                            )}
+                          </div>
+                        )}
+                        <div className="budget-info">
+                          {allocation ? (
+                            <div className="shares-calc">
+                              {formatNumber(allocation.shares)} shares @ {formatNumber(allocation.price)} = {formatNumber(allocation.spent, 'full')} GP
+                            </div>
+                          ) : (
+                            <div>{parseFloat(item.price) > 0 ? 'Enter budget above' : 'Set a buy price'}</div>
+                          )}
+                        </div>
+                      </>
+                    )}
+
+                    <label className="timer-row">
+                      <input
+                        type="checkbox"
+                        checked={item.startTimer}
+                        onChange={(e) => updateItem(id, 'startTimer', e.target.checked)}
+                      />
+                      Start timer
+                    </label>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="bulk-buy-footer">
+        <div>
+          <div className="bulk-buy-total">
+            <span className="label">Total: </span>
+            <span className="amount">
+              {mode === 'perItem'
+                ? formatNumber(perItemTotals.grand, 'full')
+                : formatNumber(budgetCalc?.totalSpent || 0, 'full')
+              } GP
+            </span>
+          </div>
+          {mode === 'budgetSplit' && budgetCalc && budgetCalc.remainder > 0 && (
+            <div className="bulk-buy-remainder">
+              Remainder: {formatNumber(budgetCalc.remainder, 'full')} GP (cannot be evenly spent)
+            </div>
+          )}
+        </div>
+        <div className="bulk-buy-actions">
+          <button className="btn-cancel" onClick={onCancel}>Cancel</button>
+          <button
+            className="btn-confirm"
+            onClick={handleConfirm}
+            disabled={!canConfirm || isSubmitting}
+          >
+            {isSubmitting ? 'Buying...' : `Confirm (${selectedCount})`}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -3985,3 +3985,550 @@
   background: rgba(148, 163, 184, 0.15);
   color: rgb(148, 163, 184);
 }
+
+/* ===== Bulk Buy Modal ===== */
+
+.bulk-buy-modal {
+  background: rgb(22, 30, 46);
+  border-radius: 0.875rem;
+  width: 52rem;
+  max-width: 95vw;
+  height: 75vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow:
+    0 0 0 1px rgba(148, 163, 184, 0.08),
+    0 4px 24px rgba(0, 0, 0, 0.4),
+    0 24px 48px -12px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+}
+
+/* Header */
+.bulk-buy-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  background: linear-gradient(180deg, rgba(51, 65, 85, 0.25) 0%, transparent 100%);
+  border-bottom: 1px solid rgba(51, 65, 85, 0.6);
+  flex-shrink: 0;
+}
+
+.bulk-buy-header h2 {
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin: 0;
+  color: rgb(241, 245, 249);
+  letter-spacing: -0.01em;
+}
+
+.bulk-buy-mode-toggle {
+  display: flex;
+  gap: 2px;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 0.5rem;
+  padding: 3px;
+  border: 1px solid rgba(51, 65, 85, 0.5);
+}
+
+.bulk-buy-mode-btn {
+  padding: 0.375rem 0.875rem;
+  border-radius: 0.375rem;
+  border: none;
+  color: rgb(148, 163, 184);
+  cursor: pointer;
+  font-size: 0.78rem;
+  font-weight: 500;
+  background: transparent;
+  transition: all 0.2s ease;
+}
+
+.bulk-buy-mode-btn.active {
+  background: rgba(34, 197, 94, 0.15);
+  color: rgb(134, 239, 172);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.bulk-buy-mode-btn:hover:not(.active) {
+  color: rgb(226, 232, 240);
+  background: rgba(51, 65, 85, 0.3);
+}
+
+/* Body grid */
+.bulk-buy-body {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* Left panel: item picker */
+.bulk-buy-picker {
+  border-right: 1px solid rgba(51, 65, 85, 0.6);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: rgba(15, 23, 42, 0.3);
+}
+
+.bulk-buy-search {
+  padding: 0.75rem 0.75rem 0.5rem;
+  flex-shrink: 0;
+}
+
+.bulk-buy-search input {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(51, 65, 85, 0.6);
+  border-radius: 0.5rem;
+  color: white;
+  font-size: 0.82rem;
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.bulk-buy-search input::placeholder {
+  color: rgb(100, 116, 139);
+}
+
+.bulk-buy-search input:focus {
+  border-color: rgba(99, 102, 241, 0.6);
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.1);
+}
+
+.bulk-buy-item-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 0.375rem 0.5rem;
+}
+
+.bulk-buy-item-list::-webkit-scrollbar {
+  width: 5px;
+}
+
+.bulk-buy-item-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.bulk-buy-item-list::-webkit-scrollbar-thumb {
+  background: rgba(100, 116, 139, 0.3);
+  border-radius: 3px;
+}
+
+.bulk-buy-item-list::-webkit-scrollbar-thumb:hover {
+  background: rgba(100, 116, 139, 0.5);
+}
+
+.bulk-buy-category-label {
+  font-size: 0.65rem;
+  font-weight: 700;
+  color: rgb(71, 85, 105);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.625rem 0.75rem 0.25rem;
+  margin-top: 0.125rem;
+  position: sticky;
+  top: 0;
+  background: rgba(22, 30, 46, 0.9);
+  backdrop-filter: blur(4px);
+  z-index: 1;
+}
+
+.bulk-buy-item-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.625rem;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  font-size: 0.8rem;
+  border: 1px solid transparent;
+  margin: 1px 0;
+}
+
+.bulk-buy-item-row:hover {
+  background: rgba(51, 65, 85, 0.4);
+}
+
+.bulk-buy-item-row.selected {
+  background: rgba(34, 197, 94, 0.08);
+  border-color: rgba(34, 197, 94, 0.25);
+  border-left: 2px solid rgb(34, 197, 94);
+  padding-left: calc(0.625rem - 1px);
+}
+
+.bulk-buy-item-row .item-icon {
+  width: 24px;
+  height: 24px;
+  image-rendering: pixelated;
+  flex-shrink: 0;
+}
+
+.bulk-buy-item-row .item-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.bulk-buy-item-row .item-name {
+  font-weight: 500;
+  color: rgb(226, 232, 240);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 0.8rem;
+}
+
+.bulk-buy-item-row .item-meta {
+  font-size: 0.68rem;
+  color: rgb(100, 116, 139);
+  margin-top: 1px;
+}
+
+.bulk-buy-item-row .item-check {
+  color: rgb(34, 197, 94);
+  font-size: 0.85rem;
+  flex-shrink: 0;
+  opacity: 0;
+  transform: scale(0.5);
+  transition: all 0.2s ease;
+}
+
+.bulk-buy-item-row.selected .item-check {
+  opacity: 1;
+  transform: scale(1);
+}
+
+/* Right panel: config */
+.bulk-buy-config {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.bulk-buy-config-header {
+  padding: 0.625rem 1rem;
+  border-bottom: 1px solid rgba(51, 65, 85, 0.6);
+  flex-shrink: 0;
+  font-size: 0.78rem;
+  color: rgb(100, 116, 139);
+  font-weight: 500;
+}
+
+.bulk-buy-budget-row {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid rgba(51, 65, 85, 0.6);
+  flex-shrink: 0;
+  background: rgba(34, 197, 94, 0.03);
+}
+
+.bulk-buy-budget-row label {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: rgb(148, 163, 184);
+  margin-bottom: 0.375rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.bulk-buy-budget-row input {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(51, 65, 85, 0.6);
+  border-radius: 0.5rem;
+  color: rgb(134, 239, 172);
+  font-size: 1rem;
+  font-weight: 600;
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.bulk-buy-budget-row input::placeholder {
+  color: rgb(71, 85, 105);
+  font-weight: 400;
+}
+
+.bulk-buy-budget-row input:focus {
+  border-color: rgba(34, 197, 94, 0.5);
+  box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.1);
+}
+
+.bulk-buy-selected-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+
+.bulk-buy-selected-list::-webkit-scrollbar {
+  width: 5px;
+}
+
+.bulk-buy-selected-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.bulk-buy-selected-list::-webkit-scrollbar-thumb {
+  background: rgba(100, 116, 139, 0.3);
+  border-radius: 3px;
+}
+
+.bulk-buy-selected-item {
+  background: rgba(15, 23, 42, 0.5);
+  border: 1px solid rgba(51, 65, 85, 0.5);
+  border-radius: 0.5rem;
+  padding: 0.625rem 0.75rem;
+  margin-bottom: 0.375rem;
+  transition: border-color 0.2s;
+}
+
+.bulk-buy-selected-item:hover {
+  border-color: rgba(71, 85, 105, 0.7);
+}
+
+.bulk-buy-selected-item .item-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.bulk-buy-selected-item .item-header .item-icon {
+  width: 20px;
+  height: 20px;
+  image-rendering: pixelated;
+}
+
+.bulk-buy-selected-item .item-header .item-name {
+  flex: 1;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: rgb(226, 232, 240);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.bulk-buy-selected-item .item-header .remove-btn {
+  background: none;
+  border: none;
+  color: rgb(71, 85, 105);
+  cursor: pointer;
+  padding: 0.125rem 0.25rem;
+  font-size: 1.1rem;
+  line-height: 1;
+  border-radius: 0.25rem;
+  transition: all 0.15s;
+}
+
+.bulk-buy-selected-item .item-header .remove-btn:hover {
+  color: rgb(239, 68, 68);
+  background: rgba(239, 68, 68, 0.1);
+}
+
+.bulk-buy-selected-item .item-inputs {
+  display: flex;
+  gap: 0.375rem;
+  align-items: center;
+}
+
+.bulk-buy-selected-item .item-inputs input {
+  flex: 1;
+  padding: 0.35rem 0.5rem;
+  background: rgba(30, 41, 59, 0.7);
+  border: 1px solid rgba(51, 65, 85, 0.5);
+  border-radius: 0.375rem;
+  color: white;
+  font-size: 0.8rem;
+  outline: none;
+  min-width: 0;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.bulk-buy-selected-item .item-inputs input::placeholder {
+  color: rgb(71, 85, 105);
+}
+
+.bulk-buy-selected-item .item-inputs input:focus {
+  border-color: rgba(34, 197, 94, 0.5);
+  box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.08);
+}
+
+.bulk-buy-selected-item .ge-btns {
+  display: flex;
+  gap: 0.25rem;
+  margin-top: 0.35rem;
+}
+
+.bulk-buy-ge-btn {
+  padding: 0.15rem 0.4rem;
+  background: rgba(51, 65, 85, 0.5);
+  border: 1px solid rgba(71, 85, 105, 0.5);
+  border-radius: 0.25rem;
+  cursor: pointer;
+  font-size: 0.68rem;
+  font-weight: 500;
+  transition: all 0.15s;
+}
+
+.bulk-buy-ge-btn:hover {
+  background: rgba(71, 85, 105, 0.6);
+  border-color: rgba(100, 116, 139, 0.4);
+}
+
+.bulk-buy-ge-btn.low {
+  color: rgb(134, 239, 172);
+}
+
+.bulk-buy-ge-btn.high {
+  color: rgb(147, 197, 253);
+}
+
+.bulk-buy-selected-item .item-subtotal {
+  font-size: 0.75rem;
+  color: rgb(251, 146, 60);
+  margin-top: 0.35rem;
+  font-weight: 600;
+}
+
+.bulk-buy-selected-item .timer-row {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  margin-top: 0.35rem;
+  font-size: 0.72rem;
+  color: rgb(100, 116, 139);
+  cursor: pointer;
+}
+
+.bulk-buy-selected-item .timer-row:hover {
+  color: rgb(148, 163, 184);
+}
+
+.bulk-buy-selected-item .timer-row input[type="checkbox"] {
+  width: 13px;
+  height: 13px;
+  cursor: pointer;
+  accent-color: rgb(34, 197, 94);
+}
+
+.bulk-buy-selected-item .budget-info {
+  font-size: 0.75rem;
+  color: rgb(148, 163, 184);
+  margin-top: 0.25rem;
+}
+
+.bulk-buy-selected-item .budget-info .shares-calc {
+  color: rgb(134, 239, 172);
+  font-weight: 600;
+}
+
+.bulk-buy-empty-config {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  color: rgb(71, 85, 105);
+  font-size: 0.82rem;
+  padding: 2rem;
+  text-align: center;
+}
+
+/* Footer */
+.bulk-buy-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1.25rem;
+  border-top: 1px solid rgba(51, 65, 85, 0.6);
+  background: rgba(15, 23, 42, 0.3);
+  flex-shrink: 0;
+}
+
+.bulk-buy-total {
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.bulk-buy-total .label {
+  color: rgb(100, 116, 139);
+  font-weight: 500;
+}
+
+.bulk-buy-total .amount {
+  color: rgb(251, 146, 60);
+  text-shadow: 0 0 20px rgba(251, 146, 60, 0.15);
+}
+
+.bulk-buy-remainder {
+  font-size: 0.72rem;
+  color: rgb(100, 116, 139);
+  margin-top: 2px;
+}
+
+.bulk-buy-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.bulk-buy-actions .btn-confirm {
+  padding: 0.5rem 1.25rem;
+  background: rgb(21, 128, 61);
+  border-radius: 0.5rem;
+  border: none;
+  color: white;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.82rem;
+  transition: all 0.2s ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.bulk-buy-actions .btn-confirm:hover:not(:disabled) {
+  background: rgb(22, 163, 74);
+  box-shadow: 0 2px 8px rgba(34, 197, 94, 0.25);
+}
+
+.bulk-buy-actions .btn-confirm:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.bulk-buy-actions .btn-cancel {
+  padding: 0.5rem 1.25rem;
+  background: rgba(71, 85, 105, 0.5);
+  border-radius: 0.5rem;
+  border: 1px solid rgba(71, 85, 105, 0.3);
+  color: rgb(148, 163, 184);
+  cursor: pointer;
+  font-weight: 500;
+  font-size: 0.82rem;
+  transition: all 0.15s;
+}
+
+.bulk-buy-actions .btn-cancel:hover {
+  background: rgba(71, 85, 105, 0.7);
+  color: white;
+}
+
+/* Responsive */
+@media (max-width: 640px) {
+  .bulk-buy-modal {
+    width: 100%;
+    height: 95vh;
+  }
+
+  .bulk-buy-body {
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr 1fr;
+  }
+
+  .bulk-buy-picker {
+    border-right: none;
+    border-bottom: 1px solid rgba(51, 65, 85, 0.6);
+    max-height: 40vh;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new Bulk Buy modal with two purchase modes: **Per-Item** (set shares + price individually per stock) and **Budget Split** (enter total GP budget, auto-distribute across selected items)
- Two-panel layout: searchable item picker (left) grouped by category in trade-screen order, and item configuration (right) with GE price quick-fill, custom pricing, and per-item timer controls
- Wired into MainApp with `handleBulkBuy` handler that sequentially processes each item (updateStock + addTransaction)

Closes #160

## Test plan
- [ ] Open Bulk Buy from category actions row
- [ ] Search and select multiple stocks across categories
- [ ] Per-Item mode: set shares/price, verify combined total, confirm purchase
- [ ] Budget Split mode: enter budget, customize prices per item, verify share calculations and remainder
- [ ] Verify stock totals and transaction records update correctly after bulk buy
- [ ] Verify timer logic starts correctly per item when checked
- [ ] Test on mobile viewport (panels should stack vertically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)