### PR TITLE
fix(table): prevent status column layout shift when timer changes state

### DIFF
--- a/src/components/StockTable.jsx
+++ b/src/components/StockTable.jsx
@@ -138,6 +138,7 @@ function TableHeader({ sortConfig, onSort, visibleColumns, showInvestmentDate })
             onClick={() => col.key && onSort(col.key)}
             className={`th-base ${col.key ? 'th-sortable' : ''}`}
             title={col.tooltip}
+            style={col.style}
           >
             <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
               {col.label}
@@ -242,7 +243,7 @@ function StockRow({
         </div>
       </td>
       {visibleColumns.status && (
-        <td style={{ padding: '0.5rem 0.75rem', textAlign: 'center', border: '1px solid rgb(51, 65, 85)' }}>
+        <td style={{ padding: '0.5rem 0.75rem', textAlign: 'center', border: '1px solid rgb(51, 65, 85)', minWidth: '7rem' }}>
           <StatusBadge stock={stock} />
         </td>
       )}
@@ -351,12 +352,10 @@ function StockRow({
 function StatusBadge({ stock }) {
   if (stock.timerEndTime && stock.timerEndTime > Date.now()) {
     return (
-      <div className="td-center">
-        <span className="badge badge-timer">
-          <span>⏰</span>
-          <span>{formatTimer(stock.timerEndTime)}</span>
-        </span>
-      </div>
+      <span className="badge badge-timer">
+        <span>⏰</span>
+        <span style={{ fontVariantNumeric: 'tabular-nums' }}>{formatTimer(stock.timerEndTime)}</span>
+      </span>
     );
   } else if (stock.shares < stock.needed) {
     if (stock.onHold) {


### PR DESCRIPTION
## Summary
The status column would change width as the 4h timer badge switched between states (active timer vs OK/LOW/HOLD), causing the table layout to shift every time a timer expired. Fixed by anchoring the column to a fixed minimum width.

## Changes
- Add `minWidth: '9rem'` to the status `<th>` via column definition `style` field
- Add `minWidth: '7rem'` to the status `<td>` so data cells don't drive column narrower
- Remove extra `<div className="td-center">` wrapper around timer badge (inconsistent with other badge states)
- Add `font-variant-numeric: tabular-nums` to timer text to prevent sub-pixel digit-width shifts