### PR TITLE
feat: post-confirm summary modal with bulk undo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,40 @@ All data lives in Supabase. Each hook wraps a Supabase table and is called from 
 - `HistoryPage` — transaction history log
 - Static pages: `About`, `Contact`, `PrivacyPolicy`, `CookiePolicy`, `Terms`
 
+### MainApp.jsx structure
+
+`MainApp.jsx` is the orchestrator. Key sections by line area:
+
+- **Imports** (top ~60 lines): all hooks, components, modals
+- **Hook calls** (~line 70-150): `useStocks`, `useTransactions`, `useCategories`, etc.
+- **Modal state** (~line 200-230): `useState` booleans for every modal (`showBuyModal`, `showBulkBuyModal`, etc.) plus `selectedStock`, `isSubmitting`
+- **Handlers** (~line 840-1050): `handleBulkBuy`, `handleBulkSell`, `handleBulkUndo`, `handleSell`, `handleRemoveStock`, etc. Each handler does: guard `isSubmitting` -> mutate via hooks -> `refetch()` -> close modal
+- **JSX modals** (~line 1870-1950): all `<ModalContainer isOpen={...}>` blocks
+
+### Modal pattern
+
+Every modal follows this pattern:
+1. State in MainApp: `const [showXModal, setShowXModal] = useState(false)`
+2. Open: `setShowXModal(true)` (from button click or stock action)
+3. Component in `src/components/modals/XModal.jsx` receives `onConfirm` and `onCancel`
+4. Render: `<ModalContainer isOpen={showXModal}><XModal .../></ModalContainer>`
+5. `ModalContainer` is a fixed overlay with z-index 200, renders null when closed
+
+### CSS conventions
+
+- All styles in `src/styles/components.css` (single file, ~5000+ lines)
+- BEM-like naming: `.component-name`, `.component-name-element`, `.component-name-element.modifier`
+- Modal colors: `rgb(22, 30, 46)` background, `rgba(51, 65, 85, 0.6)` borders
+- Green confirm: `rgb(21, 128, 61)`, gray cancel: `rgba(71, 85, 105, 0.5)`
+- Modal dimensions: `52rem` wide (or smaller for simple modals), `75vh` tall, `0.875rem` border-radius
+- Mobile breakpoint: `@media (max-width: 640px)` -- modals go full width, `95vh`
+
+### Utilities
+
+- `src/utils/formatters.js`: `formatNumber(num, format)`, `parseMK(str)`, `handleMKInput(value)`
+- `src/utils/calculations.js`: profit math
+- `src/utils/taxUtils.js`: GE tax (2%, 5M cap)
+
 ### Design
 
 - Dont use inline CSS

--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -35,6 +35,7 @@ import ModalContainer from './components/modals/ModalContainer';
 import BuyModal from './components/modals/BuyModal';
 import BulkBuyModal from './components/modals/BulkBuyModal';
 import BulkSellModal from './components/modals/BulkSellModal';
+import BulkSummaryModal from './components/modals/BulkSummaryModal';
 import SellModal from './components/modals/SellModal';
 import RemoveStockModal from './components/modals/RemoveStockModal';
 import AdjustModal from './components/modals/AdjustModal';
@@ -202,6 +203,9 @@ export default function MainApp({ session, onLogout }) {
   const [showBuyModal, setShowBuyModal] = useState(false);
   const [showBulkBuyModal, setShowBulkBuyModal] = useState(false);
   const [showBulkSellModal, setShowBulkSellModal] = useState(false);
+  const [bulkSummaryData, setBulkSummaryData] = useState(null);
+  const [isUndoing, setIsUndoing] = useState(false);
+  const [undoResult, setUndoResult] = useState(null);
   const [showSellModal, setShowSellModal] = useState(false);
   const [showRemoveModal, setShowRemoveModal] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -841,6 +845,8 @@ export default function MainApp({ session, onLogout }) {
     setIsSubmitting(true);
 
     try {
+      const completedItems = [];
+
       for (const item of items) {
         const { stock, shares, price, startTimer } = item;
         const total = shares * price;
@@ -869,7 +875,7 @@ export default function MainApp({ session, onLogout }) {
           timerEndTime,
         });
 
-        await addTransaction({
+        const transaction = await addTransaction({
           stockId: stock.id,
           stockName: stock.name,
           type: 'buy',
@@ -878,6 +884,8 @@ export default function MainApp({ session, onLogout }) {
           total,
           date: new Date().toISOString(),
         });
+
+        completedItems.push({ stockName: stock.name, shares, price, total, transaction });
 
         if (startTimer) {
           firedTimerNotifs.current.delete(stock.id);
@@ -889,6 +897,7 @@ export default function MainApp({ session, onLogout }) {
       saveFiredTimers();
       await refetch();
       setShowBulkBuyModal(false);
+      setBulkSummaryData({ type: 'buy', items: completedItems });
     } finally {
       setIsSubmitting(false);
     }
@@ -946,6 +955,8 @@ export default function MainApp({ session, onLogout }) {
     if (isSubmitting) return;
     setIsSubmitting(true);
     try {
+      const completedItems = [];
+
       for (const item of items) {
         const { stock, shares, price } = item;
         const total = shares * price;
@@ -980,14 +991,51 @@ export default function MainApp({ session, onLogout }) {
             .eq('id', newTransaction.id);
         }
 
+        completedItems.push({ stockName: stock.name, shares, price, total, transaction: newTransaction, profitEntry, profit });
+
         highlightRow(stock.id);
       }
 
       await refetch();
       setShowBulkSellModal(false);
+      setBulkSummaryData({ type: 'sell', items: completedItems });
     } finally {
       setIsSubmitting(false);
     }
+  };
+
+  const handleBulkUndo = async () => {
+    if (!bulkSummaryData || isUndoing) return;
+    setIsUndoing(true);
+
+    const items = [...bulkSummaryData.items].reverse();
+    let undoneCount = 0;
+    let failedCount = 0;
+    const errors = [];
+
+    for (const item of items) {
+      if (!item.transaction) {
+        failedCount++;
+        errors.push(`${item.stockName}: no transaction reference`);
+        continue;
+      }
+      const result = await undoTransaction(item.transaction);
+      if (result.success) {
+        undoneCount++;
+      } else {
+        failedCount++;
+        errors.push(`${item.stockName}: ${result.warning || result.error || 'unknown error'}`);
+      }
+    }
+
+    await refetch();
+    setUndoResult({ success: failedCount === 0, undoneCount, failedCount, errors });
+    setIsUndoing(false);
+  };
+
+  const handleBulkSummaryDone = () => {
+    setBulkSummaryData(null);
+    setUndoResult(null);
   };
 
   const handleRemoveStock = async (data) => {
@@ -1894,6 +1942,17 @@ export default function MainApp({ session, onLogout }) {
                 onConfirm={handleBulkSell}
                 onCancel={() => setShowBulkSellModal(false)}
                 isSubmitting={isSubmitting}
+              />
+            </ModalContainer>
+
+            <ModalContainer isOpen={bulkSummaryData !== null}>
+              <BulkSummaryModal
+                type={bulkSummaryData?.type}
+                completedItems={bulkSummaryData?.items || []}
+                onUndo={handleBulkUndo}
+                onDone={handleBulkSummaryDone}
+                isUndoing={isUndoing}
+                undoResult={undoResult}
               />
             </ModalContainer>
 

--- a/src/components/modals/BulkSummaryModal.jsx
+++ b/src/components/modals/BulkSummaryModal.jsx
@@ -1,0 +1,127 @@
+import React, { useState } from 'react';
+import { CheckCircle, Undo2, AlertTriangle, Loader2 } from 'lucide-react';
+import { formatNumber } from '../../utils/formatters';
+
+export default function BulkSummaryModal({ type, completedItems, onUndo, onDone, isUndoing, undoResult }) {
+  const [confirmUndo, setConfirmUndo] = useState(false);
+  const isBuy = type === 'buy';
+
+  const totalGP = completedItems.reduce((sum, item) => sum + item.total, 0);
+  const totalProfit = isBuy ? null : completedItems.reduce((sum, item) => sum + (item.profit || 0), 0);
+
+  const handleUndoClick = () => {
+    if (!confirmUndo) {
+      setConfirmUndo(true);
+      return;
+    }
+    onUndo();
+  };
+
+  const undone = undoResult !== null;
+
+  return (
+    <div className="bulk-summary-modal">
+      <div className="bulk-summary-header">
+        <div className="bulk-summary-header-icon">
+          {undone && !undoResult.success
+            ? <AlertTriangle size={22} />
+            : <CheckCircle size={22} />
+          }
+        </div>
+        <div className="bulk-summary-header-text">
+          <h2>
+            {undone
+              ? (undoResult.success ? 'Undo Complete' : 'Partial Undo')
+              : `Bulk ${isBuy ? 'Buy' : 'Sell'} Complete`
+            }
+          </h2>
+          <span className="bulk-summary-item-count">
+            {completedItems.length} item{completedItems.length !== 1 ? 's' : ''} {isBuy ? 'purchased' : 'sold'}
+          </span>
+        </div>
+      </div>
+
+      <div className="bulk-summary-receipt">
+        <div className="bulk-summary-receipt-header">
+          <span>Item</span>
+          <span>Qty</span>
+          <span>Price</span>
+          <span>Total</span>
+        </div>
+        <div className="bulk-summary-lines">
+          {completedItems.map((item, i) => (
+            <div className="bulk-summary-line" key={i}>
+              <span className="bulk-summary-line-name">{item.stockName}</span>
+              <span className="bulk-summary-line-qty">{formatNumber(item.shares)}</span>
+              <span className="bulk-summary-line-price">{formatNumber(item.price)}</span>
+              <span className="bulk-summary-line-total">{formatNumber(item.total)}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="bulk-summary-totals">
+        <div className="bulk-summary-totals-row">
+          <span className="bulk-summary-totals-label">
+            Total {isBuy ? 'Spent' : 'Received'}
+          </span>
+          <span className={`bulk-summary-totals-amount ${isBuy ? 'cost' : 'revenue'}`}>
+            {formatNumber(totalGP)} GP
+          </span>
+        </div>
+        {!isBuy && totalProfit !== null && (
+          <div className="bulk-summary-totals-row">
+            <span className="bulk-summary-totals-label">Total Profit</span>
+            <span className={`bulk-summary-totals-amount ${totalProfit >= 0 ? 'profit' : 'loss'}`}>
+              {totalProfit >= 0 ? '+' : ''}{formatNumber(totalProfit)} GP
+            </span>
+          </div>
+        )}
+      </div>
+
+      {undone && undoResult.errors.length > 0 && (
+        <div className="bulk-summary-undo-errors">
+          {undoResult.errors.map((err, i) => (
+            <div className="bulk-summary-undo-error" key={i}>
+              <AlertTriangle size={13} />
+              <span>{err}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="bulk-summary-footer">
+        {undone ? (
+          <div className="bulk-summary-undo-result">
+            <span className={undoResult.success ? 'undo-success' : 'undo-partial'}>
+              {undoResult.success
+                ? `All ${undoResult.undoneCount} transactions reversed`
+                : `${undoResult.undoneCount} reversed, ${undoResult.failedCount} failed`
+              }
+            </span>
+            <button className="bulk-summary-done-btn" onClick={onDone}>Close</button>
+          </div>
+        ) : (
+          <div className="bulk-summary-actions">
+            <button
+              className={`bulk-summary-undo-btn ${confirmUndo ? 'confirm' : ''}`}
+              onClick={handleUndoClick}
+              disabled={isUndoing}
+            >
+              {isUndoing ? (
+                <><Loader2 size={14} className="bulk-summary-spinner" /> Undoing...</>
+              ) : confirmUndo ? (
+                <><Undo2 size={14} /> Are you sure?</>
+              ) : (
+                <><Undo2 size={14} /> Undo All</>
+              )}
+            </button>
+            <button className="bulk-summary-done-btn" onClick={onDone} disabled={isUndoing}>
+              Done
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -5118,3 +5118,335 @@
     max-height: 40vh;
   }
 }
+
+/* =============================================
+   Bulk Summary Modal
+   ============================================= */
+
+.bulk-summary-modal {
+  background: rgb(22, 30, 46);
+  border-radius: 0.875rem;
+  width: 28rem;
+  max-width: 95vw;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow:
+    0 0 0 1px rgba(148, 163, 184, 0.08),
+    0 4px 24px rgba(0, 0, 0, 0.4),
+    0 24px 48px -12px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+}
+
+/* Header */
+.bulk-summary-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1.25rem 1.5rem 1rem;
+  border-bottom: 1px solid rgba(51, 65, 85, 0.4);
+}
+
+.bulk-summary-header-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  background: rgba(34, 197, 94, 0.12);
+  color: rgb(74, 222, 128);
+  flex-shrink: 0;
+}
+
+.bulk-summary-header-icon:has(.lucide-alert-triangle) {
+  background: rgba(251, 146, 60, 0.12);
+  color: rgb(251, 146, 60);
+}
+
+.bulk-summary-header-text h2 {
+  font-size: 1.05rem;
+  font-weight: 700;
+  margin: 0;
+  color: rgb(241, 245, 249);
+  letter-spacing: -0.01em;
+}
+
+.bulk-summary-item-count {
+  font-size: 0.75rem;
+  color: rgb(100, 116, 139);
+  font-weight: 500;
+}
+
+/* Receipt */
+.bulk-summary-receipt {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0 1.5rem;
+}
+
+.bulk-summary-receipt::-webkit-scrollbar {
+  width: 4px;
+}
+
+.bulk-summary-receipt::-webkit-scrollbar-thumb {
+  background: rgba(100, 116, 139, 0.3);
+  border-radius: 4px;
+}
+
+.bulk-summary-receipt-header {
+  display: grid;
+  grid-template-columns: 1fr 4rem 5rem 5.5rem;
+  gap: 0.5rem;
+  padding: 0.625rem 0;
+  border-bottom: 2px dashed rgba(51, 65, 85, 0.35);
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: rgb(100, 116, 139);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.bulk-summary-receipt-header span:nth-child(n+2) {
+  text-align: right;
+}
+
+.bulk-summary-lines {
+  padding: 0.25rem 0;
+}
+
+.bulk-summary-line {
+  display: grid;
+  grid-template-columns: 1fr 4rem 5rem 5.5rem;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid rgba(51, 65, 85, 0.15);
+  font-size: 0.82rem;
+  align-items: center;
+}
+
+.bulk-summary-line:last-child {
+  border-bottom: none;
+}
+
+.bulk-summary-line-name {
+  color: rgb(226, 232, 240);
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.bulk-summary-line-qty {
+  color: rgb(148, 163, 184);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.bulk-summary-line-price {
+  color: rgb(148, 163, 184);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.bulk-summary-line-total {
+  color: rgb(226, 232, 240);
+  text-align: right;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Totals */
+.bulk-summary-totals {
+  padding: 0.75rem 1.5rem;
+  border-top: 2px dashed rgba(51, 65, 85, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.bulk-summary-totals-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.bulk-summary-totals-label {
+  font-size: 0.78rem;
+  color: rgb(100, 116, 139);
+  font-weight: 500;
+}
+
+.bulk-summary-totals-amount {
+  font-size: 0.95rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.bulk-summary-totals-amount.cost {
+  color: rgb(251, 146, 60);
+}
+
+.bulk-summary-totals-amount.revenue {
+  color: rgb(74, 222, 128);
+}
+
+.bulk-summary-totals-amount.profit {
+  color: rgb(74, 222, 128);
+}
+
+.bulk-summary-totals-amount.loss {
+  color: rgb(248, 113, 113);
+}
+
+/* Undo errors */
+.bulk-summary-undo-errors {
+  padding: 0.5rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  max-height: 6rem;
+  overflow-y: auto;
+}
+
+.bulk-summary-undo-error {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.72rem;
+  color: rgb(251, 146, 60);
+  background: rgba(251, 146, 60, 0.08);
+  padding: 0.35rem 0.625rem;
+  border-radius: 0.375rem;
+}
+
+.bulk-summary-undo-error svg {
+  flex-shrink: 0;
+}
+
+/* Footer */
+.bulk-summary-footer {
+  padding: 0.875rem 1.5rem;
+  border-top: 1px solid rgba(51, 65, 85, 0.4);
+  background: rgba(15, 23, 42, 0.25);
+}
+
+.bulk-summary-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.bulk-summary-undo-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 1rem;
+  background: rgba(127, 29, 29, 0.2);
+  border: 1px solid rgba(185, 28, 28, 0.35);
+  border-radius: 0.5rem;
+  color: rgb(252, 165, 165);
+  cursor: pointer;
+  font-weight: 500;
+  font-size: 0.8rem;
+  transition: all 0.2s ease;
+}
+
+.bulk-summary-undo-btn:hover:not(:disabled) {
+  background: rgba(185, 28, 28, 0.3);
+  border-color: rgba(185, 28, 28, 0.5);
+  color: rgb(254, 202, 202);
+}
+
+.bulk-summary-undo-btn.confirm {
+  background: rgba(185, 28, 28, 0.35);
+  border-color: rgba(220, 38, 38, 0.6);
+  color: rgb(254, 202, 202);
+  animation: bulk-summary-pulse 1.5s ease-in-out infinite;
+}
+
+.bulk-summary-undo-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.bulk-summary-spinner {
+  animation: bulk-summary-spin 0.8s linear infinite;
+}
+
+@keyframes bulk-summary-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@keyframes bulk-summary-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(220, 38, 38, 0.25); }
+  50% { box-shadow: 0 0 0 4px rgba(220, 38, 38, 0.1); }
+}
+
+.bulk-summary-done-btn {
+  padding: 0.5rem 1.5rem;
+  background: rgb(21, 128, 61);
+  border-radius: 0.5rem;
+  border: none;
+  color: white;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.82rem;
+  transition: all 0.2s ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.bulk-summary-done-btn:hover:not(:disabled) {
+  background: rgb(22, 163, 74);
+  box-shadow: 0 2px 8px rgba(34, 197, 94, 0.25);
+}
+
+.bulk-summary-done-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+/* Undo result */
+.bulk-summary-undo-result {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.bulk-summary-undo-result .undo-success {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: rgb(74, 222, 128);
+}
+
+.bulk-summary-undo-result .undo-partial {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: rgb(251, 146, 60);
+}
+
+/* Responsive */
+@media (max-width: 640px) {
+  .bulk-summary-modal {
+    width: 100%;
+    max-height: 95vh;
+  }
+
+  .bulk-summary-receipt-header,
+  .bulk-summary-line {
+    grid-template-columns: 1fr 3.5rem 4rem 4.5rem;
+    gap: 0.25rem;
+  }
+
+  .bulk-summary-line-name {
+    font-size: 0.78rem;
+  }
+
+  .bulk-summary-line-qty,
+  .bulk-summary-line-price,
+  .bulk-summary-line-total {
+    font-size: 0.75rem;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a receipt-style summary modal that appears after bulk buy/sell operations complete
- Shows each item processed with quantity, price, and total GP
- Includes an "Undo All" button that reverses the entire batch using existing `undoTransaction()` in LIFO order
- Two-step undo confirmation (click once to arm, again to confirm) with loading state and partial failure reporting
- Updates CLAUDE.md with MainApp structure, modal pattern, and CSS conventions for faster future development

Closes #163

## Test plan
- [ ] Run `npm run dev`, perform a bulk buy with 2-3 items, verify summary appears with correct totals
- [ ] Click "Done" to dismiss, verify it closes cleanly
- [ ] Perform another bulk buy, click "Undo All", confirm, verify all transactions are reversed
- [ ] Repeat for bulk sell, verify profit entries are also cleaned up
- [ ] Test at 640px viewport for mobile layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)