### PR TITLE
refactor(modals): extract archive modals into dedicated components

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -51,6 +51,8 @@ import CategoryChartModal from './components/modals/CategoryChartModal';
 import SettingsModal from './components/modals/SettingsModal';
 import ChangelogModal from './components/modals/ChangelogModal';
 import PriceAlertModal from './components/modals/PriceAlertModal';
+import ArchiveModal from './components/modals/ArchiveModal';
+import ArchiveConfirmModal from './components/modals/ArchiveConfirmModal';
 import { CURRENT_VERSION } from './data/changelog';
 import { usePriceAlerts } from './hooks/usePriceAlerts';
 import { usePriceAlertChecker } from './hooks/usePriceAlertChecker';
@@ -229,37 +231,7 @@ export default function MainApp({ session, onLogout }) {
   const [newStockCategory, setNewStockCategory] = useState('');
 
   const [showArchive, setShowArchive] = useState(false);
-  const [archivedStocks, setArchivedStocks] = useState([]);
-  const [archivedLoading, setArchivedLoading] = useState(false);
   const [showArchiveConfirmModal, setShowArchiveConfirmModal] = useState(false);
-  const [stockToArchive, setStockToArchive] = useState(null);
-
-  const handleOpenArchive = async () => {
-    setArchivedLoading(true);
-    const data = await fetchArchivedStocks();
-    setArchivedStocks(data);
-    setArchivedLoading(false);
-    setShowArchive(true);
-  };
-
-  const handleArchive = (stock) => {
-    setStockToArchive(stock);
-    setShowArchiveConfirmModal(true);
-  };
-
-  const handleConfirmArchive = async () => {
-    await archiveStock(stockToArchive.id);
-    await refetch();
-    setShowArchiveConfirmModal(false);
-    setStockToArchive(null);
-  };
-
-  const handleRestore = async (stock) => {
-    await restoreStock(stock.id);
-    const data = await fetchArchivedStocks();
-    setArchivedStocks(data);
-    await refetch();
-  };
 
   // Price alert handlers
   const handleOpenPriceAlert = (stockOrItem) => {
@@ -768,6 +740,8 @@ export default function MainApp({ session, onLogout }) {
       referralProfit: setShowReferralProfitModal,
       bondsProfit: setShowBondsProfitModal,
       notes: setShowNotesModal,
+      archive: setShowArchive,
+      archiveConfirm: setShowArchiveConfirmModal,
     };
     setters[type]?.(false);
   }, []);
@@ -794,6 +768,14 @@ export default function MainApp({ session, onLogout }) {
     handleAddReferralProfit,
     handleAddBondsProfit,
     handleUpdateMilestone,
+    archivedStocks,
+    archivedLoading,
+    stockToArchive,
+    handleOpenArchive,
+    handleArchive,
+    handleConfirmArchive,
+    handleRestore,
+    refreshArchivedStocks,
   } = useModalHandlers({
     updateStock,
     addTransaction,
@@ -820,6 +802,9 @@ export default function MainApp({ session, onLogout }) {
     setNewStockCategory,
     calculateMilestoneProgress,
     setMilestoneProgress,
+    archiveStock,
+    restoreStock,
+    fetchArchivedStocks,
   });
 
   const handleInvestmentDateChange = async (stock, date) => {
@@ -1432,8 +1417,7 @@ export default function MainApp({ session, onLogout }) {
               <button
                 onClick={async () => {
                   setNewStockCategory('');
-                  const data = await fetchArchivedStocks();
-                  setArchivedStocks(data);
+                  await refreshArchivedStocks();
                   setShowNewStockModal(true);
                 }}
                 className="btn btn-success"
@@ -1453,7 +1437,10 @@ export default function MainApp({ session, onLogout }) {
                 Bulk Sell
               </button>
               <button
-                onClick={handleOpenArchive}
+                onClick={async () => {
+                  await handleOpenArchive();
+                  setShowArchive(true);
+                }}
                 className="btn btn-secondary"
               >
                 📦 Archive
@@ -1500,7 +1487,10 @@ export default function MainApp({ session, onLogout }) {
                   setSelectedStock(stock);
                   setShowDeleteModal(true);
                 }}
-                onArchive={handleArchive}
+                onArchive={(stock) => {
+                  handleArchive(stock);
+                  setShowArchiveConfirmModal(true);
+                }}
                 onNotes={(stock) => {
                   setSelectedStock(stock);
                   setShowNotesModal(true);
@@ -1761,87 +1751,21 @@ export default function MainApp({ session, onLogout }) {
         </ModalContainer>
 
         <ModalContainer isOpen={showArchive}>
-          <div style={{
-            background: 'rgb(30, 41, 59)',
-            padding: '1.5rem',
-            borderRadius: '0.75rem',
-            width: '36rem',
-            maxWidth: '90vw',
-            maxHeight: '80vh',
-            overflowY: 'auto',
-            boxShadow: '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
-            border: '1px solid rgb(51, 65, 85)'
-          }}>
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
-              <h2 style={{ fontSize: '1.5rem', fontWeight: 'bold' }}>📦 Archive</h2>
-              <button onClick={() => setShowArchive(false)} className="btn btn-secondary btn-sm">Close</button>
-            </div>
-            {archivedLoading ? (
-              <p style={{ color: 'rgb(148, 163, 184)' }}>Loading...</p>
-            ) : archivedStocks.length === 0 ? (
-              <p style={{ color: 'rgb(148, 163, 184)' }}>No archived stocks.</p>
-            ) : (
-              <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-                {archivedStocks.map(stock => (
-                  <div key={stock.id} style={{
-                    display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-                    padding: '0.75rem 1rem', background: 'rgb(51, 65, 85)',
-                    borderRadius: '0.5rem', gap: '1rem'
-                  }}>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flex: 1 }}>
-                      {stock.itemId && geIconMap[stock.itemId] && (
-                        <img src={geIconMap[stock.itemId]} alt="" style={{ width: '20px', height: '20px', objectFit: 'contain', imageRendering: 'pixelated' }} />
-                      )}
-                      <div>
-                        <div style={{ fontWeight: '600', color: 'white' }}>{stock.name}</div>
-                        <div style={{ fontSize: '0.75rem', color: 'rgb(148, 163, 184)' }}>
-                          {stock.isInvestment ? '📈 Investment' : '💼 Trade'} · {stock.category}
-                        </div>
-                      </div>
-                    </div>
-                    <button
-                      onClick={() => handleRestore(stock)}
-                      className="btn btn-success btn-sm"
-                    >
-                      Restore
-                    </button>
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
+          <ArchiveModal
+            archivedStocks={archivedStocks}
+            loading={archivedLoading}
+            geIconMap={geIconMap}
+            onRestore={handleRestore}
+            onClose={() => setShowArchive(false)}
+          />
         </ModalContainer>
 
         <ModalContainer isOpen={showArchiveConfirmModal}>
-          <div style={{
-            background: 'rgb(30, 41, 59)',
-            padding: '1.5rem',
-            borderRadius: '0.75rem',
-            width: '24rem',
-            boxShadow: '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
-            border: '1px solid rgb(51, 65, 85)'
-          }}>
-            <h2 style={{ fontSize: '1.25rem', fontWeight: 'bold', marginBottom: '0.5rem' }}>Archive Stock</h2>
-            <p style={{ color: 'rgb(148, 163, 184)', marginBottom: '1.5rem', fontSize: '0.875rem' }}>
-              Are you sure you want to archive <strong style={{ color: 'white' }}>{stockToArchive?.name}</strong>? It will be removed from your trade screen but can be restored anytime.
-            </p>
-            <div style={{ display: 'flex', gap: '0.75rem' }}>
-              <button
-                onClick={handleConfirmArchive}
-                className="btn btn-warning"
-                style={{ flex: 1 }}
-              >
-                📦 Archive
-              </button>
-              <button
-                onClick={() => { setShowArchiveConfirmModal(false); setStockToArchive(null); }}
-                className="btn btn-secondary"
-                style={{ flex: 1 }}
-              >
-                Cancel
-              </button>
-            </div>
-          </div>
+          <ArchiveConfirmModal
+            stock={stockToArchive}
+            onConfirm={handleConfirmArchive}
+            onCancel={() => { setShowArchiveConfirmModal(false); }}
+          />
         </ModalContainer>
 
         <ModalContainer isOpen={showMilestoneModal}>

--- a/src/components/modals/ArchiveConfirmModal.jsx
+++ b/src/components/modals/ArchiveConfirmModal.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import '../../styles/archive-modal.css';
+
+export default function ArchiveConfirmModal({ stock, onConfirm, onCancel }) {
+  return (
+    <div className="modal-container archive-confirm-modal">
+      <h2 className="archive-confirm-title">Archive Stock</h2>
+      <p className="archive-confirm-text">
+        Are you sure you want to archive <strong className="archive-confirm-name">{stock?.name}</strong>? It will be removed from your trade screen but can be restored anytime.
+      </p>
+      <div className="archive-confirm-actions">
+        <button onClick={onConfirm} className="btn btn-warning">
+          📦 Archive
+        </button>
+        <button onClick={onCancel} className="btn btn-secondary">
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/modals/ArchiveModal.jsx
+++ b/src/components/modals/ArchiveModal.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import '../../styles/archive-modal.css';
+
+export default function ArchiveModal({ archivedStocks, loading, geIconMap, onRestore, onClose }) {
+  return (
+    <div className="modal-container archive-modal">
+      <div className="archive-modal-header">
+        <h2 className="archive-modal-title">📦 Archive</h2>
+        <button onClick={onClose} className="btn btn-secondary btn-sm">Close</button>
+      </div>
+      {loading ? (
+        <p className="archive-modal-empty">Loading...</p>
+      ) : archivedStocks.length === 0 ? (
+        <p className="archive-modal-empty">No archived stocks.</p>
+      ) : (
+        <div className="archive-modal-list">
+          {archivedStocks.map(stock => (
+            <div key={stock.id} className="archive-modal-item">
+              <div className="archive-modal-item-info">
+                {stock.itemId && geIconMap[stock.itemId] && (
+                  <img src={geIconMap[stock.itemId]} alt="" className="archive-modal-item-icon" />
+                )}
+                <div>
+                  <div className="archive-modal-item-name">{stock.name}</div>
+                  <div className="archive-modal-item-meta">
+                    {stock.isInvestment ? '📈 Investment' : '💼 Trade'} · {stock.category}
+                  </div>
+                </div>
+              </div>
+              <button
+                onClick={() => onRestore(stock)}
+                className="btn btn-success btn-sm"
+              >
+                Restore
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useModalHandlers.js
+++ b/src/hooks/useModalHandlers.js
@@ -29,6 +29,9 @@ import { calculateCostBasis, calculateSellProfit, calculateAvgBuyPrice } from '.
  * @param {Function} opts.setNewStockCategory
  * @param {Function} opts.calculateMilestoneProgress
  * @param {Function} opts.setMilestoneProgress
+ * @param {Function} opts.archiveStock
+ * @param {Function} opts.restoreStock
+ * @param {Function} opts.fetchArchivedStocks
  */
 export function useModalHandlers({
   updateStock,
@@ -56,11 +59,18 @@ export function useModalHandlers({
   setNewStockCategory,
   calculateMilestoneProgress,
   setMilestoneProgress,
+  archiveStock,
+  restoreStock,
+  fetchArchivedStocks,
 }) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [bulkSummaryData, setBulkSummaryData] = useState(null);
   const [isUndoing, setIsUndoing] = useState(false);
   const [undoResult, setUndoResult] = useState(null);
+
+  const [archivedStocks, setArchivedStocks] = useState([]);
+  const [archivedLoading, setArchivedLoading] = useState(false);
+  const [stockToArchive, setStockToArchive] = useState(null);
 
   const processBuyItem = useCallback(async (item) => {
     const { stock, shares, price, startTimer } = item;
@@ -439,6 +449,37 @@ export function useModalHandlers({
     }
   }, [updateMilestone, setMilestoneProgress, calculateMilestoneProgress]);
 
+  const handleOpenArchive = useCallback(async () => {
+    setArchivedLoading(true);
+    const data = await fetchArchivedStocks();
+    setArchivedStocks(data);
+    setArchivedLoading(false);
+    closeModal('archiveConfirm');
+  }, [fetchArchivedStocks, closeModal]);
+
+  const handleArchive = useCallback((stock) => {
+    setStockToArchive(stock);
+  }, []);
+
+  const handleConfirmArchive = useCallback(async () => {
+    await archiveStock(stockToArchive.id);
+    await refetch();
+    setStockToArchive(null);
+    closeModal('archiveConfirm');
+  }, [stockToArchive, archiveStock, refetch, closeModal]);
+
+  const handleRestore = useCallback(async (stock) => {
+    await restoreStock(stock.id);
+    const data = await fetchArchivedStocks();
+    setArchivedStocks(data);
+    await refetch();
+  }, [restoreStock, fetchArchivedStocks, refetch]);
+
+  const refreshArchivedStocks = useCallback(async () => {
+    const data = await fetchArchivedStocks();
+    setArchivedStocks(data);
+  }, [fetchArchivedStocks]);
+
   return {
     isSubmitting,
     bulkSummaryData,
@@ -462,5 +503,13 @@ export function useModalHandlers({
     handleAddReferralProfit,
     handleAddBondsProfit,
     handleUpdateMilestone,
+    archivedStocks,
+    archivedLoading,
+    stockToArchive,
+    handleOpenArchive,
+    handleArchive,
+    handleConfirmArchive,
+    handleRestore,
+    refreshArchivedStocks,
   };
 }

--- a/src/styles/archive-modal.css
+++ b/src/styles/archive-modal.css
@@ -1,0 +1,91 @@
+.archive-modal {
+  width: 36rem;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.archive-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.archive-modal-title {
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.archive-modal-empty {
+  color: rgb(148, 163, 184);
+}
+
+.archive-modal-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.archive-modal-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  background: rgb(51, 65, 85);
+  border-radius: 0.5rem;
+  gap: 1rem;
+}
+
+.archive-modal-item-info {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1;
+}
+
+.archive-modal-item-icon {
+  width: 20px;
+  height: 20px;
+  object-fit: contain;
+  image-rendering: pixelated;
+}
+
+.archive-modal-item-name {
+  font-weight: 600;
+  color: white;
+}
+
+.archive-modal-item-meta {
+  font-size: 0.75rem;
+  color: rgb(148, 163, 184);
+}
+
+/* Confirm modal */
+.archive-confirm-modal {
+  width: 24rem;
+}
+
+.archive-confirm-title {
+  font-size: 1.25rem;
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+}
+
+.archive-confirm-text {
+  color: rgb(148, 163, 184);
+  margin-bottom: 1.5rem;
+  font-size: 0.875rem;
+}
+
+.archive-confirm-name {
+  color: white;
+}
+
+.archive-confirm-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.archive-confirm-actions .btn {
+  flex: 1;
+}


### PR DESCRIPTION
## Summary
- Created `ArchiveModal.jsx` and `ArchiveConfirmModal.jsx` as dedicated components, replacing ~80 lines of inline JSX in MainApp
- Moved archive state (`archivedStocks`, `archivedLoading`, `stockToArchive`) and handlers (`handleOpenArchive`, `handleArchive`, `handleConfirmArchive`, `handleRestore`) into `useModalHandlers`
- Extracted inline styles into `src/styles/archive-modal.css`

Closes #209

## Test plan
- [ ] Archive button opens modal, shows loading then archived stock list (or empty message)
- [ ] Restore from archive modal moves stock back, list updates in-place
- [ ] Archive a stock from row action opens confirm, confirming archives it
- [ ] Cancel archive confirm dismisses without archiving
- [ ] Add Stock button still shows archived stocks in NewStockModal
- [ ] Restore from NewStockModal closes modal and restores stock

🤖 Generated with [Claude Code](https://claude.com/claude-code)