### PR TITLE
refactor(hooks): extract useGroupedStocks from bulk modals

### DIFF
--- a/src/components/modals/BulkBuyModal.jsx
+++ b/src/components/modals/BulkBuyModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from 'react';
+import { useGroupedStocks } from '../../hooks/useGroupedStocks';
 import { formatNumber, parseMK, handleMKInput } from '../../utils/formatters';
 import '../../styles/bulk-modals.css';
 import StepInput from '../StepInput';
@@ -9,33 +10,7 @@ export default function BulkBuyModal({ stocks, categories = [], tradeMode = 'tra
   const [selectedItems, setSelectedItems] = useState({});
   const [budget, setBudget] = useState('');
 
-  // Build grouped stocks in category order (matching main trade screen)
-  const groupedStocks = useMemo(() => {
-    const filtered = stocks.filter(s =>
-      tradeMode === 'investment' ? s.isInvestment : !s.isInvestment
-    );
-    const filteredCats = categories.filter(c =>
-      tradeMode === 'investment' ? c.isInvestment : !c.isInvestment
-    );
-    const catNames = filteredCats.map(c => c.name);
-
-    const groups = [];
-    for (const cat of filteredCats) {
-      const catStocks = filtered.filter(s => s.category === cat.name);
-      if (catStocks.length > 0) {
-        groups.push({ name: cat.name, stocks: catStocks });
-      }
-    }
-
-    const uncategorized = filtered.filter(s =>
-      s.category === 'Uncategorized' || !s.category || !catNames.includes(s.category)
-    );
-    if (uncategorized.length > 0 && !filteredCats.some(c => c.name === 'Uncategorized')) {
-      groups.push({ name: 'Uncategorized', stocks: uncategorized });
-    }
-
-    return groups;
-  }, [stocks, categories, tradeMode]);
+  const groupedStocks = useGroupedStocks(stocks, categories, tradeMode);
 
   // Filtered groups for search
   const filteredGroups = useMemo(() => {

--- a/src/components/modals/BulkSellModal.jsx
+++ b/src/components/modals/BulkSellModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from 'react';
+import { useGroupedStocks } from '../../hooks/useGroupedStocks';
 import { formatNumber, handleMKInput } from '../../utils/formatters';
 import '../../styles/bulk-modals.css';
 import StepInput from '../StepInput';
@@ -7,32 +8,7 @@ export default function BulkSellModal({ stocks, categories = [], tradeMode = 'tr
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedItems, setSelectedItems] = useState({});
 
-  const groupedStocks = useMemo(() => {
-    const filtered = stocks.filter(s =>
-      (tradeMode === 'investment' ? s.isInvestment : !s.isInvestment) && s.shares > 0
-    );
-    const filteredCats = categories.filter(c =>
-      tradeMode === 'investment' ? c.isInvestment : !c.isInvestment
-    );
-    const catNames = filteredCats.map(c => c.name);
-
-    const groups = [];
-    for (const cat of filteredCats) {
-      const catStocks = filtered.filter(s => s.category === cat.name);
-      if (catStocks.length > 0) {
-        groups.push({ name: cat.name, stocks: catStocks });
-      }
-    }
-
-    const uncategorized = filtered.filter(s =>
-      s.category === 'Uncategorized' || !s.category || !catNames.includes(s.category)
-    );
-    if (uncategorized.length > 0 && !filteredCats.some(c => c.name === 'Uncategorized')) {
-      groups.push({ name: 'Uncategorized', stocks: uncategorized });
-    }
-
-    return groups;
-  }, [stocks, categories, tradeMode]);
+  const groupedStocks = useGroupedStocks(stocks, categories, tradeMode, { requireShares: true });
 
   const filteredGroups = useMemo(() => {
     if (!searchQuery.trim()) return groupedStocks;

--- a/src/hooks/useGroupedStocks.js
+++ b/src/hooks/useGroupedStocks.js
@@ -1,0 +1,41 @@
+import { useMemo } from 'react';
+
+/**
+ * Groups stocks by category in category order, appending uncategorized at the end.
+ * Returns an array of { name: string, stocks: Stock[] }.
+ *
+ * @param {Stock[]} stocks
+ * @param {Category[]} categories
+ * @param {'trade'|'investment'} tradeMode
+ * @param {{ requireShares?: boolean }} options
+ */
+export function useGroupedStocks(stocks, categories = [], tradeMode = 'trade', { requireShares = false } = {}) {
+  return useMemo(() => {
+    const filteredCats = categories.filter(c =>
+      tradeMode === 'investment' ? c.isInvestment : !c.isInvestment
+    );
+    const catNames = filteredCats.map(c => c.name);
+
+    const filtered = stocks.filter(s => {
+      const modeMatch = tradeMode === 'investment' ? s.isInvestment : !s.isInvestment;
+      return modeMatch && (!requireShares || s.shares > 0);
+    });
+
+    const groups = [];
+    for (const cat of filteredCats) {
+      const catStocks = filtered.filter(s => s.category === cat.name);
+      if (catStocks.length > 0) {
+        groups.push({ name: cat.name, stocks: catStocks });
+      }
+    }
+
+    const uncategorized = filtered.filter(s =>
+      s.category === 'Uncategorized' || !s.category || !catNames.includes(s.category)
+    );
+    if (uncategorized.length > 0 && !filteredCats.some(c => c.name === 'Uncategorized')) {
+      groups.push({ name: 'Uncategorized', stocks: uncategorized });
+    }
+
+    return groups;
+  }, [stocks, categories, tradeMode, requireShares]);
+}


### PR DESCRIPTION
## Summary
- Extracts duplicated `groupedStocks` useMemo from `BulkBuyModal` and `BulkSellModal` into a shared `useGroupedStocks` hook
- Adds `requireShares` option to handle BulkSellModal's `shares > 0` filter
- Closes #183

## Test plan
- [ ] Bulk buy modal: items grouped by category in correct order, uncategorized at bottom, search filters correctly, investment mode works
- [ ] Bulk sell modal: same as above, plus only items with shares > 0 appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)