### PR TITLE
refactor(modals): combine bulk buy/sell into shared handler

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -840,64 +840,111 @@ export default function MainApp({ session, onLogout }) {
     }
   };
 
-  const handleBulkBuy = async (items) => {
+  const processBuyItem = async (item) => {
+    const { stock, shares, price, startTimer } = item;
+    const total = shares * price;
+    const newShares = stock.shares + shares;
+
+    let timerEndTime;
+    let newOnHold = stock.onHold;
+
+    if (startTimer) {
+      timerEndTime = Date.now() + (4 * 60 * 60 * 1000);
+      newOnHold = false;
+    } else {
+      timerEndTime = stock.timerEndTime;
+    }
+
+    const timerJustEnded = stock.timerEndTime && stock.timerEndTime <= Date.now();
+    if (timerJustEnded && newShares < stock.needed && stock.onHold) {
+      newOnHold = true;
+    } else if (newShares >= stock.needed) {
+      newOnHold = false;
+    }
+
+    await updateStock(stock.id, {
+      totalCost: stock.totalCost + total,
+      shares: newShares,
+      timerEndTime,
+    });
+
+    const transaction = await addTransaction({
+      stockId: stock.id,
+      stockName: stock.name,
+      type: 'buy',
+      shares,
+      price,
+      total,
+      date: new Date().toISOString(),
+    });
+
+    if (startTimer) {
+      firedTimerNotifs.current.delete(stock.id);
+    }
+
+    return { stockName: stock.name, shares, price, total, transaction };
+  };
+
+  const processSellItem = async (item) => {
+    const { stock, shares, price } = item;
+    const total = shares * price;
+    const avgBuy = stock.shares > 0 ? stock.totalCost / stock.shares : 0;
+    const costBasisOfSharesSold = avgBuy * shares;
+    const profit = total - costBasisOfSharesSold;
+
+    await updateStock(stock.id, {
+      shares: stock.shares - shares,
+      totalCost: stock.totalCost - costBasisOfSharesSold,
+      sharesSold: stock.sharesSold + shares,
+      totalCostSold: stock.totalCostSold + total,
+      totalCostBasisSold: (stock.totalCostBasisSold || 0) + costBasisOfSharesSold
+    });
+
+    const transaction = await addTransaction({
+      stockId: stock.id,
+      stockName: stock.name,
+      type: 'sell',
+      shares,
+      price,
+      total,
+      date: new Date().toISOString(),
+    });
+
+    const profitEntry = await addProfitEntry('stock', profit, stock.id, transaction?.id ?? null);
+
+    if (transaction && profitEntry) {
+      await supabase
+        .from('transactions')
+        .update({ profit_history_id: profitEntry.id })
+        .eq('id', transaction.id);
+    }
+
+    return { stockName: stock.name, shares, price, total, transaction, profitEntry, profit };
+  };
+
+  const handleBulkOperation = async (type, items, closeModal) => {
     if (isSubmitting) return;
     setIsSubmitting(true);
 
     try {
       const completedItems = [];
+      const processItem = type === 'buy' ? processBuyItem : processSellItem;
 
       for (const item of items) {
-        const { stock, shares, price, startTimer } = item;
-        const total = shares * price;
-        const newShares = stock.shares + shares;
-
-        let timerEndTime;
-        let newOnHold = stock.onHold;
-
-        if (startTimer) {
-          timerEndTime = Date.now() + (4 * 60 * 60 * 1000);
-          newOnHold = false;
-        } else {
-          timerEndTime = stock.timerEndTime;
-        }
-
-        const timerJustEnded = stock.timerEndTime && stock.timerEndTime <= Date.now();
-        if (timerJustEnded && newShares < stock.needed && stock.onHold) {
-          newOnHold = true;
-        } else if (newShares >= stock.needed) {
-          newOnHold = false;
-        }
-
-        await updateStock(stock.id, {
-          totalCost: stock.totalCost + total,
-          shares: newShares,
-          timerEndTime,
-        });
-
-        const transaction = await addTransaction({
-          stockId: stock.id,
-          stockName: stock.name,
-          type: 'buy',
-          shares,
-          price,
-          total,
-          date: new Date().toISOString(),
-        });
-
-        completedItems.push({ stockName: stock.name, shares, price, total, transaction });
-
-        if (startTimer) {
-          firedTimerNotifs.current.delete(stock.id);
-        }
-
-        highlightRow(stock.id);
+        const completed = await processItem(item);
+        completedItems.push(completed);
+        highlightRow(item.stock.id);
       }
 
-      saveFiredTimers();
+      if (type === 'buy') {
+        saveFiredTimers();
+      }
+
       await refetch();
-      setShowBulkBuyModal(false);
-      setBulkSummaryData({ type: 'buy', items: completedItems });
+      closeModal(false);
+      if (items.length > 1) {
+        setBulkSummaryData({ type, items: completedItems });
+      }
     } finally {
       setIsSubmitting(false);
     }
@@ -907,101 +954,12 @@ export default function MainApp({ session, onLogout }) {
 
 
   const handleSell = async (data) => {
-    if (isSubmitting) return;
-    setIsSubmitting(true);
     const { shares, price } = data;
-    const total = shares * price;
-
-    const avgBuy = selectedStock.shares > 0 ? selectedStock.totalCost / selectedStock.shares : 0;
-    const costBasisOfSharesSold = avgBuy * shares;
-    const profit = total - costBasisOfSharesSold;
-
-    try {
-      await updateStock(selectedStock.id, {
-        shares: selectedStock.shares - shares,
-        totalCost: selectedStock.totalCost - costBasisOfSharesSold,
-        sharesSold: selectedStock.sharesSold + shares,
-        totalCostSold: selectedStock.totalCostSold + total,
-        totalCostBasisSold: (selectedStock.totalCostBasisSold || 0) + costBasisOfSharesSold
-      });
-
-      const newTransaction = await addTransaction({
-        stockId: selectedStock.id,
-        stockName: selectedStock.name,
-        type: 'sell',
-        shares,
-        price,
-        total,
-        date: new Date().toISOString()
-      });
-
-      const profitEntry = await addProfitEntry('stock', profit, selectedStock.id, newTransaction?.id ?? null);
-
-      if (newTransaction && profitEntry) {
-        await supabase
-          .from('transactions')
-          .update({ profit_history_id: profitEntry.id })
-          .eq('id', newTransaction.id);
-      }
-      await refetch();
-      highlightRow(selectedStock.id);
-      setShowSellModal(false);
-    } finally {
-      setIsSubmitting(false);
-    }
+    await handleBulkOperation('sell', [{ stock: selectedStock, shares, price }], setShowSellModal);
   };
 
   const handleBulkSell = async (items) => {
-    if (isSubmitting) return;
-    setIsSubmitting(true);
-    try {
-      const completedItems = [];
-
-      for (const item of items) {
-        const { stock, shares, price } = item;
-        const total = shares * price;
-        const avgBuy = stock.shares > 0 ? stock.totalCost / stock.shares : 0;
-        const costBasisOfSharesSold = avgBuy * shares;
-        const profit = total - costBasisOfSharesSold;
-
-        await updateStock(stock.id, {
-          shares: stock.shares - shares,
-          totalCost: stock.totalCost - costBasisOfSharesSold,
-          sharesSold: stock.sharesSold + shares,
-          totalCostSold: stock.totalCostSold + total,
-          totalCostBasisSold: (stock.totalCostBasisSold || 0) + costBasisOfSharesSold
-        });
-
-        const newTransaction = await addTransaction({
-          stockId: stock.id,
-          stockName: stock.name,
-          type: 'sell',
-          shares,
-          price,
-          total,
-          date: new Date().toISOString()
-        });
-
-        const profitEntry = await addProfitEntry('stock', profit, stock.id, newTransaction?.id ?? null);
-
-        if (newTransaction && profitEntry) {
-          await supabase
-            .from('transactions')
-            .update({ profit_history_id: profitEntry.id })
-            .eq('id', newTransaction.id);
-        }
-
-        completedItems.push({ stockName: stock.name, shares, price, total, transaction: newTransaction, profitEntry, profit });
-
-        highlightRow(stock.id);
-      }
-
-      await refetch();
-      setShowBulkSellModal(false);
-      setBulkSummaryData({ type: 'sell', items: completedItems });
-    } finally {
-      setIsSubmitting(false);
-    }
+    await handleBulkOperation('sell', items, setShowBulkSellModal);
   };
 
   const handleBulkUndo = async () => {
@@ -1926,7 +1884,7 @@ export default function MainApp({ session, onLogout }) {
                 tradeMode={tradeMode}
                 gePrices={gePrices}
                 geIconMap={geIconMap}
-                onConfirm={handleBulkBuy}
+                onConfirm={(items) => handleBulkOperation('buy', items, setShowBulkBuyModal)}
                 onCancel={() => setShowBulkBuyModal(false)}
                 isSubmitting={isSubmitting}
               />

--- a/src/components/modals/BulkSummaryModal.jsx
+++ b/src/components/modals/BulkSummaryModal.jsx
@@ -42,19 +42,25 @@ export default function BulkSummaryModal({ type, completedItems, onUndo, onDone,
       </div>
 
       <div className="bulk-summary-receipt">
-        <div className="bulk-summary-receipt-header">
+        <div className={`bulk-summary-receipt-header ${!isBuy ? 'with-profit' : ''}`}>
           <span>Item</span>
           <span>Qty</span>
           <span>Price</span>
           <span>Total</span>
+          {!isBuy && <span>Profit</span>}
         </div>
         <div className="bulk-summary-lines">
           {completedItems.map((item, i) => (
-            <div className="bulk-summary-line" key={i}>
+            <div className={`bulk-summary-line ${!isBuy ? 'with-profit' : ''}`} key={i}>
               <span className="bulk-summary-line-name">{item.stockName}</span>
               <span className="bulk-summary-line-qty">{formatNumber(item.shares)}</span>
               <span className="bulk-summary-line-price">{formatNumber(item.price)}</span>
               <span className="bulk-summary-line-total">{formatNumber(item.total)}</span>
+              {!isBuy && (
+                <span className={`bulk-summary-line-profit ${item.profit >= 0 ? 'profit' : 'loss'}`}>
+                  {item.profit >= 0 ? '+' : ''}{formatNumber(item.profit)}
+                </span>
+              )}
             </div>
           ))}
         </div>

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -5126,7 +5126,7 @@
 .bulk-summary-modal {
   background: rgb(22, 30, 46);
   border-radius: 0.875rem;
-  width: 28rem;
+  width: 36rem;
   max-width: 95vw;
   max-height: 80vh;
   display: flex;
@@ -5195,6 +5195,10 @@
   border-radius: 4px;
 }
 
+.bulk-summary-receipt-header.with-profit {
+  grid-template-columns: 1fr 4rem 5rem 5.5rem 5.5rem;
+}
+
 .bulk-summary-receipt-header {
   display: grid;
   grid-template-columns: 1fr 4rem 5rem 5.5rem;
@@ -5214,6 +5218,10 @@
 
 .bulk-summary-lines {
   padding: 0.25rem 0;
+}
+
+.bulk-summary-line.with-profit {
+  grid-template-columns: 1fr 4rem 5rem 5.5rem 5.5rem;
 }
 
 .bulk-summary-line {
@@ -5255,6 +5263,20 @@
   text-align: right;
   font-weight: 600;
   font-variant-numeric: tabular-nums;
+}
+
+.bulk-summary-line-profit {
+  text-align: right;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.bulk-summary-line-profit.profit {
+  color: rgb(34, 197, 94);
+}
+
+.bulk-summary-line-profit.loss {
+  color: rgb(239, 68, 68);
 }
 
 /* Totals */
@@ -5440,13 +5462,19 @@
     gap: 0.25rem;
   }
 
+  .bulk-summary-receipt-header.with-profit,
+  .bulk-summary-line.with-profit {
+    grid-template-columns: 1fr 3.5rem 4rem 4.5rem 4.5rem;
+  }
+
   .bulk-summary-line-name {
     font-size: 0.78rem;
   }
 
   .bulk-summary-line-qty,
   .bulk-summary-line-price,
-  .bulk-summary-line-total {
+  .bulk-summary-line-total,
+  .bulk-summary-line-profit {
     font-size: 0.75rem;
   }
 }


### PR DESCRIPTION
## Summary
- Consolidated `handleBulkBuy`, `handleBulkSell`, and `handleSell` into a single `handleBulkOperation(type, items, closeModal)` with `processBuyItem` / `processSellItem` helpers
- Added per-item profit column to the bulk sell summary modal (green/red coloring)
- Widened summary modal from 28rem to 36rem to prevent name truncation

Closes #181

## Test plan
- [ ] Bulk buy 2+ items, verify stocks update and summary modal shows
- [ ] Bulk sell 2+ items, verify profit column shows per-item profit with correct coloring
- [ ] Single sell via sell modal, verify it works and bulk summary does NOT appear
- [ ] Test undo from bulk summary modal
- [ ] Check mobile layout for summary modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)