### PR TITLE
feat(modals): add bulk sell modal

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -34,6 +34,7 @@ import ChangePasswordModal from './components/modals/ChangePasswordModal';
 import ModalContainer from './components/modals/ModalContainer';
 import BuyModal from './components/modals/BuyModal';
 import BulkBuyModal from './components/modals/BulkBuyModal';
+import BulkSellModal from './components/modals/BulkSellModal';
 import SellModal from './components/modals/SellModal';
 import RemoveStockModal from './components/modals/RemoveStockModal';
 import AdjustModal from './components/modals/AdjustModal';
@@ -200,6 +201,7 @@ export default function MainApp({ session, onLogout }) {
   // Modal states
   const [showBuyModal, setShowBuyModal] = useState(false);
   const [showBulkBuyModal, setShowBulkBuyModal] = useState(false);
+  const [showBulkSellModal, setShowBulkSellModal] = useState(false);
   const [showSellModal, setShowSellModal] = useState(false);
   const [showRemoveModal, setShowRemoveModal] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -935,6 +937,54 @@ export default function MainApp({ session, onLogout }) {
       await refetch();
       highlightRow(selectedStock.id);
       setShowSellModal(false);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleBulkSell = async (items) => {
+    if (isSubmitting) return;
+    setIsSubmitting(true);
+    try {
+      for (const item of items) {
+        const { stock, shares, price } = item;
+        const total = shares * price;
+        const avgBuy = stock.shares > 0 ? stock.totalCost / stock.shares : 0;
+        const costBasisOfSharesSold = avgBuy * shares;
+        const profit = total - costBasisOfSharesSold;
+
+        await updateStock(stock.id, {
+          shares: stock.shares - shares,
+          totalCost: stock.totalCost - costBasisOfSharesSold,
+          sharesSold: stock.sharesSold + shares,
+          totalCostSold: stock.totalCostSold + total,
+          totalCostBasisSold: (stock.totalCostBasisSold || 0) + costBasisOfSharesSold
+        });
+
+        const newTransaction = await addTransaction({
+          stockId: stock.id,
+          stockName: stock.name,
+          type: 'sell',
+          shares,
+          price,
+          total,
+          date: new Date().toISOString()
+        });
+
+        const profitEntry = await addProfitEntry('stock', profit, stock.id, newTransaction?.id ?? null);
+
+        if (newTransaction && profitEntry) {
+          await supabase
+            .from('transactions')
+            .update({ profit_history_id: profitEntry.id })
+            .eq('id', newTransaction.id);
+        }
+
+        highlightRow(stock.id);
+      }
+
+      await refetch();
+      setShowBulkSellModal(false);
     } finally {
       setIsSubmitting(false);
     }
@@ -1723,6 +1773,12 @@ export default function MainApp({ session, onLogout }) {
                 Bulk Buy
               </button>
               <button
+                onClick={() => setShowBulkSellModal(true)}
+                className="btn btn-danger"
+              >
+                Bulk Sell
+              </button>
+              <button
                 onClick={handleOpenArchive}
                 className="btn btn-secondary"
               >
@@ -1824,6 +1880,19 @@ export default function MainApp({ session, onLogout }) {
                 geIconMap={geIconMap}
                 onConfirm={handleBulkBuy}
                 onCancel={() => setShowBulkBuyModal(false)}
+                isSubmitting={isSubmitting}
+              />
+            </ModalContainer>
+
+            <ModalContainer isOpen={showBulkSellModal}>
+              <BulkSellModal
+                stocks={stocks}
+                categories={categories}
+                tradeMode={tradeMode}
+                gePrices={gePrices}
+                geIconMap={geIconMap}
+                onConfirm={handleBulkSell}
+                onCancel={() => setShowBulkSellModal(false)}
                 isSubmitting={isSubmitting}
               />
             </ModalContainer>

--- a/src/components/modals/BulkSellModal.jsx
+++ b/src/components/modals/BulkSellModal.jsx
@@ -1,0 +1,325 @@
+import React, { useState, useMemo } from 'react';
+import { formatNumber, handleMKInput } from '../../utils/formatters';
+
+export default function BulkSellModal({ stocks, categories = [], tradeMode = 'trade', gePrices = {}, geIconMap = {}, onConfirm, onCancel, isSubmitting = false }) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedItems, setSelectedItems] = useState({});
+
+  const groupedStocks = useMemo(() => {
+    const filtered = stocks.filter(s =>
+      (tradeMode === 'investment' ? s.isInvestment : !s.isInvestment) && s.shares > 0
+    );
+    const filteredCats = categories.filter(c =>
+      tradeMode === 'investment' ? c.isInvestment : !c.isInvestment
+    );
+    const catNames = filteredCats.map(c => c.name);
+
+    const groups = [];
+    for (const cat of filteredCats) {
+      const catStocks = filtered.filter(s => s.category === cat.name);
+      if (catStocks.length > 0) {
+        groups.push({ name: cat.name, stocks: catStocks });
+      }
+    }
+
+    const uncategorized = filtered.filter(s =>
+      s.category === 'Uncategorized' || !s.category || !catNames.includes(s.category)
+    );
+    if (uncategorized.length > 0 && !filteredCats.some(c => c.name === 'Uncategorized')) {
+      groups.push({ name: 'Uncategorized', stocks: uncategorized });
+    }
+
+    return groups;
+  }, [stocks, categories, tradeMode]);
+
+  const filteredGroups = useMemo(() => {
+    if (!searchQuery.trim()) return groupedStocks;
+    const q = searchQuery.toLowerCase();
+    return groupedStocks
+      .map(g => ({ ...g, stocks: g.stocks.filter(s => s.name.toLowerCase().includes(q)) }))
+      .filter(g => g.stocks.length > 0);
+  }, [groupedStocks, searchQuery]);
+
+  const toggleItem = (stock) => {
+    setSelectedItems(prev => {
+      const next = { ...prev };
+      if (next[stock.id]) {
+        delete next[stock.id];
+      } else {
+        const geHigh = stock.itemId ? gePrices[stock.itemId]?.high : null;
+        const avgSell = stock.sharesSold > 0 ? Math.round(stock.totalCostSold / stock.sharesSold) : null;
+        const defaultPrice = geHigh || avgSell || '';
+        next[stock.id] = {
+          stock,
+          shares: '',
+          price: defaultPrice ? defaultPrice.toString() : '',
+        };
+      }
+      return next;
+    });
+  };
+
+  const removeItem = (stockId) => {
+    setSelectedItems(prev => {
+      const next = { ...prev };
+      delete next[stockId];
+      return next;
+    });
+  };
+
+  const updateItem = (stockId, field, value) => {
+    setSelectedItems(prev => ({
+      ...prev,
+      [stockId]: { ...prev[stockId], [field]: value },
+    }));
+  };
+
+  const handleSharesInput = (stockId, value) => {
+    handleMKInput(value, (v) => updateItem(stockId, 'shares', v));
+  };
+
+  const handlePriceInput = (stockId, value) => {
+    handleMKInput(value, (v) => updateItem(stockId, 'price', v));
+  };
+
+  const selectedEntries = Object.entries(selectedItems);
+  const selectedCount = selectedEntries.length;
+
+  const calculations = useMemo(() => {
+    let totalRevenue = 0;
+    let totalProfit = 0;
+    const perItem = {};
+
+    for (const [id, item] of selectedEntries) {
+      const shares = parseFloat(item.shares) || 0;
+      const price = parseFloat(item.price) || 0;
+      const revenue = shares * price;
+      const avgBuy = item.stock.shares > 0 ? item.stock.totalCost / item.stock.shares : 0;
+      const costBasis = avgBuy * shares;
+      const profit = revenue - costBasis;
+      const profitPercent = avgBuy > 0 ? ((price - avgBuy) / avgBuy) * 100 : 0;
+
+      perItem[id] = { revenue, avgBuy, costBasis, profit, profitPercent };
+      totalRevenue += revenue;
+      totalProfit += profit;
+    }
+
+    return { perItem, totalRevenue, totalProfit };
+  }, [selectedItems]);
+
+  const canConfirm = useMemo(() => {
+    if (selectedCount === 0) return false;
+    return selectedEntries.every(([, item]) => {
+      const s = parseFloat(item.shares);
+      const p = parseFloat(item.price);
+      return s > 0 && p > 0 && s <= item.stock.shares;
+    });
+  }, [selectedItems]);
+
+  const handleConfirm = () => {
+    if (!canConfirm || isSubmitting) return;
+    const items = selectedEntries.map(([, item]) => ({
+      stock: item.stock,
+      shares: parseFloat(item.shares),
+      price: parseFloat(item.price),
+    }));
+    onConfirm(items);
+  };
+
+  return (
+    <div className="bulk-sell-modal">
+      <div className="bulk-sell-header">
+        <h2>Bulk Sell</h2>
+        <div className="bulk-sell-item-count">
+          {selectedCount > 0 && (
+            <span className="bulk-sell-count-badge">{selectedCount}</span>
+          )}
+        </div>
+      </div>
+
+      <div className="bulk-sell-body">
+        {/* Left: Item Picker */}
+        <div className="bulk-sell-picker">
+          <div className="bulk-sell-search">
+            <input
+              type="text"
+              placeholder="Search stocks..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+          </div>
+          <div className="bulk-sell-item-list">
+            {filteredGroups.map(group => (
+              <React.Fragment key={group.name}>
+                <div className="bulk-sell-category-label">{group.name}</div>
+                {group.stocks.map(stock => {
+                  const isSelected = !!selectedItems[stock.id];
+                  const avgBuy = stock.shares > 0 ? Math.round(stock.totalCost / stock.shares) : 0;
+                  const iconUrl = stock.itemId ? geIconMap[stock.itemId] : null;
+
+                  return (
+                    <div
+                      key={stock.id}
+                      className={`bulk-sell-item-row ${isSelected ? 'selected' : ''}`}
+                      onClick={() => toggleItem(stock)}
+                    >
+                      {iconUrl && <img className="item-icon" src={iconUrl} alt="" />}
+                      <div className="item-info">
+                        <div className="item-name">{stock.name}</div>
+                        <div className="item-meta">
+                          {formatNumber(stock.shares)} held | Avg: {formatNumber(avgBuy)}
+                        </div>
+                      </div>
+                      {isSelected && <span className="item-check">&#10003;</span>}
+                    </div>
+                  );
+                })}
+              </React.Fragment>
+            ))}
+            {filteredGroups.length === 0 && (
+              <div className="bulk-sell-empty-config">No stocks with holdings found</div>
+            )}
+          </div>
+        </div>
+
+        {/* Right: Config */}
+        <div className="bulk-sell-config">
+          <div className="bulk-sell-config-header">
+            {selectedCount} item{selectedCount !== 1 ? 's' : ''} selected
+          </div>
+
+          {selectedCount === 0 ? (
+            <div className="bulk-sell-empty-config">
+              Select items from the left panel to sell
+            </div>
+          ) : (
+            <div className="bulk-sell-selected-list">
+              {selectedEntries.map(([id, item]) => {
+                const { stock } = item;
+                const iconUrl = stock.itemId ? geIconMap[stock.itemId] : null;
+                const geLow = stock.itemId ? gePrices[stock.itemId]?.low : null;
+                const geHigh = stock.itemId ? gePrices[stock.itemId]?.high : null;
+                const calc = calculations.perItem[id];
+                const shares = parseFloat(item.shares) || 0;
+                const price = parseFloat(item.price) || 0;
+                const overMax = shares > stock.shares;
+
+                return (
+                  <div key={id} className="bulk-sell-selected-item">
+                    <div className="item-header">
+                      {iconUrl && <img className="item-icon" src={iconUrl} alt="" />}
+                      <span className="item-name">{stock.name}</span>
+                      <span className="item-held">{formatNumber(stock.shares)} held</span>
+                      <button className="remove-btn" onClick={() => removeItem(stock.id)}>&times;</button>
+                    </div>
+
+                    <div className="item-inputs">
+                      <div className="input-group">
+                        <input
+                          type="text"
+                          value={item.shares}
+                          onChange={(e) => handleSharesInput(id, e.target.value)}
+                          placeholder="Qty"
+                          className={overMax ? 'input-error' : ''}
+                        />
+                        <button
+                          className="sell-all-btn"
+                          onClick={() => updateItem(id, 'shares', stock.shares.toString())}
+                        >
+                          ALL
+                        </button>
+                      </div>
+                      <input
+                        type="text"
+                        value={item.price}
+                        onChange={(e) => handlePriceInput(id, e.target.value)}
+                        placeholder="Price"
+                      />
+                    </div>
+
+                    {(geLow || geHigh) && (
+                      <div className="ge-btns">
+                        {geLow && (
+                          <button
+                            className="bulk-sell-ge-btn low"
+                            onClick={() => updateItem(id, 'price', geLow.toString())}
+                          >
+                            Low: {formatNumber(geLow)}
+                          </button>
+                        )}
+                        {geHigh && (
+                          <button
+                            className="bulk-sell-ge-btn high"
+                            onClick={() => updateItem(id, 'price', geHigh.toString())}
+                          >
+                            High: {formatNumber(geHigh)}
+                          </button>
+                        )}
+                      </div>
+                    )}
+
+                    {shares > 0 && price > 0 && calc && (
+                      <div className={`profit-preview ${calc.profit >= 0 ? 'profit' : 'loss'}`}>
+                        <div className="profit-preview-row">
+                          <span>Revenue</span>
+                          <span>{formatNumber(calc.revenue, 'full')} GP</span>
+                        </div>
+                        <div className="profit-preview-row">
+                          <span>Cost basis</span>
+                          <span>{formatNumber(calc.costBasis, 'full')} GP</span>
+                        </div>
+                        <div className="profit-preview-divider"></div>
+                        <div className="profit-preview-row profit-row">
+                          <span>Profit</span>
+                          <span>
+                            {(calc.profit >= 0 ? '+' : '') + formatNumber(calc.profit, 'full')} GP
+                            <span className="profit-pct">
+                              ({(calc.profitPercent >= 0 ? '+' : '') + calc.profitPercent.toFixed(1)}%)
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    )}
+
+                    {overMax && (
+                      <div className="item-error">
+                        Exceeds available ({formatNumber(stock.shares)})
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="bulk-sell-footer">
+        <div className="bulk-sell-footer-stats">
+          <div className="bulk-sell-total">
+            <span className="label">Revenue: </span>
+            <span className="amount">{formatNumber(calculations.totalRevenue, 'full')} GP</span>
+          </div>
+          {selectedCount > 0 && (
+            <div className={`bulk-sell-profit ${calculations.totalProfit >= 0 ? 'profit' : 'loss'}`}>
+              <span className="label">Profit: </span>
+              <span className="amount">
+                {(calculations.totalProfit >= 0 ? '+' : '') + formatNumber(calculations.totalProfit, 'full')} GP
+              </span>
+            </div>
+          )}
+        </div>
+        <div className="bulk-sell-actions">
+          <button className="btn-cancel" onClick={onCancel}>Cancel</button>
+          <button
+            className="btn-confirm"
+            onClick={handleConfirm}
+            disabled={!canConfirm || isSubmitting}
+          >
+            {isSubmitting ? 'Selling...' : `Sell (${selectedCount})`}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -4532,3 +4532,589 @@
     max-height: 40vh;
   }
 }
+
+
+/* ===== Bulk Sell Modal ===== */
+
+.bulk-sell-modal {
+  background: rgb(22, 30, 46);
+  border-radius: 0.875rem;
+  width: 52rem;
+  max-width: 95vw;
+  height: 75vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow:
+    0 0 0 1px rgba(251, 146, 60, 0.06),
+    0 4px 24px rgba(0, 0, 0, 0.4),
+    0 24px 48px -12px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+}
+
+/* Header */
+.bulk-sell-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  background: linear-gradient(180deg, rgba(251, 146, 60, 0.06) 0%, transparent 100%);
+  border-bottom: 1px solid rgba(51, 65, 85, 0.6);
+  flex-shrink: 0;
+}
+
+.bulk-sell-header h2 {
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin: 0;
+  color: rgb(241, 245, 249);
+  letter-spacing: -0.01em;
+}
+
+.bulk-sell-count-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(251, 146, 60, 0.15);
+  color: rgb(251, 146, 60);
+  font-size: 0.72rem;
+  font-weight: 700;
+  min-width: 1.4rem;
+  height: 1.4rem;
+  border-radius: 0.75rem;
+  padding: 0 0.4rem;
+  border: 1px solid rgba(251, 146, 60, 0.25);
+}
+
+/* Body grid */
+.bulk-sell-body {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* Left panel: item picker */
+.bulk-sell-picker {
+  border-right: 1px solid rgba(51, 65, 85, 0.6);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: rgba(15, 23, 42, 0.3);
+}
+
+.bulk-sell-search {
+  padding: 0.75rem 0.75rem 0.5rem;
+  flex-shrink: 0;
+}
+
+.bulk-sell-search input {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(51, 65, 85, 0.6);
+  border-radius: 0.5rem;
+  color: white;
+  font-size: 0.82rem;
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.bulk-sell-search input::placeholder {
+  color: rgb(100, 116, 139);
+}
+
+.bulk-sell-search input:focus {
+  border-color: rgba(251, 146, 60, 0.5);
+  box-shadow: 0 0 0 2px rgba(251, 146, 60, 0.08);
+}
+
+.bulk-sell-item-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 0.375rem 0.5rem;
+}
+
+.bulk-sell-item-list::-webkit-scrollbar {
+  width: 5px;
+}
+
+.bulk-sell-item-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.bulk-sell-item-list::-webkit-scrollbar-thumb {
+  background: rgba(100, 116, 139, 0.3);
+  border-radius: 3px;
+}
+
+.bulk-sell-item-list::-webkit-scrollbar-thumb:hover {
+  background: rgba(100, 116, 139, 0.5);
+}
+
+.bulk-sell-category-label {
+  font-size: 0.65rem;
+  font-weight: 700;
+  color: rgb(71, 85, 105);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.625rem 0.75rem 0.25rem;
+  margin-top: 0.125rem;
+  position: sticky;
+  top: 0;
+  background: rgba(22, 30, 46, 0.9);
+  backdrop-filter: blur(4px);
+  z-index: 1;
+}
+
+.bulk-sell-item-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.625rem;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  font-size: 0.8rem;
+  border: 1px solid transparent;
+  margin: 1px 0;
+}
+
+.bulk-sell-item-row:hover {
+  background: rgba(51, 65, 85, 0.4);
+}
+
+.bulk-sell-item-row.selected {
+  background: rgba(251, 146, 60, 0.06);
+  border-color: rgba(251, 146, 60, 0.2);
+  border-left: 2px solid rgb(251, 146, 60);
+  padding-left: calc(0.625rem - 1px);
+}
+
+.bulk-sell-item-row .item-icon {
+  width: 24px;
+  height: 24px;
+  image-rendering: pixelated;
+  flex-shrink: 0;
+}
+
+.bulk-sell-item-row .item-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.bulk-sell-item-row .item-name {
+  font-weight: 500;
+  color: rgb(226, 232, 240);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 0.8rem;
+}
+
+.bulk-sell-item-row .item-meta {
+  font-size: 0.68rem;
+  color: rgb(100, 116, 139);
+  margin-top: 1px;
+}
+
+.bulk-sell-item-row .item-check {
+  color: rgb(251, 146, 60);
+  font-size: 0.85rem;
+  flex-shrink: 0;
+  opacity: 0;
+  transform: scale(0.5);
+  transition: all 0.2s ease;
+}
+
+.bulk-sell-item-row.selected .item-check {
+  opacity: 1;
+  transform: scale(1);
+}
+
+/* Right panel: config */
+.bulk-sell-config {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.bulk-sell-config-header {
+  padding: 0.625rem 1rem;
+  border-bottom: 1px solid rgba(51, 65, 85, 0.6);
+  flex-shrink: 0;
+  font-size: 0.78rem;
+  color: rgb(100, 116, 139);
+  font-weight: 500;
+}
+
+.bulk-sell-selected-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+
+.bulk-sell-selected-list::-webkit-scrollbar {
+  width: 5px;
+}
+
+.bulk-sell-selected-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.bulk-sell-selected-list::-webkit-scrollbar-thumb {
+  background: rgba(100, 116, 139, 0.3);
+  border-radius: 3px;
+}
+
+.bulk-sell-selected-item {
+  background: rgba(15, 23, 42, 0.5);
+  border: 1px solid rgba(51, 65, 85, 0.5);
+  border-radius: 0.5rem;
+  padding: 0.625rem 0.75rem;
+  margin-bottom: 0.375rem;
+  transition: border-color 0.2s;
+}
+
+.bulk-sell-selected-item:hover {
+  border-color: rgba(71, 85, 105, 0.7);
+}
+
+.bulk-sell-selected-item .item-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.bulk-sell-selected-item .item-header .item-icon {
+  width: 20px;
+  height: 20px;
+  image-rendering: pixelated;
+}
+
+.bulk-sell-selected-item .item-header .item-name {
+  flex: 1;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: rgb(226, 232, 240);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.bulk-sell-selected-item .item-header .item-held {
+  font-size: 0.68rem;
+  color: rgb(100, 116, 139);
+  flex-shrink: 0;
+}
+
+.bulk-sell-selected-item .item-header .remove-btn {
+  background: none;
+  border: none;
+  color: rgb(71, 85, 105);
+  cursor: pointer;
+  padding: 0.125rem 0.25rem;
+  font-size: 1.1rem;
+  line-height: 1;
+  border-radius: 0.25rem;
+  transition: all 0.15s;
+}
+
+.bulk-sell-selected-item .item-header .remove-btn:hover {
+  color: rgb(239, 68, 68);
+  background: rgba(239, 68, 68, 0.1);
+}
+
+.bulk-sell-selected-item .item-inputs {
+  display: flex;
+  gap: 0.375rem;
+  align-items: center;
+}
+
+.bulk-sell-selected-item .item-inputs .input-group {
+  flex: 1;
+  display: flex;
+  gap: 0;
+  min-width: 0;
+}
+
+.bulk-sell-selected-item .item-inputs .input-group input {
+  flex: 1;
+  padding: 0.35rem 0.5rem;
+  background: rgba(30, 41, 59, 0.7);
+  border: 1px solid rgba(51, 65, 85, 0.5);
+  border-radius: 0.375rem 0 0 0.375rem;
+  color: white;
+  font-size: 0.8rem;
+  outline: none;
+  min-width: 0;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.bulk-sell-selected-item .item-inputs .input-group input.input-error {
+  border-color: rgba(239, 68, 68, 0.6);
+  box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.08);
+}
+
+.bulk-sell-selected-item .item-inputs .input-group .sell-all-btn {
+  padding: 0.35rem 0.5rem;
+  background: rgba(185, 28, 28, 0.3);
+  border: 1px solid rgba(185, 28, 28, 0.4);
+  border-left: none;
+  border-radius: 0 0.375rem 0.375rem 0;
+  color: rgb(252, 165, 165);
+  font-size: 0.68rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+  letter-spacing: 0.03em;
+}
+
+.bulk-sell-selected-item .item-inputs .input-group .sell-all-btn:hover {
+  background: rgba(185, 28, 28, 0.5);
+  color: white;
+}
+
+.bulk-sell-selected-item .item-inputs > input {
+  flex: 1;
+  padding: 0.35rem 0.5rem;
+  background: rgba(30, 41, 59, 0.7);
+  border: 1px solid rgba(51, 65, 85, 0.5);
+  border-radius: 0.375rem;
+  color: white;
+  font-size: 0.8rem;
+  outline: none;
+  min-width: 0;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.bulk-sell-selected-item .item-inputs input::placeholder {
+  color: rgb(71, 85, 105);
+}
+
+.bulk-sell-selected-item .item-inputs input:focus {
+  border-color: rgba(251, 146, 60, 0.5);
+  box-shadow: 0 0 0 2px rgba(251, 146, 60, 0.08);
+}
+
+.bulk-sell-selected-item .ge-btns {
+  display: flex;
+  gap: 0.25rem;
+  margin-top: 0.35rem;
+}
+
+.bulk-sell-ge-btn {
+  padding: 0.15rem 0.4rem;
+  background: rgba(51, 65, 85, 0.5);
+  border: 1px solid rgba(71, 85, 105, 0.5);
+  border-radius: 0.25rem;
+  cursor: pointer;
+  font-size: 0.68rem;
+  font-weight: 500;
+  transition: all 0.15s;
+}
+
+.bulk-sell-ge-btn:hover {
+  background: rgba(71, 85, 105, 0.6);
+  border-color: rgba(100, 116, 139, 0.4);
+}
+
+.bulk-sell-ge-btn.low {
+  color: rgb(134, 239, 172);
+}
+
+.bulk-sell-ge-btn.high {
+  color: rgb(147, 197, 253);
+}
+
+/* Profit preview per item */
+.bulk-sell-selected-item .profit-preview {
+  padding: 0.375rem 0.5rem;
+  border-radius: 0.375rem;
+  margin-top: 0.4rem;
+  font-size: 0.72rem;
+}
+
+.bulk-sell-selected-item .profit-preview.profit {
+  background: rgba(52, 211, 153, 0.06);
+  border: 1px solid rgba(52, 211, 153, 0.2);
+}
+
+.bulk-sell-selected-item .profit-preview.loss {
+  background: rgba(248, 113, 113, 0.06);
+  border: 1px solid rgba(248, 113, 113, 0.2);
+}
+
+.bulk-sell-selected-item .profit-preview-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1px 0;
+}
+
+.bulk-sell-selected-item .profit-preview-row span:first-child {
+  color: rgb(100, 116, 139);
+}
+
+.bulk-sell-selected-item .profit-preview-row span:last-child {
+  color: rgb(148, 163, 184);
+  font-weight: 500;
+}
+
+.bulk-sell-selected-item .profit-preview-divider {
+  height: 1px;
+  background: rgba(51, 65, 85, 0.5);
+  margin: 3px 0;
+}
+
+.bulk-sell-selected-item .profit-preview-row.profit-row span:last-child {
+  font-weight: 700;
+}
+
+.bulk-sell-selected-item .profit-preview.profit .profit-row span:last-child {
+  color: rgb(52, 211, 153);
+}
+
+.bulk-sell-selected-item .profit-preview.loss .profit-row span:last-child {
+  color: rgb(248, 113, 113);
+}
+
+.bulk-sell-selected-item .profit-pct {
+  margin-left: 0.25rem;
+  opacity: 0.7;
+  font-weight: 500;
+}
+
+.bulk-sell-selected-item .item-error {
+  font-size: 0.68rem;
+  color: rgb(239, 68, 68);
+  margin-top: 0.25rem;
+  font-weight: 500;
+}
+
+.bulk-sell-empty-config {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  color: rgb(71, 85, 105);
+  font-size: 0.82rem;
+  padding: 2rem;
+  text-align: center;
+}
+
+/* Footer */
+.bulk-sell-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1.25rem;
+  border-top: 1px solid rgba(51, 65, 85, 0.6);
+  background: rgba(15, 23, 42, 0.3);
+  flex-shrink: 0;
+}
+
+.bulk-sell-footer-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.bulk-sell-total {
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+
+.bulk-sell-total .label {
+  color: rgb(100, 116, 139);
+  font-weight: 500;
+}
+
+.bulk-sell-total .amount {
+  color: rgb(251, 146, 60);
+  text-shadow: 0 0 20px rgba(251, 146, 60, 0.15);
+}
+
+.bulk-sell-profit {
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.bulk-sell-profit .label {
+  color: rgb(100, 116, 139);
+  font-weight: 500;
+}
+
+.bulk-sell-profit.profit .amount {
+  color: rgb(52, 211, 153);
+}
+
+.bulk-sell-profit.loss .amount {
+  color: rgb(248, 113, 113);
+}
+
+.bulk-sell-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.bulk-sell-actions .btn-confirm {
+  padding: 0.5rem 1.25rem;
+  background: rgb(185, 28, 28);
+  border-radius: 0.5rem;
+  border: none;
+  color: white;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.82rem;
+  transition: all 0.2s ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.bulk-sell-actions .btn-confirm:hover:not(:disabled) {
+  background: rgb(153, 27, 27);
+  box-shadow: 0 2px 8px rgba(239, 68, 68, 0.25);
+}
+
+.bulk-sell-actions .btn-confirm:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.bulk-sell-actions .btn-cancel {
+  padding: 0.5rem 1.25rem;
+  background: rgba(71, 85, 105, 0.5);
+  border-radius: 0.5rem;
+  border: 1px solid rgba(71, 85, 105, 0.3);
+  color: rgb(148, 163, 184);
+  cursor: pointer;
+  font-weight: 500;
+  font-size: 0.82rem;
+  transition: all 0.15s;
+}
+
+.bulk-sell-actions .btn-cancel:hover {
+  background: rgba(71, 85, 105, 0.7);
+  color: white;
+}
+
+/* Responsive */
+@media (max-width: 640px) {
+  .bulk-sell-modal {
+    width: 100%;
+    height: 95vh;
+  }
+
+  .bulk-sell-body {
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr 1fr;
+  }
+
+  .bulk-sell-picker {
+    border-right: none;
+    border-bottom: 1px solid rgba(51, 65, 85, 0.6);
+    max-height: 40vh;
+  }
+}


### PR DESCRIPTION
## Summary
- Add bulk sell modal for selling multiple items at once (closes #176)
- Two-panel layout: searchable item picker (left) with per-item config (right)
- Per-item profit/loss preview with cost basis breakdown
- GE Low/High quick-select price buttons and ALL button for max shares
- Orange/red sell theme with green/red profit indicators
- Full sell transaction flow: stock update, transaction record, profit history entry, and linking

## Test plan
- [ ] Open Bulk Sell modal, verify only stocks with holdings appear
- [ ] Select items, confirm config panel populates with correct prices
- [ ] Test GE Low/High buttons and ALL button
- [ ] Verify per-item profit preview and footer totals
- [ ] Confirm sell with multiple items, check DB for correct stock updates, transactions, and profit entries
- [ ] Test validation: shares > available disables confirm
- [ ] Test responsive layout at mobile breakpoint
- [ ] Test double-click protection

🤖 Generated with [Claude Code](https://claude.com/claude-code)