### PR TITLE
refactor(calculations): extract cost basis and sell profit into utils

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -64,6 +64,7 @@ import {
   DEFAULT_CATEGORIES,
   DEFAULT_VISIBLE_COLUMNS
 } from './utils/constants';
+import { calculateCostBasis, calculateSellProfit, calculateAvgBuyPrice } from './utils/calculations';
 
 const PAGE_PATHS = { home: '/', trade: '/trade', history: '/history', graphs: '/graphs' };
 
@@ -782,7 +783,6 @@ export default function MainApp({ session, onLogout }) {
     const { shares, price, startTimer } = data;
     const total = shares * price;
 
-    const avgBuy = selectedStock.shares > 0 ? selectedStock.totalCost / selectedStock.shares : 0;
     const newShares = selectedStock.shares + shares;
     let timerEndTime;
     let newOnHold = selectedStock.onHold; // Track if we should update onHold status
@@ -883,9 +883,8 @@ export default function MainApp({ session, onLogout }) {
   const processSellItem = async (item) => {
     const { stock, shares, price } = item;
     const total = shares * price;
-    const avgBuy = stock.shares > 0 ? stock.totalCost / stock.shares : 0;
-    const costBasisOfSharesSold = avgBuy * shares;
-    const profit = total - costBasisOfSharesSold;
+    const costBasisOfSharesSold = calculateCostBasis(stock, shares);
+    const profit = calculateSellProfit(stock, shares, price);
 
     await updateStock(stock.id, {
       shares: stock.shares - shares,
@@ -996,8 +995,8 @@ export default function MainApp({ session, onLogout }) {
     setIsSubmitting(true);
     const { shares } = data;
 
-    const avgBuy = selectedStock.shares > 0 ? selectedStock.totalCost / selectedStock.shares : 0;
-    const costToRemove = avgBuy * shares;
+    const avgBuy = calculateAvgBuyPrice(selectedStock);
+    const costToRemove = calculateCostBasis(selectedStock, shares);
 
     try {
       await updateStock(selectedStock.id, {

--- a/src/utils/calculations.js
+++ b/src/utils/calculations.js
@@ -13,6 +13,14 @@ export const calculateAvgBuyPrice = (stock) => {
   return stock.shares > 0 ? stock.totalCost / stock.shares : 0;
 };
 
+export const calculateCostBasis = (stock, shares) => {
+  return calculateAvgBuyPrice(stock) * shares;
+};
+
+export const calculateSellProfit = (stock, shares, sellPrice) => {
+  return shares * sellPrice - calculateCostBasis(stock, shares);
+};
+
 export const calculateAvgSellPrice = (stock) => {
   return stock.sharesSold > 0 ? stock.totalCostSold / stock.sharesSold : 0;
 };


### PR DESCRIPTION
## Summary
Moves inlined cost basis and profit math out of `MainApp` handlers and into `calculations.js`, resolving #186. The avgBuy formula was duplicated 3 times and the costBasis formula 2 times — now there's one authoritative place for each.

## Changes
- Add `calculateCostBasis(stock, shares)` to `calculations.js`
- Add `calculateSellProfit(stock, shares, sellPrice)` to `calculations.js`
- Replace inline math in `processSellItem` with the new functions
- Replace inline math in `handleRemoveStock` with `calculateAvgBuyPrice` + `calculateCostBasis`
- Remove dead `avgBuy` variable in `handleBuy`