### PR TITLE
refactor(context): add GEDataContext and TradeContext

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import Auth from './components/Auth';
 import MainApp from './MainApp';
 import UpdatePassword from './components/UpdatePassword';
 import LandingPage from './pages/LandingPage';
+import { GEDataProvider } from './contexts/GEDataContext';
 
 
 export default function App() {
@@ -65,6 +66,10 @@ export default function App() {
     );
   }
 
-  return <MainApp session={session} onLogout={() => setShowLanding(false)} />;
+  return (
+    <GEDataProvider>
+      <MainApp session={session} onLogout={() => setShowLanding(false)} />
+    </GEDataProvider>
+  );
 
 }

--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { LogOut } from 'lucide-react';
 import HomePage from './pages/HomePage';
 import HistoryPage from './pages/HistoryPage';
@@ -14,7 +14,8 @@ import { useNotificationSettings } from './hooks/useNotificationSettings';
 import { useProfits } from './hooks/useProfits';
 import { useMilestones } from './hooks/useMilestones';
 import { useProfitHistory } from './hooks/useProfitHistory';
-import { useGEPrices } from './hooks/useGEPrices';
+import { useGEData } from './contexts/GEDataContext';
+import { TradeProvider } from './contexts/TradeContext';
 import { useNotifications } from './hooks/useNotifications';
 import { useOSRSNews } from './hooks/useOSRSNews';
 import { useJmodComments } from './hooks/useJmodComments';
@@ -87,13 +88,7 @@ export default function MainApp({ session, onLogout }) {
   const [showChangelog, setShowChangelog] = useState(false);
   // Custom hooks for Supabase
   const [tradeMode, setTradeMode] = useState('trade');
-  // Update the destructure:
-  const { prices: gePrices, mapping: geMapping, iconMap: geIconMap, mappingLoading } = useGEPrices();
-
-  const membershipMap = useMemo(
-    () => Object.fromEntries((geMapping || []).map(item => [item.id, !!item.members])),
-    [geMapping]
-  );
+  const { gePrices, geMapping, geIconMap, membershipMap, mappingLoading } = useGEData();
 
   const switchTradeMode = (mode) => {
     refetch();
@@ -1419,7 +1414,7 @@ export default function MainApp({ session, onLogout }) {
 
 
   return (
-
+    <TradeProvider stocks={stocks} categories={categories} refetchStocks={refetch} refetchCategories={fetchCategories}>
     <div style={{
       minHeight: '100vh',
       background: 'rgb(15, 23, 42)',
@@ -1560,12 +1555,16 @@ export default function MainApp({ session, onLogout }) {
           {/* Right - Search + Notifications + User dropdown */}
           <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
           <GlobalSearch
-            stocks={stocks}
-            categories={categories}
             transactions={transactions}
-            geMapping={geMapping}
-            geIconMap={geIconMap}
             navigateToPage={navigateToPage}
+            onExpandCategory={(cat) => {
+              setCollapsedCategories(prev => {
+                if (!prev[cat]) return prev;
+                const next = { ...prev, [cat]: false };
+                localStorage.setItem('collapsedCategories', JSON.stringify(next));
+                return next;
+              });
+            }}
           />
           <NotificationCenter
             notifications={notifications}
@@ -1581,8 +1580,6 @@ export default function MainApp({ session, onLogout }) {
             newOsrsNewsCount={notifications.filter(n => n.type === 'osrsNews' && !n.read).length}
             priceAlerts={priceAlerts}
             allPriceAlerts={allPriceAlerts}
-            geIconMap={geIconMap}
-            gePrices={gePrices}
             onEditAlert={(alert) => {
               setSelectedAlertItem({ itemId: alert.itemId, itemName: alert.itemName });
               setShowPriceAlertModal(true);
@@ -1635,7 +1632,6 @@ export default function MainApp({ session, onLogout }) {
       <div style={{ maxWidth: '1600px', margin: '0 auto', padding: '0 2rem' }}>
         {currentPage === 'home' ? (
           <HomePage
-            stocks={stocks}
             transactions={transactions}
             profitHistory={profitHistory}
             gpTradedStats={gpTradedStats}
@@ -1646,7 +1642,6 @@ export default function MainApp({ session, onLogout }) {
             onNavigateToTrade={() => navigateToPage('trade')}
             onOpenMilestoneModal={() => { setMilestoneInitialView('main'); setShowMilestoneModal(true); }}
             onOpenMilestoneHistory={() => { setMilestoneInitialView('history'); setShowMilestoneModal(true); }}
-            geData={gePrices}
           />
         ) : currentPage === 'history' ? (
           <HistoryPage
@@ -1654,7 +1649,6 @@ export default function MainApp({ session, onLogout }) {
             profitHistory={profitHistory}
             pagedLoading={pagedLoading}
             totalCount={totalCount}
-            stocks={stocks}
             totalPages={totalPages}
             page={page}
             pageSize={pageSize}
@@ -1668,22 +1662,15 @@ export default function MainApp({ session, onLogout }) {
             onApplySort={applySort}
             onReset={resetPaged}
             onUndo={undoTransaction}
-            membershipMap={membershipMap}
-            geIconMap={geIconMap}
             showMembershipIcon={visibleColumns.membershipIcon}
           />
         ) : currentPage === 'graphs' ? (
           <GraphsPage
-            mapping={geMapping}
-            prices={gePrices}
-            iconMap={geIconMap}
-            mappingLoading={mappingLoading}
             userId={userId}
             initialItemId={graphItemId}
             navigateToPage={navigateToPage}
             priceAlerts={priceAlerts}
             onPriceAlert={handleOpenPriceAlert}
-            stocks={stocks}
             stockNotes={stockNotes}
             onSaveNote={saveNote}
           />
@@ -1696,7 +1683,6 @@ export default function MainApp({ session, onLogout }) {
             />
 
             <PortfolioSummary
-              stocks={stocks}
               dumpProfit={dumpProfit}
               referralProfit={referralProfit}
               bondsProfit={bondsProfit}
@@ -1705,7 +1691,6 @@ export default function MainApp({ session, onLogout }) {
               onAddReferralProfit={() => setShowReferralProfitModal(true)}
               onAddBondsProfit={() => setShowBondsProfitModal(true)}
               numberFormat={numberFormat}
-              geData={gePrices}
               showUnrealisedProfitStats={showUnrealisedProfitStats}
             />
 
@@ -1799,7 +1784,6 @@ export default function MainApp({ session, onLogout }) {
                 key={category}
                 category={category}
                 stocks={categoryStocks}
-                categories={categoryNames}
                 isCollapsed={collapsedCategories[category]}
                 onToggleCollapse={toggleCategory}
                 onAddStock={(cat) => {
@@ -1855,9 +1839,6 @@ export default function MainApp({ session, onLogout }) {
                 numberFormat={numberFormat}
                 showCategoryStats={showCategoryStats}
                 showCategoryUnrealisedProfit={showCategoryUnrealisedProfit}
-                geData={gePrices}
-                geIconMap={geIconMap}
-                membershipMap={membershipMap}
                 showMembershipIcon={visibleColumns.membershipIcon}
                 showInvestmentDate={tradeMode === 'investment' && visibleColumns.investmentStartDate}
                 onInvestmentDateChange={handleInvestmentDateChange}
@@ -1873,18 +1854,13 @@ export default function MainApp({ session, onLogout }) {
                 stock={selectedStock}
                 onConfirm={handleBuy}
                 onCancel={() => setShowBuyModal(false)}
-                geData={gePrices}
                 isSubmitting={isSubmitting}
               />
             </ModalContainer>
 
             <ModalContainer isOpen={showBulkBuyModal}>
               <BulkBuyModal
-                stocks={stocks}
-                categories={categories}
                 tradeMode={tradeMode}
-                gePrices={gePrices}
-                geIconMap={geIconMap}
                 onConfirm={(items) => handleBulkOperation('buy', items, setShowBulkBuyModal)}
                 onCancel={() => setShowBulkBuyModal(false)}
                 isSubmitting={isSubmitting}
@@ -1893,11 +1869,7 @@ export default function MainApp({ session, onLogout }) {
 
             <ModalContainer isOpen={showBulkSellModal}>
               <BulkSellModal
-                stocks={stocks}
-                categories={categories}
                 tradeMode={tradeMode}
-                gePrices={gePrices}
-                geIconMap={geIconMap}
                 onConfirm={handleBulkSell}
                 onCancel={() => setShowBulkSellModal(false)}
                 isSubmitting={isSubmitting}
@@ -1920,7 +1892,6 @@ export default function MainApp({ session, onLogout }) {
                 stock={selectedStock}
                 onConfirm={handleSell}
                 onCancel={() => setShowSellModal(false)}
-                geData={gePrices}
                 isSubmitting={isSubmitting}
               />
             </ModalContainer>
@@ -1937,9 +1908,7 @@ export default function MainApp({ session, onLogout }) {
             <ModalContainer isOpen={showAdjustModal}>
               <AdjustModal
                 stock={selectedStock}
-                categories={categories}
                 onConfirm={handleAdjust}
-                mapping={geMapping}
                 onCancel={() => setShowAdjustModal(false)}
               />
             </ModalContainer>
@@ -1954,11 +1923,9 @@ export default function MainApp({ session, onLogout }) {
 
             <ModalContainer isOpen={showNewStockModal}>
               <NewStockModal
-                categories={categories}
                 defaultCategory={newStockCategory}
                 defaultIsInvestment={tradeMode === 'investment'}
                 onConfirm={handleAddStock}
-                mapping={geMapping}
                 archivedStocks={archivedStocks}
                 onRestoreFromArchive={async (stock) => {
                   await handleRestore(stock);
@@ -2019,7 +1986,6 @@ export default function MainApp({ session, onLogout }) {
 
             <ModalContainer isOpen={showProfitChartModal}>
               <ProfitChartModal
-                stocks={stocks}
                 dumpProfit={dumpProfit}
                 referralProfit={referralProfit}
                 bondsProfit={bondsProfit}
@@ -2213,6 +2179,6 @@ export default function MainApp({ session, onLogout }) {
       </div>
       <Footer />
     </div>
-
+    </TradeProvider>
   );
 }

--- a/src/components/CategorySection.jsx
+++ b/src/components/CategorySection.jsx
@@ -3,12 +3,12 @@ import { Plus, Trash2 } from 'lucide-react';
 import StockTable from './StockTable';
 import { formatNumber } from '../utils/formatters';
 import { calculateUnrealizedProfit } from '../utils/taxUtils';
+import { useGEData } from '../contexts/GEDataContext';
 import '../styles/category-section.css';
 
 export default function CategorySection({
   category,
   stocks,
-  categories,
   isCollapsed,
   onToggleCollapse,
   onAddStock,
@@ -37,9 +37,6 @@ export default function CategorySection({
   numberFormat,
   showCategoryStats,
   showCategoryUnrealisedProfit = false,
-  geData = {},
-  geIconMap = {},
-  membershipMap = {},
   showMembershipIcon = true,
   onArchive,
   showInvestmentDate = false,
@@ -48,6 +45,7 @@ export default function CategorySection({
   priceAlerts = {},
   onViewGraph,
 }) {
+  const { gePrices: geData, geIconMap, membershipMap } = useGEData();
   const categoryStocks = stocks.filter(s => s.category === category);
 
   return (
@@ -254,9 +252,6 @@ export default function CategorySection({
             currentTime={currentTime}
             numberFormat={numberFormat}
             showCategoryStats={showCategoryStats}
-            geData={geData}
-            geIconMap={geIconMap}
-            membershipMap={membershipMap}
             showMembershipIcon={showMembershipIcon}
             onArchive={onArchive}
             showInvestmentDate={showInvestmentDate}

--- a/src/components/GlobalSearch.jsx
+++ b/src/components/GlobalSearch.jsx
@@ -1,15 +1,16 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { Search, Package, FolderOpen, ArrowLeftRight, BarChart3, X } from 'lucide-react';
+import { useGEData } from '../contexts/GEDataContext';
+import { useTrade } from '../contexts/TradeContext';
 import '../styles/global-search.css';
 
 export default function GlobalSearch({
-  stocks = [],
-  categories = [],
   transactions = [],
-  geMapping = [],
-  geIconMap = {},
-  navigateToPage
+  navigateToPage,
+  onExpandCategory
 }) {
+  const { geMapping, geIconMap } = useGEData();
+  const { stocks, categories } = useTrade();
   const [isOpen, setIsOpen] = useState(false);
   const [query, setQuery] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -145,24 +146,31 @@ export default function GlobalSearch({
     setSelectedIndex(0);
   }, [results]);
 
+  const scrollToCategory = useCallback((categoryName) => {
+    onExpandCategory?.(categoryName);
+    setTimeout(() => {
+      const el = document.querySelector(`[data-category="${categoryName}"]`);
+      if (el) {
+        const topbar = document.querySelector('.topbar');
+        const offset = topbar ? topbar.offsetHeight + 16 : 0;
+        const top = el.getBoundingClientRect().top + window.scrollY - offset;
+        window.scrollTo({ top, behavior: 'smooth' });
+      }
+    }, 150);
+  }, [onExpandCategory]);
+
   const handleSelect = useCallback((item) => {
     setIsOpen(false);
     switch (item.type) {
       case 'stock': {
         const category = item.data.category || 'Uncategorized';
         navigateToPage('trade');
-        setTimeout(() => {
-          const el = document.querySelector(`[data-category="${category}"]`);
-          if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        }, 100);
+        setTimeout(() => scrollToCategory(category), 50);
         break;
       }
       case 'category': {
         navigateToPage('trade');
-        setTimeout(() => {
-          const el = document.querySelector(`[data-category="${item.data.name}"]`);
-          if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        }, 100);
+        setTimeout(() => scrollToCategory(item.data.name), 50);
         break;
       }
       case 'transaction': {
@@ -174,7 +182,7 @@ export default function GlobalSearch({
         break;
       }
     }
-  }, [navigateToPage]);
+  }, [navigateToPage, scrollToCategory]);
 
   // Keyboard navigation
   useEffect(() => {

--- a/src/components/NotificationCenter.jsx
+++ b/src/components/NotificationCenter.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Bell, Clock, Trophy, User, Check, X, CheckCheck, Trash2, Newspaper, ExternalLink, MessageSquare, Filter, TrendingUp, TrendingDown, Edit3 } from 'lucide-react';
 import { formatNumber } from '../utils/formatters';
+import { useGEData } from '../contexts/GEDataContext';
 import '../styles/notification-center.css';
 
 function getTimeAgo(timestamp) {
@@ -72,12 +73,11 @@ export default function NotificationCenter({
   newOsrsNewsCount = 0,
   priceAlerts = {},
   allPriceAlerts = [],
-  geIconMap = {},
-  gePrices = {},
   onEditAlert,
   onDismissAlert,
   onNewAlert,
 }) {
+  const { geIconMap, gePrices } = useGEData();
   const [isOpen, setIsOpen] = useState(false);
   const [activeTab, setActiveTab] = useState('inbox');
   const [newsFilter, setNewsFilter] = useState('osrsNews');

--- a/src/components/PortfolioSummary.jsx
+++ b/src/components/PortfolioSummary.jsx
@@ -3,9 +3,10 @@ import { Plus } from 'lucide-react';
 import { formatNumber } from '../utils/formatters';
 import { calculateStocksProfit, calculateTotalProfit } from '../utils/calculations';
 import { calculateUnrealizedProfit } from '../utils/taxUtils';
+import { useGEData } from '../contexts/GEDataContext';
+import { useTrade } from '../contexts/TradeContext';
 
 export default function PortfolioSummary({
-  stocks,
   dumpProfit,
   referralProfit,
   bondsProfit,
@@ -14,9 +15,10 @@ export default function PortfolioSummary({
   onAddReferralProfit,
   onAddBondsProfit,
   numberFormat,
-  geData = {},
   showUnrealisedProfitStats = false
 }) {
+  const { gePrices: geData } = useGEData();
+  const { stocks } = useTrade();
   const stocksProfit = calculateStocksProfit(stocks);
   const totalProfit = calculateTotalProfit(stocks, dumpProfit, referralProfit, bondsProfit);
 

--- a/src/components/StockTable.jsx
+++ b/src/components/StockTable.jsx
@@ -3,6 +3,7 @@ import { Edit3, Trash2, GripVertical, Star, Bell, BellRing } from 'lucide-react'
 import { formatNumber, formatTimer, formatAvgPrice } from '../utils/formatters';
 import { calculateAvgBuyPrice, calculateAvgSellPrice, calculateProfit } from '../utils/calculations';
 import { calculateUnrealizedProfit } from '../utils/taxUtils';
+import { useGEData } from '../contexts/GEDataContext';
 import '../styles/table.css';
 import { sortStocks } from '../utils/calculations';
 
@@ -45,9 +46,6 @@ export default function StockTable({
   stockNotes,
   currentTime,
   numberFormat,
-  geData = {},
-  geIconMap = {},
-  membershipMap = {},
   showMembershipIcon = true,
   onArchive,
   showInvestmentDate = false,
@@ -56,6 +54,7 @@ export default function StockTable({
   priceAlerts = {},
   onViewGraph,
 }) {
+  const { gePrices: geData, geIconMap, membershipMap } = useGEData();
   const sortedStocks = sortStocks(stocks, sortConfig);
 
   return (

--- a/src/components/modals/AdjustModal.jsx
+++ b/src/components/modals/AdjustModal.jsx
@@ -1,8 +1,12 @@
 import React, { useState, useMemo, useRef, useEffect } from 'react';
 import { handleMKInput } from '../../utils/formatters';
+import { useGEData } from '../../contexts/GEDataContext';
+import { useTrade } from '../../contexts/TradeContext';
 import StepInput from '../StepInput';
 
-export default function AdjustModal({ stock, categories, mapping = [], onConfirm, onCancel }) {
+export default function AdjustModal({ stock, onConfirm, onCancel }) {
+  const { geMapping: mapping } = useGEData();
+  const { categories } = useTrade();
   const [stockType, setStockType] = useState(stock.itemId ? 'osrs' : 'custom');
   const [name, setName] = useState(stock.name);
   const [needed, setNeeded] = useState(stock.needed.toString());

--- a/src/components/modals/BulkBuyModal.jsx
+++ b/src/components/modals/BulkBuyModal.jsx
@@ -1,10 +1,14 @@
 import React, { useState, useMemo } from 'react';
 import { useGroupedStocks } from '../../hooks/useGroupedStocks';
 import { formatNumber, parseMK, handleMKInput } from '../../utils/formatters';
+import { useGEData } from '../../contexts/GEDataContext';
+import { useTrade } from '../../contexts/TradeContext';
 import '../../styles/bulk-modals.css';
 import StepInput from '../StepInput';
 
-export default function BulkBuyModal({ stocks, categories = [], tradeMode = 'trade', gePrices = {}, geIconMap = {}, onConfirm, onCancel, isSubmitting = false }) {
+export default function BulkBuyModal({ tradeMode = 'trade', onConfirm, onCancel, isSubmitting = false }) {
+  const { gePrices, geIconMap } = useGEData();
+  const { stocks, categories } = useTrade();
   const [mode, setMode] = useState('perItem');
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedItems, setSelectedItems] = useState({});

--- a/src/components/modals/BulkSellModal.jsx
+++ b/src/components/modals/BulkSellModal.jsx
@@ -1,10 +1,14 @@
 import React, { useState, useMemo } from 'react';
 import { useGroupedStocks } from '../../hooks/useGroupedStocks';
 import { formatNumber, handleMKInput } from '../../utils/formatters';
+import { useGEData } from '../../contexts/GEDataContext';
+import { useTrade } from '../../contexts/TradeContext';
 import '../../styles/bulk-modals.css';
 import StepInput from '../StepInput';
 
-export default function BulkSellModal({ stocks, categories = [], tradeMode = 'trade', gePrices = {}, geIconMap = {}, onConfirm, onCancel, isSubmitting = false }) {
+export default function BulkSellModal({ tradeMode = 'trade', onConfirm, onCancel, isSubmitting = false }) {
+  const { gePrices, geIconMap } = useGEData();
+  const { stocks, categories } = useTrade();
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedItems, setSelectedItems] = useState({});
 

--- a/src/components/modals/BuyModal.jsx
+++ b/src/components/modals/BuyModal.jsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
 import { formatNumber, parseMK, handleMKInput } from '../../utils/formatters';
+import { useGEData } from '../../contexts/GEDataContext';
 
-export default function BuyModal({ stock, onConfirm, onCancel, geData = {}, isSubmitting = false }) {
+export default function BuyModal({ stock, onConfirm, onCancel, isSubmitting = false }) {
+  const { gePrices: geData } = useGEData();
   const [shares, setShares] = useState((stock.limit4h * 1).toString());
   const [price, setPrice] = useState('');
   const [startTimer, setStartTimer] = useState(true);

--- a/src/components/modals/NewStockModal.jsx
+++ b/src/components/modals/NewStockModal.jsx
@@ -1,8 +1,12 @@
 import StepInput from '../StepInput';
 import React, { useState, useMemo, useRef, useEffect } from 'react';
 import { handleMKInput } from '../../utils/formatters';
+import { useGEData } from '../../contexts/GEDataContext';
+import { useTrade } from '../../contexts/TradeContext';
 
-export default function NewStockModal({ categories, defaultCategory = '', defaultIsInvestment = false, mapping = [], archivedStocks = [], onConfirm, onCancel, onRestoreFromArchive }) {
+export default function NewStockModal({ defaultCategory = '', defaultIsInvestment = false, archivedStocks = [], onConfirm, onCancel, onRestoreFromArchive }) {
+  const { geMapping: mapping } = useGEData();
+  const { categories } = useTrade();
   const [stockType, setStockType] = useState('osrs'); // 'osrs' | 'custom'
   const [name, setName] = useState('');
   const [category, setCategory] = useState(defaultCategory);

--- a/src/components/modals/ProfitChartModal.jsx
+++ b/src/components/modals/ProfitChartModal.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { formatNumber } from '../../utils/formatters';
 import { calculateStocksProfit } from '../../utils/calculations';
+import { useTrade } from '../../contexts/TradeContext';
 
-export default function ProfitChartModal({ stocks, dumpProfit, referralProfit, bondsProfit, onCancel, numberFormat }) {
+export default function ProfitChartModal({ dumpProfit, referralProfit, bondsProfit, onCancel, numberFormat }) {
+  const { stocks } = useTrade();
   const stocksProfit = calculateStocksProfit(stocks);
   const totalProfit = stocksProfit + dumpProfit + referralProfit + bondsProfit;
 

--- a/src/components/modals/SellModal.jsx
+++ b/src/components/modals/SellModal.jsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
 import { formatNumber, parseMK, handleMKInput } from '../../utils/formatters';
+import { useGEData } from '../../contexts/GEDataContext';
 
-export default function SellModal({ stock, onConfirm, onCancel, geData = {}, isSubmitting = false }) {
+export default function SellModal({ stock, onConfirm, onCancel, isSubmitting = false }) {
+  const { gePrices: geData } = useGEData();
   const [shares, setShares] = useState('');
   const [price, setPrice] = useState('');
   const [useTotal, setUseTotal] = useState(false);

--- a/src/contexts/GEDataContext.jsx
+++ b/src/contexts/GEDataContext.jsx
@@ -1,0 +1,29 @@
+import { createContext, useContext, useMemo } from 'react';
+import { useGEPrices } from '../hooks/useGEPrices';
+
+const GE_DATA_DEFAULT = { gePrices: {}, geMapping: [], geIconMap: {}, membershipMap: {}, mappingLoading: true };
+const GEDataContext = createContext(GE_DATA_DEFAULT);
+
+export function GEDataProvider({ children }) {
+  const { prices: gePrices, mapping: geMapping, iconMap: geIconMap, mappingLoading } = useGEPrices();
+
+  const membershipMap = useMemo(
+    () => Object.fromEntries((geMapping || []).map(item => [item.id, !!item.members])),
+    [geMapping]
+  );
+
+  const value = useMemo(
+    () => ({ gePrices, geMapping, geIconMap, membershipMap, mappingLoading }),
+    [gePrices, geMapping, geIconMap, membershipMap, mappingLoading]
+  );
+
+  return (
+    <GEDataContext.Provider value={value}>
+      {children}
+    </GEDataContext.Provider>
+  );
+}
+
+export function useGEData() {
+  return useContext(GEDataContext);
+}

--- a/src/contexts/TradeContext.jsx
+++ b/src/contexts/TradeContext.jsx
@@ -1,0 +1,21 @@
+import { createContext, useContext, useMemo } from 'react';
+
+const TRADE_DEFAULT = { stocks: [], categories: [], refetchStocks: () => {}, refetchCategories: () => {} };
+const TradeContext = createContext(TRADE_DEFAULT);
+
+export function TradeProvider({ stocks, categories, refetchStocks, refetchCategories, children }) {
+  const value = useMemo(
+    () => ({ stocks, categories, refetchStocks, refetchCategories }),
+    [stocks, categories, refetchStocks, refetchCategories]
+  );
+
+  return (
+    <TradeContext.Provider value={value}>
+      {children}
+    </TradeContext.Provider>
+  );
+}
+
+export function useTrade() {
+  return useContext(TradeContext);
+}

--- a/src/pages/GraphsPage.jsx
+++ b/src/pages/GraphsPage.jsx
@@ -4,6 +4,8 @@ import { Star, Clock, Search, ChevronDown, Bell, BellRing, StickyNote } from 'lu
 import { useTimeseries } from '../hooks/useTimeseries';
 import { useGraphPreferences } from '../hooks/useGraphPreferences';
 import { calculateGETax } from '../utils/taxUtils';
+import { useGEData } from '../contexts/GEDataContext';
+import { useTrade } from '../contexts/TradeContext';
 import ModalContainer from '../components/modals/ModalContainer';
 import NotesModal from '../components/modals/NotesModal';
 import '../styles/graphs-page.css';
@@ -17,7 +19,9 @@ const TIMEFRAMES = [
   { label: '1Y', timestep: '24h', filterDays: 365 },
 ];
 
-export default function GraphsPage({ mapping, prices, iconMap, mappingLoading, userId, initialItemId, navigateToPage, priceAlerts = {}, onPriceAlert, stocks = [], stockNotes = {}, onSaveNote }) {
+export default function GraphsPage({ userId, initialItemId, navigateToPage, priceAlerts = {}, onPriceAlert, stockNotes = {}, onSaveNote }) {
+  const { geMapping: mapping, gePrices: prices, geIconMap: iconMap, mappingLoading } = useGEData();
+  const { stocks } = useTrade();
   const [searchQuery, setSearchQuery] = useState('');
   const [showDropdown, setShowDropdown] = useState(false);
   const [selectedItem, setSelectedItem] = useState(null);

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import { Star } from 'lucide-react';
 import { formatNumber } from '../utils/formatters';
+import { useGEData } from '../contexts/GEDataContext';
+import { useTrade } from '../contexts/TradeContext';
 import '../styles/table.css';
 import '../styles/history-page.css';
 import '../styles/filter-panel.css';
@@ -29,8 +31,10 @@ export default function HistoryPage({
   page = 1, pageSize = 25, filters = EMPTY_FILTERS,
   onGoToPage, onChangePageSize, onApplyFilters, onInit, numberFormat,
   sortConfig = { key: 'date', dir: 'desc' },
-  onApplySort, stocks = [], onReset, onUndo, membershipMap = {}, geIconMap = {}, showMembershipIcon = true
+  onApplySort, onReset, onUndo, showMembershipIcon = true
 }) {
+  const { geIconMap, membershipMap } = useGEData();
+  const { stocks } = useTrade();
   useEffect(() => { onInit(); }, []);
 
   const stockItemIdMap = useMemo(

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import { formatNumber } from '../utils/formatters';
 import { calculateUnrealizedProfit } from '../utils/taxUtils';
+import { useGEData } from '../contexts/GEDataContext';
+import { useTrade } from '../contexts/TradeContext';
 import '../styles/home-page.css';
 
 const SORT_OPTIONS = [
@@ -14,7 +16,6 @@ const SORT_OPTIONS = [
 ];
 
 export default function HomePage({
-  stocks,
   transactions,
   gpTradedStats,
   profits,
@@ -25,8 +26,9 @@ export default function HomePage({
   onOpenMilestoneModal,
   onOpenMilestoneHistory,
   profitHistory,
-  geData
 }) {
+  const { gePrices: geData } = useGEData();
+  const { stocks } = useTrade();
   const [topItemsSortBy, setTopItemsSortBy] = useState('profit');
   // Use milestoneProgress for period profits (already calculated in MainApp)
   const dayProfit = milestoneProgress?.day || 0;


### PR DESCRIPTION
## Summary
- Add `GEDataContext` (session-global GE prices, mapping, icons) and `TradeContext` (user-scoped stocks, categories) to replace prop drilling from MainApp
- Remove GE/stock/category props from 15 components — they now pull from context directly
- Fix GlobalSearch category navigation: account for topbar height offset and auto-expand collapsed categories

Closes #184

## Test plan
- [ ] Trade page: stock table renders icons, prices, membership badges
- [ ] Buy/Sell/BulkBuy/BulkSell modals show GE prices and submit correctly
- [ ] Adjust/NewStock modals load categories dropdown and GE item search
- [ ] Home page: portfolio stats and unrealized profit display
- [ ] History page: transaction icons, membership badges, stock filtering
- [ ] Graphs page: item search and price charts
- [ ] Global search (Ctrl+K): navigate to category scrolls correctly below topbar
- [ ] Global search: navigate to stock in collapsed category expands it

🤖 Generated with [Claude Code](https://claude.com/claude-code)