### PR TITLE
feat(modals): add step buttons and arrow key support to numeric inputs

### DIFF
--- a/src/components/StepInput.jsx
+++ b/src/components/StepInput.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export default function StepInput({ onStep, className, wrapperStyle, ...props }) {
+  return (
+    <div className="input-step-wrapper" style={wrapperStyle}>
+      <input
+        className={`input-step-field${className ? ` ${className}` : ''}`}
+        onKeyDown={(e) => {
+          if (e.key === 'ArrowUp') { e.preventDefault(); onStep(1); }
+          else if (e.key === 'ArrowDown') { e.preventDefault(); onStep(-1); }
+        }}
+        {...props}
+      />
+      <div className="input-step-btns">
+        <button type="button" className="input-step-btn" onClick={() => onStep(1)}>▲</button>
+        <button type="button" className="input-step-btn" onClick={() => onStep(-1)}>▼</button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/modals/AdjustModal.jsx
+++ b/src/components/modals/AdjustModal.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo, useRef, useEffect } from 'react';
 import { handleMKInput } from '../../utils/formatters';
+import StepInput from '../StepInput';
 
 export default function AdjustModal({ stock, categories, mapping = [], onConfirm, onCancel }) {
   const [stockType, setStockType] = useState(stock.itemId ? 'osrs' : 'custom');
@@ -225,10 +226,11 @@ export default function AdjustModal({ stock, categories, mapping = [], onConfirm
           <label style={{ display: 'block', fontSize: '0.875rem', fontWeight: '500', color: 'rgb(209, 213, 219)', marginBottom: '0.5rem' }}>
             4H Limit
           </label>
-          <input
+          <StepInput
             type="text"
             value={limit4h}
             onChange={(e) => handleMKInput(e.target.value, setLimit4h)}
+            onStep={(d) => setLimit4h(prev => Math.max(0, (parseFloat(prev) || 0) + d).toString())}
             placeholder="Enter 4h limit (e.g. 10k)"
             style={inputStyle}
             onFocus={(e) => e.target.style.borderColor = focusColor}
@@ -241,10 +243,11 @@ export default function AdjustModal({ stock, categories, mapping = [], onConfirm
           <label style={{ display: 'block', fontSize: '0.875rem', fontWeight: '500', color: 'rgb(209, 213, 219)', marginBottom: '0.5rem' }}>
             Desired Stock
           </label>
-          <input
+          <StepInput
             type="text"
             value={needed}
             onChange={(e) => handleMKInput(e.target.value, setNeeded)}
+            onStep={(d) => setNeeded(prev => Math.max(0, (parseFloat(prev) || 0) + d).toString())}
             placeholder="Enter desired stock (e.g. 100k)"
             style={inputStyle}
             onFocus={(e) => e.target.style.borderColor = focusColor}

--- a/src/components/modals/AltTimerModal.jsx
+++ b/src/components/modals/AltTimerModal.jsx
@@ -3,6 +3,8 @@ import React, { useState } from 'react';
 export default function AltTimerModal({ onConfirm, onCancel }) {
   const [days, setDays] = useState(7);
 
+  const stepDays = (delta) => setDays(prev => Math.max(1, Math.min(365, prev + delta)));
+
   const handleSubmit = (e) => {
     e.preventDefault();
     if (days > 0) {
@@ -32,22 +34,33 @@ export default function AltTimerModal({ onConfirm, onCancel }) {
           <label style={{ display: 'block', fontSize: '0.875rem', fontWeight: '600', marginBottom: '0.5rem' }}>
             Days until check:
           </label>
-          <input
-            type="number"
-            value={days}
-            onChange={(e) => setDays(Number(e.target.value))}
-            min="1"
-            max="365"
-            style={{
-              width: '100%',
-              padding: '0.75rem',
-              background: 'rgb(15, 23, 42)',
-              border: '1px solid rgb(51, 65, 85)',
-              borderRadius: '0.5rem',
-              color: 'white',
-              fontSize: '1rem'
-            }}
-          />
+          <div className="input-step-wrapper">
+            <input
+              className="input-step-field"
+              type="number"
+              value={days}
+              onChange={(e) => setDays(Number(e.target.value))}
+              min="1"
+              max="365"
+              style={{
+                width: '100%',
+                padding: '0.75rem',
+                background: 'rgb(15, 23, 42)',
+                border: '1px solid rgb(51, 65, 85)',
+                borderRadius: '0.5rem',
+                color: 'white',
+                fontSize: '1rem'
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'ArrowUp') { e.preventDefault(); stepDays(1); }
+                else if (e.key === 'ArrowDown') { e.preventDefault(); stepDays(-1); }
+              }}
+            />
+            <div className="input-step-btns">
+              <button type="button" className="input-step-btn" onClick={() => stepDays(1)}>▲</button>
+              <button type="button" className="input-step-btn" onClick={() => stepDays(-1)}>▼</button>
+            </div>
+          </div>
         </div>
         <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'flex-end' }}>
           <button

--- a/src/components/modals/BulkBuyModal.jsx
+++ b/src/components/modals/BulkBuyModal.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import { formatNumber, parseMK, handleMKInput } from '../../utils/formatters';
 import '../../styles/bulk-modals.css';
+import StepInput from '../StepInput';
 
 export default function BulkBuyModal({ stocks, categories = [], tradeMode = 'trade', gePrices = {}, geIconMap = {}, onConfirm, onCancel, isSubmitting = false }) {
   const [mode, setMode] = useState('perItem');
@@ -252,10 +253,11 @@ export default function BulkBuyModal({ stocks, categories = [], tradeMode = 'tra
           {mode === 'budgetSplit' && (
             <div className="bulk-buy-budget-row">
               <label>Total Budget (GP)</label>
-              <input
+              <StepInput
                 type="text"
                 value={budget}
                 onChange={(e) => handleMKInput(e.target.value, setBudget)}
+                onStep={(d) => setBudget(prev => Math.max(0, (parseFloat(prev) || 0) + d).toString())}
                 placeholder="e.g. 100m"
               />
             </div>
@@ -285,16 +287,18 @@ export default function BulkBuyModal({ stocks, categories = [], tradeMode = 'tra
                     {mode === 'perItem' ? (
                       <>
                         <div className="item-inputs">
-                          <input
+                          <StepInput
                             type="text"
                             value={item.shares}
                             onChange={(e) => handleSharesInput(id, e.target.value)}
+                            onStep={(d) => updateItem(id, 'shares', Math.max(0, (parseFloat(item.shares) || 0) + d).toString())}
                             placeholder="Shares"
                           />
-                          <input
+                          <StepInput
                             type="text"
                             value={item.price}
                             onChange={(e) => handlePriceInput(id, e.target.value)}
+                            onStep={(d) => updateItem(id, 'price', Math.max(0, (parseFloat(item.price) || 0) + d).toString())}
                             placeholder="Price"
                           />
                         </div>
@@ -327,10 +331,11 @@ export default function BulkBuyModal({ stocks, categories = [], tradeMode = 'tra
                     ) : (
                       <>
                         <div className="item-inputs">
-                          <input
+                          <StepInput
                             type="text"
                             value={item.price}
                             onChange={(e) => handlePriceInput(id, e.target.value)}
+                            onStep={(d) => updateItem(id, 'price', Math.max(0, (parseFloat(item.price) || 0) + d).toString())}
                             placeholder="Buy price"
                           />
                         </div>

--- a/src/components/modals/BulkSellModal.jsx
+++ b/src/components/modals/BulkSellModal.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import { formatNumber, handleMKInput } from '../../utils/formatters';
 import '../../styles/bulk-modals.css';
+import StepInput from '../StepInput';
 
 export default function BulkSellModal({ stocks, categories = [], tradeMode = 'trade', gePrices = {}, geIconMap = {}, onConfirm, onCancel, isSubmitting = false }) {
   const [searchQuery, setSearchQuery] = useState('');
@@ -216,10 +217,11 @@ export default function BulkSellModal({ stocks, categories = [], tradeMode = 'tr
 
                     <div className="item-inputs">
                       <div className="input-group">
-                        <input
+                        <StepInput
                           type="text"
                           value={item.shares}
                           onChange={(e) => handleSharesInput(id, e.target.value)}
+                          onStep={(d) => updateItem(id, 'shares', Math.max(0, Math.min(stock.shares, (parseFloat(item.shares) || 0) + d)).toString())}
                           placeholder="Qty"
                           className={overMax ? 'input-error' : ''}
                         />
@@ -230,10 +232,11 @@ export default function BulkSellModal({ stocks, categories = [], tradeMode = 'tr
                           ALL
                         </button>
                       </div>
-                      <input
+                      <StepInput
                         type="text"
                         value={item.price}
                         onChange={(e) => handlePriceInput(id, e.target.value)}
+                        onStep={(d) => updateItem(id, 'price', Math.max(0, (parseFloat(item.price) || 0) + d).toString())}
                         placeholder="Price"
                       />
                     </div>

--- a/src/components/modals/BuyModal.jsx
+++ b/src/components/modals/BuyModal.jsx
@@ -82,6 +82,23 @@ export default function BuyModal({ stock, onConfirm, onCancel, geData = {}, isSu
     }
   };
 
+  const stepShares = (delta) => {
+    const current = parseFloat(parseMK(shares)) || 0;
+    const newVal = Math.max(0, current + delta);
+    setShares(newVal.toString());
+    if (price) setTotalAmount((newVal * parseFloat(price)).toFixed(0));
+  };
+
+  const stepPrice = (delta) => {
+    if (useTotal) {
+      const current = parseFloat(totalAmount) || 0;
+      handleTotalChange(Math.max(0, current + delta).toString());
+    } else {
+      const current = parseFloat(price) || 0;
+      handlePriceChange(Math.max(0, current + delta).toString());
+    }
+  };
+
   const handleConfirm = () => {
     if (useTotal) {
       if (!shares || !totalAmount) return;
@@ -167,23 +184,34 @@ export default function BuyModal({ stock, onConfirm, onCancel, geData = {}, isSu
               </button>
             ))}
           </div>
-          <input
-            type="text"
-            value={shares}
-            onChange={(e) => handleMKInput(e.target.value, setShares)}
-            placeholder="Number of shares (e.g. 10k)"
-            style={{
-              width: '100%',
-              padding: '0.5rem 1rem',
-              background: 'rgb(51, 65, 85)',
-              borderRadius: '0.5rem',
-              outline: 'none',
-              border: '2px solid transparent',
-              color: 'white'
-            }}
-            onFocus={(e) => e.target.style.borderColor = 'rgb(34, 197, 94)'}
-            onBlur={(e) => { handleSharesBlur(); e.target.style.borderColor = 'transparent'; }}
-          />
+          <div className="input-step-wrapper">
+            <input
+              className="input-step-field"
+              type="text"
+              value={shares}
+              onChange={(e) => handleMKInput(e.target.value, setShares)}
+              placeholder="Number of shares (e.g. 10k)"
+              style={{
+                width: '100%',
+                padding: '0.5rem 1rem',
+                background: 'rgb(51, 65, 85)',
+                borderRadius: '0.5rem',
+                outline: 'none',
+                border: '2px solid transparent',
+                color: 'white'
+              }}
+              onFocus={(e) => e.target.style.borderColor = 'rgb(34, 197, 94)'}
+              onBlur={(e) => { handleSharesBlur(); e.target.style.borderColor = 'transparent'; }}
+              onKeyDown={(e) => {
+                if (e.key === 'ArrowUp') { e.preventDefault(); stepShares(1); }
+                else if (e.key === 'ArrowDown') { e.preventDefault(); stepShares(-1); }
+              }}
+            />
+            <div className="input-step-btns">
+              <button type="button" className="input-step-btn" onClick={() => stepShares(1)}>▲</button>
+              <button type="button" className="input-step-btn" onClick={() => stepShares(-1)}>▼</button>
+            </div>
+          </div>
         </div>
         <div>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.5rem' }}>
@@ -257,44 +285,55 @@ export default function BuyModal({ stock, onConfirm, onCancel, geData = {}, isSu
               ⇄ {useTotal ? 'Price' : 'Total'}
             </button>
           </div>
-          <input
-            type="text"
-            value={useTotal ? formatTotalInput(totalAmount) : price}
-            onChange={(e) => {
-              const val = e.target.value;
-              if (useTotal) {
-                const lower = val.toLowerCase();
-                if (lower.endsWith('k') || lower.endsWith('m')) {
-                  const parsed = parseMK(val.replace(/\./g, ''));
-                  if (parsed !== val) {
-                    setTotalAmount(parsed);
-                    if (shares && parsed) {
-                      setPrice((parseFloat(parsed) / parseFloat(shares)).toFixed(2));
+          <div className="input-step-wrapper">
+            <input
+              className="input-step-field"
+              type="text"
+              value={useTotal ? formatTotalInput(totalAmount) : price}
+              onChange={(e) => {
+                const val = e.target.value;
+                if (useTotal) {
+                  const lower = val.toLowerCase();
+                  if (lower.endsWith('k') || lower.endsWith('m')) {
+                    const parsed = parseMK(val.replace(/\./g, ''));
+                    if (parsed !== val) {
+                      setTotalAmount(parsed);
+                      if (shares && parsed) {
+                        setPrice((parseFloat(parsed) / parseFloat(shares)).toFixed(2));
+                      }
+                      return;
                     }
-                    return;
+                  }
+                  handleTotalInputChange(val);
+                } else {
+                  const parsed = handleMKInput(val, setPrice);
+                  if (shares && parsed) {
+                    setTotalAmount((parseFloat(shares) * parseFloat(parsed)).toFixed(0));
                   }
                 }
-                handleTotalInputChange(val);
-              } else {
-                const parsed = handleMKInput(val, setPrice);
-                if (shares && parsed) {
-                  setTotalAmount((parseFloat(shares) * parseFloat(parsed)).toFixed(0));
-                }
-              }
-            }}
-            placeholder={useTotal ? 'Total cost (e.g. 10m)' : 'Price per share (e.g. 1.5k)'}
-            style={{
-              width: '100%',
-              padding: '0.5rem 1rem',
-              background: 'rgb(51, 65, 85)',
-              borderRadius: '0.5rem',
-              outline: 'none',
-              border: '2px solid transparent',
-              color: 'white'
-            }}
-            onFocus={(e) => e.target.style.borderColor = 'rgb(34, 197, 94)'}
-            onBlur={(e) => e.target.style.borderColor = 'transparent'}
-          />
+              }}
+              placeholder={useTotal ? 'Total cost (e.g. 10m)' : 'Price per share (e.g. 1.5k)'}
+              style={{
+                width: '100%',
+                padding: '0.5rem 1rem',
+                background: 'rgb(51, 65, 85)',
+                borderRadius: '0.5rem',
+                outline: 'none',
+                border: '2px solid transparent',
+                color: 'white'
+              }}
+              onFocus={(e) => e.target.style.borderColor = 'rgb(34, 197, 94)'}
+              onBlur={(e) => e.target.style.borderColor = 'transparent'}
+              onKeyDown={(e) => {
+                if (e.key === 'ArrowUp') { e.preventDefault(); stepPrice(1); }
+                else if (e.key === 'ArrowDown') { e.preventDefault(); stepPrice(-1); }
+              }}
+            />
+            <div className="input-step-btns">
+              <button type="button" className="input-step-btn" onClick={() => stepPrice(1)}>▲</button>
+              <button type="button" className="input-step-btn" onClick={() => stepPrice(-1)}>▼</button>
+            </div>
+          </div>
           {useTotal && price && (
             <div style={{
               background: 'rgba(234, 88, 12, 0.1)',

--- a/src/components/modals/MilestoneTrackerModal.jsx
+++ b/src/components/modals/MilestoneTrackerModal.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { X } from 'lucide-react';
 import { formatNumber, handleMKInput } from '../../utils/formatters';
+import StepInput from '../StepInput';
 
 const formatPeriodRange = (periodStart, period) => {
   // Parse as local date (YYYY-MM-DD) to avoid UTC shift issues
@@ -369,13 +370,14 @@ export default function MilestoneTrackerModal({
                   Or enter custom amount:
                 </label>
                 <div style={{ display: 'flex', gap: '0.5rem' }}>
-                  <input
+                  <StepInput
                     type="text"
                     value={customGoal}
                     onChange={(e) => handleMKInput(e.target.value, setCustomGoal)}
+                    onStep={(d) => setCustomGoal(prev => Math.max(0, (parseFloat(prev) || 0) + d).toString())}
                     placeholder="Enter custom goal (e.g. 10m)"
+                    wrapperStyle={{ flex: 1 }}
                     style={{
-                      flex: 1,
                       padding: '0.75rem',
                       background: 'rgb(15, 23, 42)',
                       border: '1px solid rgb(51, 65, 85)',

--- a/src/components/modals/NewStockModal.jsx
+++ b/src/components/modals/NewStockModal.jsx
@@ -1,3 +1,4 @@
+import StepInput from '../StepInput';
 import React, { useState, useMemo, useRef, useEffect } from 'react';
 import { handleMKInput } from '../../utils/formatters';
 
@@ -212,10 +213,11 @@ export default function NewStockModal({ categories, defaultCategory = '', defaul
         )}
 
         {/* 4H Limit */}
-        <input
+        <StepInput
           type="text"
           value={limit4h}
           onChange={(e) => handleMKInput(e.target.value, setLimit4h)}
+          onStep={(d) => setLimit4h(prev => Math.max(0, (parseFloat(prev) || 0) + d).toString())}
           placeholder="4H Limit (e.g. 10k)"
           style={inputStyle}
           onFocus={(e) => e.target.style.borderColor = 'rgb(37, 99, 235)'}
@@ -223,10 +225,11 @@ export default function NewStockModal({ categories, defaultCategory = '', defaul
         />
 
         {/* Desired Stock */}
-        <input
+        <StepInput
           type="text"
           value={needed}
           onChange={(e) => handleMKInput(e.target.value, setNeeded)}
+          onStep={(d) => setNeeded(prev => Math.max(0, (parseFloat(prev) || 0) + d).toString())}
           placeholder="Desired stock (e.g. 100k)"
           style={inputStyle}
           onFocus={(e) => e.target.style.borderColor = 'rgb(37, 99, 235)'}

--- a/src/components/modals/PriceAlertModal.jsx
+++ b/src/components/modals/PriceAlertModal.jsx
@@ -14,6 +14,18 @@ export default function PriceAlertModal({ itemId, itemName, currentAlert, gePric
 
   const isEditing = !!currentAlert?.isActive;
 
+  const stepHigh = (delta) => {
+    const newVal = Math.max(0, (parseInt(highThreshold) || 0) + delta);
+    setHighThreshold(newVal.toString());
+    setError('');
+  };
+
+  const stepLow = (delta) => {
+    const newVal = Math.max(0, (parseInt(lowThreshold) || 0) + delta);
+    setLowThreshold(newVal.toString());
+    setError('');
+  };
+
   const handleSave = () => {
     const high = highThreshold ? parseInt(highThreshold, 10) : null;
     const low = lowThreshold ? parseInt(lowThreshold, 10) : null;
@@ -71,14 +83,24 @@ export default function PriceAlertModal({ itemId, itemName, currentAlert, gePric
             <TrendingUp size={14} className="price-alert-field-icon-up" />
             Notify when price above
           </label>
-          <input
-            type="number"
-            className="price-alert-input"
-            value={highThreshold}
-            onChange={(e) => { setHighThreshold(e.target.value); setError(''); }}
-            placeholder="e.g. 5000000"
-            min="1"
-          />
+          <div className="input-step-wrapper">
+            <input
+              type="number"
+              className="price-alert-input input-step-field"
+              value={highThreshold}
+              onChange={(e) => { setHighThreshold(e.target.value); setError(''); }}
+              onKeyDown={(e) => {
+                if (e.key === 'ArrowUp') { e.preventDefault(); stepHigh(1); }
+                else if (e.key === 'ArrowDown') { e.preventDefault(); stepHigh(-1); }
+              }}
+              placeholder="e.g. 5000000"
+              min="1"
+            />
+            <div className="input-step-btns">
+              <button type="button" className="input-step-btn" onClick={() => stepHigh(1)}>▲</button>
+              <button type="button" className="input-step-btn" onClick={() => stepHigh(-1)}>▼</button>
+            </div>
+          </div>
         </div>
 
         <div className="price-alert-field">
@@ -86,14 +108,24 @@ export default function PriceAlertModal({ itemId, itemName, currentAlert, gePric
             <TrendingDown size={14} className="price-alert-field-icon-down" />
             Notify when price below
           </label>
-          <input
-            type="number"
-            className="price-alert-input"
-            value={lowThreshold}
-            onChange={(e) => { setLowThreshold(e.target.value); setError(''); }}
-            placeholder="e.g. 3000000"
-            min="1"
-          />
+          <div className="input-step-wrapper">
+            <input
+              type="number"
+              className="price-alert-input input-step-field"
+              value={lowThreshold}
+              onChange={(e) => { setLowThreshold(e.target.value); setError(''); }}
+              onKeyDown={(e) => {
+                if (e.key === 'ArrowUp') { e.preventDefault(); stepLow(1); }
+                else if (e.key === 'ArrowDown') { e.preventDefault(); stepLow(-1); }
+              }}
+              placeholder="e.g. 3000000"
+              min="1"
+            />
+            <div className="input-step-btns">
+              <button type="button" className="input-step-btn" onClick={() => stepLow(1)}>▲</button>
+              <button type="button" className="input-step-btn" onClick={() => stepLow(-1)}>▼</button>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/src/components/modals/ProfitModal.jsx
+++ b/src/components/modals/ProfitModal.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { handleMKInput } from '../../utils/formatters';
+import StepInput from '../StepInput';
 
 export default function ProfitModal({ type, onConfirm, onCancel }) {
   const [amount, setAmount] = useState('');
@@ -40,10 +41,11 @@ export default function ProfitModal({ type, onConfirm, onCancel }) {
     }}>
       <h2 style={{ fontSize: '1.5rem', fontWeight: 'bold', marginBottom: '1rem' }}>{title}</h2>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-        <input
+        <StepInput
           type="text"
           value={amount}
           onChange={(e) => handleMKInput(e.target.value, setAmount)}
+          onStep={(d) => setAmount(prev => Math.max(0, (parseFloat(prev) || 0) + d).toString())}
           placeholder="Enter profit amount (e.g. 10m, 500k)"
           style={{
             width: '100%',

--- a/src/components/modals/RemoveStockModal.jsx
+++ b/src/components/modals/RemoveStockModal.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { formatNumber, handleMKInput } from '../../utils/formatters';
+import StepInput from '../StepInput';
 
 export default function RemoveStockModal({ stock, onConfirm, onCancel, isSubmitting = false }) {
   const [shares, setShares] = useState('');
@@ -116,10 +117,11 @@ export default function RemoveStockModal({ stock, onConfirm, onCancel, isSubmitt
               ALL
             </button>
           </div>
-          <input
+          <StepInput
             type="text"
             value={shares}
             onChange={(e) => handleMKInput(e.target.value, setShares)}
+            onStep={(d) => setShares(prev => Math.max(0, Math.min(stock.shares, (parseFloat(prev) || 0) + d)).toString())}
             placeholder="Number of shares (e.g. 10k)"
             style={{
               width: '100%',

--- a/src/components/modals/SellModal.jsx
+++ b/src/components/modals/SellModal.jsx
@@ -58,6 +58,23 @@ export default function SellModal({ stock, onConfirm, onCancel, geData = {}, isS
     }
   };
 
+  const stepShares = (delta) => {
+    const current = parseFloat(parseMK(shares)) || 0;
+    const newVal = Math.max(0, Math.min(stock.shares, current + delta));
+    setShares(newVal.toString());
+  };
+
+  const stepPrice = (delta) => {
+    if (useTotal) {
+      const current = parseFloat(totalAmount) || 0;
+      const newTotal = Math.max(0, current + delta).toString();
+      setTotalAmount(newTotal);
+      if (shares && newTotal) setPrice((parseFloat(newTotal) / parseFloat(shares)).toFixed(2));
+    } else {
+      handlePriceChange(Math.max(0, (parseFloat(price) || 0) + delta).toString());
+    }
+  };
+
   const handleModeToggle = () => {
     if (!useTotal && price && shares) {
       setTotalAmount(Math.round(parseFloat(shares) * parseFloat(price)).toString());
@@ -214,23 +231,34 @@ export default function SellModal({ stock, onConfirm, onCancel, geData = {}, isS
               ALL
             </button>
           </div>
-          <input
-            type="text"
-            value={shares}
-            onChange={(e) => handleMKInput(e.target.value, setShares)}
-            placeholder="Number of shares (e.g. 10k)"
-            style={{
-              width: '100%',
-              padding: '0.5rem 1rem',
-              background: 'rgb(51, 65, 85)',
-              borderRadius: '0.5rem',
-              outline: 'none',
-              border: '2px solid transparent',
-              color: 'white'
-            }}
-            onFocus={(e) => e.target.style.borderColor = 'rgb(239, 68, 68)'}
-            onBlur={(e) => { handleSharesBlur(); e.target.style.borderColor = 'transparent'; }}
-          />
+          <div className="input-step-wrapper">
+            <input
+              className="input-step-field"
+              type="text"
+              value={shares}
+              onChange={(e) => handleMKInput(e.target.value, setShares)}
+              placeholder="Number of shares (e.g. 10k)"
+              style={{
+                width: '100%',
+                padding: '0.5rem 1rem',
+                background: 'rgb(51, 65, 85)',
+                borderRadius: '0.5rem',
+                outline: 'none',
+                border: '2px solid transparent',
+                color: 'white'
+              }}
+              onFocus={(e) => e.target.style.borderColor = 'rgb(239, 68, 68)'}
+              onBlur={(e) => { handleSharesBlur(); e.target.style.borderColor = 'transparent'; }}
+              onKeyDown={(e) => {
+                if (e.key === 'ArrowUp') { e.preventDefault(); stepShares(1); }
+                else if (e.key === 'ArrowDown') { e.preventDefault(); stepShares(-1); }
+              }}
+            />
+            <div className="input-step-btns">
+              <button type="button" className="input-step-btn" onClick={() => stepShares(1)}>▲</button>
+              <button type="button" className="input-step-btn" onClick={() => stepShares(-1)}>▼</button>
+            </div>
+          </div>
         </div>
         <div>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.5rem' }}>
@@ -304,44 +332,55 @@ export default function SellModal({ stock, onConfirm, onCancel, geData = {}, isS
               ⇄ {useTotal ? 'Price' : 'Total'}
             </button>
           </div>
-          <input
-            type="text"
-            value={useTotal ? formatTotalInput(totalAmount) : price}
-            onChange={(e) => {
-              const val = e.target.value;
-              if (useTotal) {
-                const lower = val.toLowerCase();
-                if (lower.endsWith('k') || lower.endsWith('m')) {
-                  const parsed = parseMK(val.replace(/\./g, ''));
-                  if (parsed !== val) {
-                    setTotalAmount(parsed);
-                    if (shares && parsed) {
-                      setPrice((parseFloat(parsed) / parseFloat(shares)).toFixed(2));
+          <div className="input-step-wrapper">
+            <input
+              className="input-step-field"
+              type="text"
+              value={useTotal ? formatTotalInput(totalAmount) : price}
+              onChange={(e) => {
+                const val = e.target.value;
+                if (useTotal) {
+                  const lower = val.toLowerCase();
+                  if (lower.endsWith('k') || lower.endsWith('m')) {
+                    const parsed = parseMK(val.replace(/\./g, ''));
+                    if (parsed !== val) {
+                      setTotalAmount(parsed);
+                      if (shares && parsed) {
+                        setPrice((parseFloat(parsed) / parseFloat(shares)).toFixed(2));
+                      }
+                      return;
                     }
-                    return;
+                  }
+                  handleTotalInputChange(val);
+                } else {
+                  const parsed = handleMKInput(val, setPrice);
+                  if (shares && parsed) {
+                    setTotalAmount((parseFloat(shares) * parseFloat(parsed)).toFixed(0));
                   }
                 }
-                handleTotalInputChange(val);
-              } else {
-                const parsed = handleMKInput(val, setPrice);
-                if (shares && parsed) {
-                  setTotalAmount((parseFloat(shares) * parseFloat(parsed)).toFixed(0));
-                }
-              }
-            }}
-            placeholder={useTotal ? 'Total revenue (e.g. 10m)' : 'Price per share (e.g. 1.5k)'}
-            style={{
-              width: '100%',
-              padding: '0.5rem 1rem',
-              background: 'rgb(51, 65, 85)',
-              borderRadius: '0.5rem',
-              outline: 'none',
-              border: '2px solid transparent',
-              color: 'white'
-            }}
-            onFocus={(e) => e.target.style.borderColor = 'rgb(239, 68, 68)'}
-            onBlur={(e) => e.target.style.borderColor = 'transparent'}
-          />
+              }}
+              placeholder={useTotal ? 'Total revenue (e.g. 10m)' : 'Price per share (e.g. 1.5k)'}
+              style={{
+                width: '100%',
+                padding: '0.5rem 1rem',
+                background: 'rgb(51, 65, 85)',
+                borderRadius: '0.5rem',
+                outline: 'none',
+                border: '2px solid transparent',
+                color: 'white'
+              }}
+              onFocus={(e) => e.target.style.borderColor = 'rgb(239, 68, 68)'}
+              onBlur={(e) => e.target.style.borderColor = 'transparent'}
+              onKeyDown={(e) => {
+                if (e.key === 'ArrowUp') { e.preventDefault(); stepPrice(1); }
+                else if (e.key === 'ArrowDown') { e.preventDefault(); stepPrice(-1); }
+              }}
+            />
+            <div className="input-step-btns">
+              <button type="button" className="input-step-btn" onClick={() => stepPrice(1)}>▲</button>
+              <button type="button" className="input-step-btn" onClick={() => stepPrice(-1)}>▼</button>
+            </div>
+          </div>
         </div>
         <div style={{ display: 'flex', gap: '0.75rem', paddingTop: '1rem' }}>
           <button

--- a/src/components/modals/TimeCalculatorModal.jsx
+++ b/src/components/modals/TimeCalculatorModal.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { handleMKInput } from '../../utils/formatters';
+import StepInput from '../StepInput';
 
 export default function TimeCalculatorModal({ stock, onClose }) {
   const [targetAmount, setTargetAmount] = useState(stock.needed.toString());
@@ -36,10 +37,11 @@ export default function TimeCalculatorModal({ stock, onClose }) {
           <label style={{ display: 'block', fontSize: '0.875rem', fontWeight: '500', color: 'rgb(209, 213, 219)', marginBottom: '0.5rem' }}>
             Target Amount
           </label>
-          <input
+          <StepInput
             type="text"
             value={targetAmount}
             onChange={(e) => handleMKInput(e.target.value, setTargetAmount)}
+            onStep={(d) => setTargetAmount(prev => Math.max(0, (parseFloat(prev) || 0) + d).toString())}
             placeholder="Enter target amount (e.g. 100k)"
             autoFocus
             style={{
@@ -61,10 +63,11 @@ export default function TimeCalculatorModal({ stock, onClose }) {
           <label style={{ display: 'block', fontSize: '0.875rem', fontWeight: '500', color: 'rgb(209, 213, 219)', marginBottom: '0.5rem' }}>
             Number of Accounts
           </label>
-          <input
+          <StepInput
             type="text"
             value={accountCount}
             onChange={(e) => handleMKInput(e.target.value, setAccountCount)}
+            onStep={(d) => setAccountCount(prev => Math.max(1, (parseFloat(prev) || 1) + d).toString())}
             placeholder="Enter number of accounts"
             style={{
               width: '100%',

--- a/src/styles/bulk-modals.css
+++ b/src/styles/bulk-modals.css
@@ -1131,3 +1131,17 @@
   }
 }
 
+/* StepInput wrapper overrides — flex children must not be width:100% */
+.bulk-sell-selected-item .item-inputs .input-group .input-step-wrapper,
+.bulk-sell-selected-item .item-inputs > .input-step-wrapper,
+.bulk-buy-selected-item .item-inputs > .input-step-wrapper {
+  flex: 1;
+  width: auto;
+  min-width: 0;
+}
+
+/* Hide step buttons in the qty input-group — ALL button already fills that role */
+.bulk-sell-selected-item .item-inputs .input-group .input-step-btns {
+  display: none;
+}
+

--- a/src/styles/shared.css
+++ b/src/styles/shared.css
@@ -333,3 +333,54 @@
   color: white;
   font-size: 1.5rem;
 }
+
+/* Input with step buttons */
+.input-step-wrapper {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  gap: 0.25rem;
+}
+
+.input-step-field {
+  flex: 1;
+  min-width: 0;
+}
+
+.input-step-btns {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.input-step-btn {
+  width: 22px;
+  flex: 1;
+  background: rgb(71, 85, 105);
+  border: none;
+  color: rgb(203, 213, 225);
+  cursor: pointer;
+  border-radius: 0.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.625rem;
+  line-height: 1;
+  padding: 0;
+  transition: background 0.15s;
+}
+
+.input-step-btn:hover {
+  background: rgb(100, 116, 139);
+  transform: none;
+}
+
+.input-step-wrapper input[type="number"]::-webkit-inner-spin-button,
+.input-step-wrapper input[type="number"]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.input-step-wrapper input[type="number"] {
+  -moz-appearance: textfield;
+}


### PR DESCRIPTION
## Summary
- Adds `StepInput` component wrapping numeric fields with ▲/▼ buttons and `ArrowUp`/`ArrowDown` keyboard support
- Applied to all numeric inputs across 13 modals (Buy, Sell, BulkBuy, BulkSell, Adjust, NewStock, RemoveStock, Profit, MilestoneTracker, TimeCalculator, PriceAlert, AltTimer)
- `PriceAlertModal` and `AltTimerModal` use `type="number"` — native browser spinners hidden via CSS in favour of the consistent styled buttons
- BulkSellModal qty field hides the visual buttons (ALL button serves the same role) but retains keyboard support

## Test plan
- [ ] Buy/Sell modals: verify ▲▼ buttons and arrow keys increment/decrement shares and price
- [ ] BulkBuy: verify budget, per-item shares and price all step correctly
- [ ] BulkSell: verify qty (keyboard only) and price (buttons + keyboard) work; ALL button still accessible
- [ ] AdjustModal / NewStockModal: verify limit4h and needed fields step correctly
- [ ] PriceAlertModal: verify high/low threshold buttons work and native spinners are hidden
- [ ] AltTimerModal: verify days clamp to 1–365

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)