### PR TITLE
refactor(modals): extract ModalManager and ModalContext from MainApp

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -16,43 +16,19 @@ import { useMilestones } from './hooks/useMilestones';
 import { useProfitHistory } from './hooks/useProfitHistory';
 import { useGEData } from './contexts/GEDataContext';
 import { TradeProvider } from './contexts/TradeContext';
+import { ModalProvider, useModal } from './contexts/ModalContext';
 import { useNotifications } from './hooks/useNotifications';
 import { useOSRSNews } from './hooks/useOSRSNews';
 import { useJmodComments } from './hooks/useJmodComments';
 import CategoryQuickNav from './components/CategoryQuickNav';
 import MilestoneProgressBar from './components/MilestoneProgressBar';
-import MilestoneTrackerModal from './components/modals/MilestoneTrackerModal';
-import AltTimerModal from './components/modals/AltTimerModal';
 import Footer from './components/Footer';
-import EditCategoryModal from './components/modals/EditCategoryModal';
-import TimeCalculatorModal from './components/modals/TimeCalculatorModal';
 import Header from './components/Header';
 import NotificationCenter from './components/NotificationCenter';
 import PortfolioSummary from './components/PortfolioSummary';
 import ChartButtons from './components/ChartButtons';
 import CategorySection from './components/CategorySection';
-import ChangePasswordModal from './components/modals/ChangePasswordModal';
-import ModalContainer from './components/modals/ModalContainer';
-import BuyModal from './components/modals/BuyModal';
-import BulkBuyModal from './components/modals/BulkBuyModal';
-import BulkSellModal from './components/modals/BulkSellModal';
-import BulkSummaryModal from './components/modals/BulkSummaryModal';
-import SellModal from './components/modals/SellModal';
-import RemoveStockModal from './components/modals/RemoveStockModal';
-import AdjustModal from './components/modals/AdjustModal';
-import DeleteModal from './components/modals/DeleteModal';
-import NewStockModal from './components/modals/NewStockModal';
-import CategoryModal from './components/modals/CategoryModal';
-import DeleteCategoryModal from './components/modals/DeleteCategoryModal';
-import ProfitModal from './components/modals/ProfitModal';
-import NotesModal from './components/modals/NotesModal';
-import ProfitChartModal from './components/modals/ProfitChartModal';
-import CategoryChartModal from './components/modals/CategoryChartModal';
-import SettingsModal from './components/modals/SettingsModal';
-import ChangelogModal from './components/modals/ChangelogModal';
-import PriceAlertModal from './components/modals/PriceAlertModal';
-import ArchiveModal from './components/modals/ArchiveModal';
-import ArchiveConfirmModal from './components/modals/ArchiveConfirmModal';
+import ModalManager from './components/ModalManager';
 import { CURRENT_VERSION } from './data/changelog';
 import { usePriceAlerts } from './hooks/usePriceAlerts';
 import { usePriceAlertChecker } from './hooks/usePriceAlertChecker';
@@ -85,10 +61,17 @@ function getPageFromURL() {
   return 'home';
 }
 
-export default function MainApp({ session, onLogout }) {
+export default function MainApp(props) {
+  return (
+    <ModalProvider>
+      <MainAppInner {...props} />
+    </ModalProvider>
+  );
+}
+
+function MainAppInner({ session, onLogout }) {
   const userId = session.user.id;
   const userEmail = session.user.email;
-  const [showChangelog, setShowChangelog] = useState(false);
   // Custom hooks for Supabase
   const [tradeMode, setTradeMode] = useState('trade');
   const { gePrices, geMapping, geIconMap, membershipMap, mappingLoading } = useGEData();
@@ -197,61 +180,28 @@ export default function MainApp({ session, onLogout }) {
   const [currentTime, setCurrentTime] = useState(Date.now());
   const dataLoaded = !stocksLoading && !categoriesLoading && !transactionsLoading && !notesLoading && !settingsLoading && !profitsLoading && !milestonesLoading && !profitHistoryLoading && !gpStatsLoading;
 
-  // Modal states
-  const [showBuyModal, setShowBuyModal] = useState(false);
-  const [showBulkBuyModal, setShowBulkBuyModal] = useState(false);
-  const [showBulkSellModal, setShowBulkSellModal] = useState(false);
-  const [showSellModal, setShowSellModal] = useState(false);
-  const [showRemoveModal, setShowRemoveModal] = useState(false);
   const [selectedMilestonePeriod, setSelectedMilestonePeriod] = useState('day');
-  const [showAdjustModal, setShowAdjustModal] = useState(false);
-  const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const [showMilestoneModal, setShowMilestoneModal] = useState(false);
-  const [milestoneInitialView, setMilestoneInitialView] = useState('main');
-  const [showNewStockModal, setShowNewStockModal] = useState(false);
-  const [showCategoryModal, setShowCategoryModal] = useState(false);
-  const [showAltTimerModal, setShowAltTimerModal] = useState(false);
-  const [showChangePasswordModal, setShowChangePasswordModal] = useState(false);
-  const [showDeleteCategoryModal, setShowDeleteCategoryModal] = useState(false);
-  const [showDumpProfitModal, setShowDumpProfitModal] = useState(false);
-  const [showReferralProfitModal, setShowReferralProfitModal] = useState(false);
-  const [showBondsProfitModal, setShowBondsProfitModal] = useState(false);
-  const [showNotesModal, setShowNotesModal] = useState(false);
-  const [showProfitChartModal, setShowProfitChartModal] = useState(false);
-  const [showCategoryChartModal, setShowCategoryChartModal] = useState(false);
-  const [showSettingsModal, setShowSettingsModal] = useState(false);
-  const [showTimeCalculatorModal, setShowTimeCalculatorModal] = useState(false);
-  const [showEditCategoryModal, setShowEditCategoryModal] = useState(false);
-  const [showPriceAlertModal, setShowPriceAlertModal] = useState(false);
-  const [selectedAlertItem, setSelectedAlertItem] = useState(null);
   const [userMenuOpen, setUserMenuOpen] = useState(false);
 
-  const [selectedStock, setSelectedStock] = useState(null);
-  const [selectedCategory, setSelectedCategory] = useState(null);
-  const [newStockCategory, setNewStockCategory] = useState('');
-
-  const [showArchive, setShowArchive] = useState(false);
-  const [showArchiveConfirmModal, setShowArchiveConfirmModal] = useState(false);
+  // Modal context
+  const { openModal, closeModal, selectedStock, setSelectedStock, selectedCategory, setSelectedCategory, newStockCategory, setNewStockCategory, setSelectedAlertItem } = useModal();
 
   // Price alert handlers
   const handleOpenPriceAlert = (stockOrItem) => {
     const itemId = stockOrItem.itemId ?? stockOrItem.itemId;
     const itemName = stockOrItem.itemName ?? stockOrItem.name;
     if (!itemId) return;
-    setSelectedAlertItem({ itemId, itemName });
-    setShowPriceAlertModal(true);
+    openModal('priceAlert', { alertItem: { itemId, itemName } });
   };
 
   const handleSavePriceAlert = async (itemId, itemName, highThreshold, lowThreshold) => {
     await savePriceAlert(itemId, itemName, highThreshold, lowThreshold);
-    setShowPriceAlertModal(false);
-    setSelectedAlertItem(null);
+    closeModal('priceAlert');
   };
 
   const handleDeletePriceAlert = async (alertId) => {
     await dismissPriceAlert(alertId);
-    setShowPriceAlertModal(false);
-    setSelectedAlertItem(null);
+    closeModal('priceAlert');
   };
 
   // Notifications
@@ -700,13 +650,13 @@ export default function MainApp({ session, onLogout }) {
     const storageKey = `lastSeenVersion_${userId}`;
     const lastSeen = localStorage.getItem(storageKey);
     if (lastSeen !== CURRENT_VERSION) {
-      setShowChangelog(true);
+      openModal('changelog');
     }
   }, [userId]);
 
   const handleCloseChangelog = () => {
     localStorage.setItem(`lastSeenVersion_${userId}`, CURRENT_VERSION);
-    setShowChangelog(false);
+    closeModal('changelog');
   };
 
   const toggleCategory = (category) => {
@@ -722,29 +672,6 @@ export default function MainApp({ session, onLogout }) {
   };
 
   const [milestoneProgress, setMilestoneProgress] = useState({ day: 0, week: 0, month: 0, year: 0 });
-
-  const closeModal = useCallback((type) => {
-    const setters = {
-      buy: setShowBuyModal,
-      bulkBuy: setShowBulkBuyModal,
-      bulkSell: setShowBulkSellModal,
-      sell: setShowSellModal,
-      remove: setShowRemoveModal,
-      adjust: setShowAdjustModal,
-      delete: setShowDeleteModal,
-      newStock: setShowNewStockModal,
-      category: setShowCategoryModal,
-      deleteCategory: setShowDeleteCategoryModal,
-      editCategory: setShowEditCategoryModal,
-      dumpProfit: setShowDumpProfitModal,
-      referralProfit: setShowReferralProfitModal,
-      bondsProfit: setShowBondsProfitModal,
-      notes: setShowNotesModal,
-      archive: setShowArchive,
-      archiveConfirm: setShowArchiveConfirmModal,
-    };
-    setters[type]?.(false);
-  }, []);
 
   const {
     isSubmitting,
@@ -872,7 +799,7 @@ export default function MainApp({ session, onLogout }) {
     const timerEndTime = Date.now() + (days * 24 * 60 * 60 * 1000);
     firedAltTimerNotif.current = false;
     await updateSettings({ altAccountTimer: timerEndTime });
-    setShowAltTimerModal(false);
+    closeModal('altTimer');
   };
 
   const handleResetAltTimer = async () => {
@@ -882,7 +809,7 @@ export default function MainApp({ session, onLogout }) {
 
   const handleSaveNotes = async (noteText) => {
     await saveNote(selectedStock.id, noteText);
-    setShowNotesModal(false);
+    closeModal('notes');
   };
 
   // Drag and drop operations
@@ -923,30 +850,11 @@ export default function MainApp({ session, onLogout }) {
   };
 
   const handleStockAction = (stock, action) => {
-    setSelectedStock(stock);
-    switch (action) {
-      case 'buy':
-        setShowBuyModal(true);
-        break;
-      case 'sell':
-        setShowSellModal(true);
-        break;
-      case 'remove':
-        setShowRemoveModal(true);
-        break;
-      case 'adjust':
-        setShowAdjustModal(true);
-        break;
-      case 'delete':
-        setShowDeleteModal(true);
-        break;
-      case 'notes':
-        setShowNotesModal(true);
-        break;
-      case 'calculate':
-        handleCalculateTime(stock);
-        break;
+    if (action === 'calculate') {
+      handleCalculateTime(stock);
+      return;
     }
+    openModal(action, { stock });
   };
 
   const handleStockDragStart = (e, stockId, sourceCategory) => {
@@ -1049,9 +957,8 @@ export default function MainApp({ session, onLogout }) {
     }
   };
 
-  const handleCalculateTime = async (stock) => {
-    setSelectedStock(stock);
-    setShowTimeCalculatorModal(true);
+  const handleCalculateTime = (stock) => {
+    openModal('timeCalculator', { stock });
   };
 
 
@@ -1247,10 +1154,7 @@ export default function MainApp({ session, onLogout }) {
             newOsrsNewsCount={notifications.filter(n => n.type === 'osrsNews' && !n.read).length}
             priceAlerts={priceAlerts}
             allPriceAlerts={allPriceAlerts}
-            onEditAlert={(alert) => {
-              setSelectedAlertItem({ itemId: alert.itemId, itemName: alert.itemName });
-              setShowPriceAlertModal(true);
-            }}
+            onEditAlert={(alert) => openModal('priceAlert', { alertItem: { itemId: alert.itemId, itemName: alert.itemName } })}
             onDismissAlert={dismissPriceAlert}
             onNewAlert={() => navigateToPage('graphs')}
           />
@@ -1269,7 +1173,7 @@ export default function MainApp({ session, onLogout }) {
               <div className="user-dropdown-menu">
                 <button
                   className="user-dropdown-item"
-                  onClick={() => { setShowSettingsModal(true); setUserMenuOpen(false); }}
+                  onClick={() => { openModal('settings'); setUserMenuOpen(false); }}
                 >
                   ⚙️ Settings
                 </button>
@@ -1307,8 +1211,8 @@ export default function MainApp({ session, onLogout }) {
             milestones={milestones}
             milestoneProgress={milestoneProgress}
             onNavigateToTrade={() => navigateToPage('trade')}
-            onOpenMilestoneModal={() => { setMilestoneInitialView('main'); setShowMilestoneModal(true); }}
-            onOpenMilestoneHistory={() => { setMilestoneInitialView('history'); setShowMilestoneModal(true); }}
+            onOpenMilestoneModal={() => openModal('milestone', { milestoneView: 'main' })}
+            onOpenMilestoneHistory={() => openModal('milestone', { milestoneView: 'history' })}
           />
         ) : currentPage === 'history' ? (
           <HistoryPage
@@ -1354,9 +1258,9 @@ export default function MainApp({ session, onLogout }) {
               referralProfit={referralProfit}
               bondsProfit={bondsProfit}
               visibleProfits={visibleProfits}
-              onAddDumpProfit={() => setShowDumpProfitModal(true)}
-              onAddReferralProfit={() => setShowReferralProfitModal(true)}
-              onAddBondsProfit={() => setShowBondsProfitModal(true)}
+              onAddDumpProfit={() => openModal('dumpProfit')}
+              onAddReferralProfit={() => openModal('referralProfit')}
+              onAddBondsProfit={() => openModal('bondsProfit')}
               numberFormat={numberFormat}
               showUnrealisedProfitStats={showUnrealisedProfitStats}
             />
@@ -1375,15 +1279,15 @@ export default function MainApp({ session, onLogout }) {
                 currentProgress={milestoneProgress}
                 selectedPeriod={selectedMilestonePeriod}
                 onPeriodChange={setSelectedMilestonePeriod}
-                onOpenModal={() => { setMilestoneInitialView('main'); setShowMilestoneModal(true); }}
+                onOpenModal={() => openModal('milestone', { milestoneView: 'main' })}
                 numberFormat={numberFormat}
               />
 
               <ChartButtons
-                onShowProfitChart={() => setShowProfitChartModal(true)}
-                onShowCategoryChart={() => setShowCategoryChartModal(true)}
+                onShowProfitChart={() => openModal('profitChart')}
+                onShowCategoryChart={() => openModal('categoryChart')}
                 altAccountTimer={altAccountTimer}
-                onSetAltTimer={() => setShowAltTimerModal(true)}
+                onSetAltTimer={() => openModal('altTimer')}
                 onResetAltTimer={handleResetAltTimer}
                 currentTime={currentTime}
               />
@@ -1409,29 +1313,28 @@ export default function MainApp({ session, onLogout }) {
             {/* Category Actions */}
             <div className="category-actions-row">
               <button
-                onClick={() => setShowCategoryModal(true)}
+                onClick={() => openModal('category')}
                 className="btn btn-primary"
               >
                 + Add Category
               </button>
               <button
                 onClick={async () => {
-                  setNewStockCategory('');
                   await refreshArchivedStocks();
-                  setShowNewStockModal(true);
+                  openModal('newStock', { newStockCategory: '' });
                 }}
                 className="btn btn-success"
               >
                 + Add Stock
               </button>
               <button
-                onClick={() => setShowBulkBuyModal(true)}
+                onClick={() => openModal('bulkBuy')}
                 className="btn btn-success"
               >
                 Bulk Buy
               </button>
               <button
-                onClick={() => setShowBulkSellModal(true)}
+                onClick={() => openModal('bulkSell')}
                 className="btn btn-danger"
               >
                 Bulk Sell
@@ -1439,7 +1342,7 @@ export default function MainApp({ session, onLogout }) {
               <button
                 onClick={async () => {
                   await handleOpenArchive();
-                  setShowArchive(true);
+                  openModal('archive');
                 }}
                 className="btn btn-secondary"
               >
@@ -1455,46 +1358,19 @@ export default function MainApp({ session, onLogout }) {
                 stocks={categoryStocks}
                 isCollapsed={collapsedCategories[category]}
                 onToggleCollapse={toggleCategory}
-                onAddStock={(cat) => {
-                  setNewStockCategory(cat);
-                  setShowNewStockModal(true);
-                }}
-                onDeleteCategory={(cat) => {
-                  setSelectedCategory(cat);
-                  setShowDeleteCategoryModal(true);
-                }}
-                onEditCategory={(cat) => {
-                  setSelectedCategory(cat);
-                  setShowEditCategoryModal(true);
-                }}
-                onBuy={(stock) => {
-                  setSelectedStock(stock);
-                  setShowBuyModal(true);
-                }}
-                onSell={(stock) => {
-                  setSelectedStock(stock);
-                  setShowSellModal(true);
-                }}
-                onRemove={(stock) => {
-                  setSelectedStock(stock);
-                  setShowRemoveModal(true);
-                }}
-                onAdjust={(stock) => {
-                  setSelectedStock(stock);
-                  setShowAdjustModal(true);
-                }}
-                onDelete={(stock) => {
-                  setSelectedStock(stock);
-                  setShowDeleteModal(true);
-                }}
+                onAddStock={(cat) => openModal('newStock', { newStockCategory: cat })}
+                onDeleteCategory={(cat) => openModal('deleteCategory', { category: cat })}
+                onEditCategory={(cat) => openModal('editCategory', { category: cat })}
+                onBuy={(stock) => openModal('buy', { stock })}
+                onSell={(stock) => openModal('sell', { stock })}
+                onRemove={(stock) => openModal('remove', { stock })}
+                onAdjust={(stock) => openModal('adjust', { stock })}
+                onDelete={(stock) => openModal('delete', { stock })}
                 onArchive={(stock) => {
                   handleArchive(stock);
-                  setShowArchiveConfirmModal(true);
+                  openModal('archiveConfirm');
                 }}
-                onNotes={(stock) => {
-                  setSelectedStock(stock);
-                  setShowNotesModal(true);
-                }}
+                onNotes={(stock) => openModal('notes', { stock })}
                 onCalculate={handleCalculateTime}
                 onDragStart={handleStockDragStart}
                 onDragOver={handleStockDragOver}
@@ -1520,267 +1396,66 @@ export default function MainApp({ session, onLogout }) {
               />
             ))}
 
-            {/* Modals */}
-            <ModalContainer isOpen={showBuyModal}>
-              <BuyModal
-                stock={selectedStock}
-                onConfirm={handleBuy}
-                onCancel={() => setShowBuyModal(false)}
-                isSubmitting={isSubmitting}
-              />
-            </ModalContainer>
-
-            <ModalContainer isOpen={showBulkBuyModal}>
-              <BulkBuyModal
-                tradeMode={tradeMode}
-                onConfirm={handleBulkBuy}
-                onCancel={() => setShowBulkBuyModal(false)}
-                isSubmitting={isSubmitting}
-              />
-            </ModalContainer>
-
-            <ModalContainer isOpen={showBulkSellModal}>
-              <BulkSellModal
-                tradeMode={tradeMode}
-                onConfirm={handleBulkSell}
-                onCancel={() => setShowBulkSellModal(false)}
-                isSubmitting={isSubmitting}
-              />
-            </ModalContainer>
-
-            <ModalContainer isOpen={bulkSummaryData !== null}>
-              <BulkSummaryModal
-                type={bulkSummaryData?.type}
-                completedItems={bulkSummaryData?.items || []}
-                onUndo={handleBulkUndo}
-                onDone={handleBulkSummaryDone}
-                isUndoing={isUndoing}
-                undoResult={undoResult}
-              />
-            </ModalContainer>
-
-            <ModalContainer isOpen={showSellModal}>
-              <SellModal
-                stock={selectedStock}
-                onConfirm={handleSell}
-                onCancel={() => setShowSellModal(false)}
-                isSubmitting={isSubmitting}
-              />
-            </ModalContainer>
-
-            <ModalContainer isOpen={showRemoveModal}>
-              <RemoveStockModal
-                stock={selectedStock}
-                onConfirm={handleRemoveStock}
-                onCancel={() => setShowRemoveModal(false)}
-                isSubmitting={isSubmitting}
-              />
-            </ModalContainer>
-
-            <ModalContainer isOpen={showAdjustModal}>
-              <AdjustModal
-                stock={selectedStock}
-                onConfirm={handleAdjust}
-                onCancel={() => setShowAdjustModal(false)}
-              />
-            </ModalContainer>
-
-            <ModalContainer isOpen={showDeleteModal}>
-              <DeleteModal
-                stock={selectedStock}
-                onConfirm={handleDelete}
-                onCancel={() => setShowDeleteModal(false)}
-              />
-            </ModalContainer>
-
-            <ModalContainer isOpen={showNewStockModal}>
-              <NewStockModal
-                defaultCategory={newStockCategory}
-                defaultIsInvestment={tradeMode === 'investment'}
-                onConfirm={handleAddStock}
-                archivedStocks={archivedStocks}
-                onRestoreFromArchive={async (stock) => {
-                  await handleRestore(stock);
-                  setShowNewStockModal(false);
-                }}
-                onCancel={() => setShowNewStockModal(false)}
-              />
-            </ModalContainer>
-
-            <ModalContainer isOpen={showCategoryModal}>
-              <CategoryModal
-                defaultIsInvestment={tradeMode === 'investment'}
-                onConfirm={handleAddCategory}
-                onCancel={() => setShowCategoryModal(false)}
-              />
-            </ModalContainer>
-
-            <ModalContainer isOpen={showDeleteCategoryModal}>
-              <DeleteCategoryModal
-                category={selectedCategory}
-                onConfirm={handleDeleteCategory}
-                onCancel={() => setShowDeleteCategoryModal(false)}
-              />
-            </ModalContainer>
-
-            <ModalContainer isOpen={showDumpProfitModal}>
-              <ProfitModal
-                type="dump"
-                onConfirm={handleAddDumpProfit}
-                onCancel={() => setShowDumpProfitModal(false)}
-              />
-            </ModalContainer>
-
-            <ModalContainer isOpen={showReferralProfitModal}>
-              <ProfitModal
-                type="referral"
-                onConfirm={handleAddReferralProfit}
-                onCancel={() => setShowReferralProfitModal(false)}
-              />
-            </ModalContainer>
-
-            <ModalContainer isOpen={showBondsProfitModal}>
-              <ProfitModal
-                type="bonds"
-                onConfirm={handleAddBondsProfit}
-                onCancel={() => setShowBondsProfitModal(false)}
-              />
-            </ModalContainer>
-
-            <ModalContainer isOpen={showNotesModal}>
-              <NotesModal
-                stock={selectedStock}
-                notes={stockNotes[selectedStock?.id]}
-                onConfirm={handleSaveNotes}
-                onCancel={() => setShowNotesModal(false)}
-              />
-            </ModalContainer>
-
-            <ModalContainer isOpen={showProfitChartModal}>
-              <ProfitChartModal
-                dumpProfit={dumpProfit}
-                referralProfit={referralProfit}
-                bondsProfit={bondsProfit}
-                onCancel={() => setShowProfitChartModal(false)}
-                numberFormat={numberFormat}
-              />
-            </ModalContainer>
-
-            <ModalContainer isOpen={showCategoryChartModal}>
-              <CategoryChartModal
-                groupedStocks={groupedStocks}
-                onCancel={() => setShowCategoryChartModal(false)}
-                numberFormat={numberFormat}
-              />
-            </ModalContainer>
-
-
-
-            <ModalContainer isOpen={showEditCategoryModal}>
-              <EditCategoryModal
-                category={selectedCategory}
-                categories={categoryNames}
-                onConfirm={handleEditCategory}
-                onCancel={() => setShowEditCategoryModal(false)}
-              />
-            </ModalContainer>
-
-            <ModalContainer isOpen={showTimeCalculatorModal}>
-              <TimeCalculatorModal
-                stock={selectedStock}
-                onClose={() => setShowTimeCalculatorModal(false)}
-              />
-            </ModalContainer>
-
-            <ModalContainer isOpen={showAltTimerModal}>
-              <AltTimerModal
-                onConfirm={handleSetAltTimer}
-                onCancel={() => setShowAltTimerModal(false)}
-              />
-            </ModalContainer>
-
-            <ModalContainer isOpen={showChangePasswordModal}>
-              <ChangePasswordModal
-                onCancel={() => setShowChangePasswordModal(false)}
-              />
-            </ModalContainer>
-
           </>
         )}
 
-        <ModalContainer isOpen={showPriceAlertModal}>
-          <PriceAlertModal
-            itemId={selectedAlertItem?.itemId}
-            itemName={selectedAlertItem?.itemName}
-            currentAlert={selectedAlertItem ? priceAlerts[selectedAlertItem.itemId] : null}
-            gePrice={selectedAlertItem ? gePrices[selectedAlertItem.itemId] : null}
-            onSave={handleSavePriceAlert}
-            onDelete={handleDeletePriceAlert}
-            onCancel={() => { setShowPriceAlertModal(false); setSelectedAlertItem(null); }}
-          />
-        </ModalContainer>
-
-        <ModalContainer isOpen={showSettingsModal}>
-          <SettingsModal
-            numberFormat={numberFormat}
-            onNumberFormatChange={(newFormat) => updateSettings({ numberFormat: newFormat })}
-            visibleColumns={visibleColumns}
-            onVisibleColumnsChange={(newColumns) => updateSettings({ visibleColumns: newColumns })}
-            visibleProfits={visibleProfits}
-            onVisibleProfitsChange={(newProfits) => updateSettings({ visibleProfits: newProfits })}
-            showCategoryStats={showCategoryStats}
-            onShowCategoryStatsChange={(value) => updateSettings({ showCategoryStats: value })}
-            showUnrealisedProfitStats={showUnrealisedProfitStats}
-            onShowUnrealisedProfitStatsChange={(v) => updateSettings({ showUnrealisedProfitStats: v })}
-            showCategoryUnrealisedProfit={showCategoryUnrealisedProfit}
-            onShowCategoryUnrealisedProfitChange={(v) => updateSettings({ showCategoryUnrealisedProfit: v })}
-            notificationPreferences={notificationPreferences}
-            onNotificationTypeChange={updateNotificationPreference}
-            notificationVolume={notificationVolume}
-            onNotificationVolumeChange={(v) => updateSettings({ notificationVolume: v })}
-            onCancel={() => setShowSettingsModal(false)}
-            onChangePassword={() => {
-              setShowSettingsModal(false);
-              setShowChangePasswordModal(true);
-            }}
-          />
-        </ModalContainer>
-
-        <ModalContainer isOpen={showChangelog}>
-          <ChangelogModal onClose={handleCloseChangelog} />
-        </ModalContainer>
-
-        <ModalContainer isOpen={showArchive}>
-          <ArchiveModal
-            archivedStocks={archivedStocks}
-            loading={archivedLoading}
-            geIconMap={geIconMap}
-            onRestore={handleRestore}
-            onClose={() => setShowArchive(false)}
-          />
-        </ModalContainer>
-
-        <ModalContainer isOpen={showArchiveConfirmModal}>
-          <ArchiveConfirmModal
-            stock={stockToArchive}
-            onConfirm={handleConfirmArchive}
-            onCancel={() => { setShowArchiveConfirmModal(false); }}
-          />
-        </ModalContainer>
-
-        <ModalContainer isOpen={showMilestoneModal}>
-          <MilestoneTrackerModal
-            milestones={milestones}
-            currentProgress={milestoneProgress}
-            milestoneHistory={milestoneHistory}
-            initialView={milestoneInitialView}
-            onUpdateMilestone={handleUpdateMilestone}
-            onCancel={() => setShowMilestoneModal(false)}
-            numberFormat={numberFormat}
-            PRESET_GOALS={PRESET_GOALS}
-          />
-        </ModalContainer>
-
+        <ModalManager
+          isSubmitting={isSubmitting}
+          bulkSummaryData={bulkSummaryData}
+          isUndoing={isUndoing}
+          undoResult={undoResult}
+          handleBuy={handleBuy}
+          handleSell={handleSell}
+          handleBulkBuy={handleBulkBuy}
+          handleBulkSell={handleBulkSell}
+          handleBulkUndo={handleBulkUndo}
+          handleBulkSummaryDone={handleBulkSummaryDone}
+          handleRemoveStock={handleRemoveStock}
+          handleAdjust={handleAdjust}
+          handleDelete={handleDelete}
+          handleAddStock={handleAddStock}
+          handleAddCategory={handleAddCategory}
+          handleDeleteCategory={handleDeleteCategory}
+          handleEditCategory={handleEditCategory}
+          handleAddDumpProfit={handleAddDumpProfit}
+          handleAddReferralProfit={handleAddReferralProfit}
+          handleAddBondsProfit={handleAddBondsProfit}
+          handleUpdateMilestone={handleUpdateMilestone}
+          archivedStocks={archivedStocks}
+          archivedLoading={archivedLoading}
+          stockToArchive={stockToArchive}
+          handleConfirmArchive={handleConfirmArchive}
+          handleRestore={handleRestore}
+          handleSetAltTimer={handleSetAltTimer}
+          handleSaveNotes={handleSaveNotes}
+          handleCloseChangelog={handleCloseChangelog}
+          handleSavePriceAlert={handleSavePriceAlert}
+          handleDeletePriceAlert={handleDeletePriceAlert}
+          tradeMode={tradeMode}
+          stockNotes={stockNotes}
+          dumpProfit={dumpProfit}
+          referralProfit={referralProfit}
+          bondsProfit={bondsProfit}
+          numberFormat={numberFormat}
+          groupedStocks={groupedStocks}
+          categoryNames={categoryNames}
+          geIconMap={geIconMap}
+          gePrices={gePrices}
+          priceAlerts={priceAlerts}
+          visibleColumns={visibleColumns}
+          visibleProfits={visibleProfits}
+          showCategoryStats={showCategoryStats}
+          showUnrealisedProfitStats={showUnrealisedProfitStats}
+          showCategoryUnrealisedProfit={showCategoryUnrealisedProfit}
+          notificationPreferences={notificationPreferences}
+          updateNotificationPreference={updateNotificationPreference}
+          notificationVolume={notificationVolume}
+          updateSettings={updateSettings}
+          milestones={milestones}
+          milestoneProgress={milestoneProgress}
+          milestoneHistory={milestoneHistory}
+          PRESET_GOALS={PRESET_GOALS}
+        />
 
       </div>
       <Footer />

--- a/src/components/ModalManager.jsx
+++ b/src/components/ModalManager.jsx
@@ -1,0 +1,361 @@
+import React from 'react';
+import { useModal } from '../contexts/ModalContext';
+import ModalContainer from './modals/ModalContainer';
+import BuyModal from './modals/BuyModal';
+import BulkBuyModal from './modals/BulkBuyModal';
+import BulkSellModal from './modals/BulkSellModal';
+import BulkSummaryModal from './modals/BulkSummaryModal';
+import SellModal from './modals/SellModal';
+import RemoveStockModal from './modals/RemoveStockModal';
+import AdjustModal from './modals/AdjustModal';
+import DeleteModal from './modals/DeleteModal';
+import NewStockModal from './modals/NewStockModal';
+import CategoryModal from './modals/CategoryModal';
+import DeleteCategoryModal from './modals/DeleteCategoryModal';
+import EditCategoryModal from './modals/EditCategoryModal';
+import ProfitModal from './modals/ProfitModal';
+import NotesModal from './modals/NotesModal';
+import ProfitChartModal from './modals/ProfitChartModal';
+import CategoryChartModal from './modals/CategoryChartModal';
+import SettingsModal from './modals/SettingsModal';
+import ChangelogModal from './modals/ChangelogModal';
+import ChangePasswordModal from './modals/ChangePasswordModal';
+import PriceAlertModal from './modals/PriceAlertModal';
+import ArchiveModal from './modals/ArchiveModal';
+import ArchiveConfirmModal from './modals/ArchiveConfirmModal';
+import MilestoneTrackerModal from './modals/MilestoneTrackerModal';
+import AltTimerModal from './modals/AltTimerModal';
+import TimeCalculatorModal from './modals/TimeCalculatorModal';
+
+export default function ModalManager({
+  // Handlers from useModalHandlers
+  isSubmitting,
+  bulkSummaryData,
+  isUndoing,
+  undoResult,
+  handleBuy,
+  handleSell,
+  handleBulkBuy,
+  handleBulkSell,
+  handleBulkUndo,
+  handleBulkSummaryDone,
+  handleRemoveStock,
+  handleAdjust,
+  handleDelete,
+  handleAddStock,
+  handleAddCategory,
+  handleDeleteCategory,
+  handleEditCategory,
+  handleAddDumpProfit,
+  handleAddReferralProfit,
+  handleAddBondsProfit,
+  handleUpdateMilestone,
+  archivedStocks,
+  archivedLoading,
+  stockToArchive,
+  handleConfirmArchive,
+  handleRestore,
+  // Other handlers
+  handleSetAltTimer,
+  handleSaveNotes,
+  handleCloseChangelog,
+  handleSavePriceAlert,
+  handleDeletePriceAlert,
+  // Data
+  tradeMode,
+  stockNotes,
+  dumpProfit,
+  referralProfit,
+  bondsProfit,
+  numberFormat,
+  groupedStocks,
+  categoryNames,
+  geIconMap,
+  gePrices,
+  priceAlerts,
+  // Settings
+  visibleColumns,
+  visibleProfits,
+  showCategoryStats,
+  showUnrealisedProfitStats,
+  showCategoryUnrealisedProfit,
+  notificationPreferences,
+  updateNotificationPreference,
+  notificationVolume,
+  updateSettings,
+  // Milestones
+  milestones,
+  milestoneProgress,
+  milestoneHistory,
+  PRESET_GOALS,
+}) {
+  const {
+    modals,
+    closeModal,
+    selectedStock,
+    selectedCategory,
+    newStockCategory,
+    selectedAlertItem,
+    milestoneInitialView,
+    openModal,
+  } = useModal();
+
+  return (
+    <>
+      <ModalContainer isOpen={modals.buy}>
+        <BuyModal
+          stock={selectedStock}
+          onConfirm={handleBuy}
+          onCancel={() => closeModal('buy')}
+          isSubmitting={isSubmitting}
+        />
+      </ModalContainer>
+
+      <ModalContainer isOpen={modals.bulkBuy}>
+        <BulkBuyModal
+          tradeMode={tradeMode}
+          onConfirm={handleBulkBuy}
+          onCancel={() => closeModal('bulkBuy')}
+          isSubmitting={isSubmitting}
+        />
+      </ModalContainer>
+
+      <ModalContainer isOpen={modals.bulkSell}>
+        <BulkSellModal
+          tradeMode={tradeMode}
+          onConfirm={handleBulkSell}
+          onCancel={() => closeModal('bulkSell')}
+          isSubmitting={isSubmitting}
+        />
+      </ModalContainer>
+
+      <ModalContainer isOpen={bulkSummaryData !== null}>
+        <BulkSummaryModal
+          type={bulkSummaryData?.type}
+          completedItems={bulkSummaryData?.items || []}
+          onUndo={handleBulkUndo}
+          onDone={handleBulkSummaryDone}
+          isUndoing={isUndoing}
+          undoResult={undoResult}
+        />
+      </ModalContainer>
+
+      <ModalContainer isOpen={modals.sell}>
+        <SellModal
+          stock={selectedStock}
+          onConfirm={handleSell}
+          onCancel={() => closeModal('sell')}
+          isSubmitting={isSubmitting}
+        />
+      </ModalContainer>
+
+      <ModalContainer isOpen={modals.remove}>
+        <RemoveStockModal
+          stock={selectedStock}
+          onConfirm={handleRemoveStock}
+          onCancel={() => closeModal('remove')}
+          isSubmitting={isSubmitting}
+        />
+      </ModalContainer>
+
+      <ModalContainer isOpen={modals.adjust}>
+        <AdjustModal
+          stock={selectedStock}
+          onConfirm={handleAdjust}
+          onCancel={() => closeModal('adjust')}
+        />
+      </ModalContainer>
+
+      <ModalContainer isOpen={modals.delete}>
+        <DeleteModal
+          stock={selectedStock}
+          onConfirm={handleDelete}
+          onCancel={() => closeModal('delete')}
+        />
+      </ModalContainer>
+
+      <ModalContainer isOpen={modals.newStock}>
+        <NewStockModal
+          defaultCategory={newStockCategory}
+          defaultIsInvestment={tradeMode === 'investment'}
+          onConfirm={handleAddStock}
+          archivedStocks={archivedStocks}
+          onRestoreFromArchive={async (stock) => {
+            await handleRestore(stock);
+            closeModal('newStock');
+          }}
+          onCancel={() => closeModal('newStock')}
+        />
+      </ModalContainer>
+
+      <ModalContainer isOpen={modals.category}>
+        <CategoryModal
+          defaultIsInvestment={tradeMode === 'investment'}
+          onConfirm={handleAddCategory}
+          onCancel={() => closeModal('category')}
+        />
+      </ModalContainer>
+
+      <ModalContainer isOpen={modals.deleteCategory}>
+        <DeleteCategoryModal
+          category={selectedCategory}
+          onConfirm={handleDeleteCategory}
+          onCancel={() => closeModal('deleteCategory')}
+        />
+      </ModalContainer>
+
+      <ModalContainer isOpen={modals.dumpProfit}>
+        <ProfitModal
+          type="dump"
+          onConfirm={handleAddDumpProfit}
+          onCancel={() => closeModal('dumpProfit')}
+        />
+      </ModalContainer>
+
+      <ModalContainer isOpen={modals.referralProfit}>
+        <ProfitModal
+          type="referral"
+          onConfirm={handleAddReferralProfit}
+          onCancel={() => closeModal('referralProfit')}
+        />
+      </ModalContainer>
+
+      <ModalContainer isOpen={modals.bondsProfit}>
+        <ProfitModal
+          type="bonds"
+          onConfirm={handleAddBondsProfit}
+          onCancel={() => closeModal('bondsProfit')}
+        />
+      </ModalContainer>
+
+      <ModalContainer isOpen={modals.notes}>
+        <NotesModal
+          stock={selectedStock}
+          notes={stockNotes[selectedStock?.id]}
+          onConfirm={handleSaveNotes}
+          onCancel={() => closeModal('notes')}
+        />
+      </ModalContainer>
+
+      <ModalContainer isOpen={modals.profitChart}>
+        <ProfitChartModal
+          dumpProfit={dumpProfit}
+          referralProfit={referralProfit}
+          bondsProfit={bondsProfit}
+          onCancel={() => closeModal('profitChart')}
+          numberFormat={numberFormat}
+        />
+      </ModalContainer>
+
+      <ModalContainer isOpen={modals.categoryChart}>
+        <CategoryChartModal
+          groupedStocks={groupedStocks}
+          onCancel={() => closeModal('categoryChart')}
+          numberFormat={numberFormat}
+        />
+      </ModalContainer>
+
+      <ModalContainer isOpen={modals.editCategory}>
+        <EditCategoryModal
+          category={selectedCategory}
+          categories={categoryNames}
+          onConfirm={handleEditCategory}
+          onCancel={() => closeModal('editCategory')}
+        />
+      </ModalContainer>
+
+      <ModalContainer isOpen={modals.timeCalculator}>
+        <TimeCalculatorModal
+          stock={selectedStock}
+          onClose={() => closeModal('timeCalculator')}
+        />
+      </ModalContainer>
+
+      <ModalContainer isOpen={modals.altTimer}>
+        <AltTimerModal
+          onConfirm={handleSetAltTimer}
+          onCancel={() => closeModal('altTimer')}
+        />
+      </ModalContainer>
+
+      <ModalContainer isOpen={modals.changePassword}>
+        <ChangePasswordModal
+          onCancel={() => closeModal('changePassword')}
+        />
+      </ModalContainer>
+
+      <ModalContainer isOpen={modals.priceAlert}>
+        <PriceAlertModal
+          itemId={selectedAlertItem?.itemId}
+          itemName={selectedAlertItem?.itemName}
+          currentAlert={selectedAlertItem ? priceAlerts[selectedAlertItem.itemId] : null}
+          gePrice={selectedAlertItem ? gePrices[selectedAlertItem.itemId] : null}
+          onSave={handleSavePriceAlert}
+          onDelete={handleDeletePriceAlert}
+          onCancel={() => closeModal('priceAlert')}
+        />
+      </ModalContainer>
+
+      <ModalContainer isOpen={modals.settings}>
+        <SettingsModal
+          numberFormat={numberFormat}
+          onNumberFormatChange={(newFormat) => updateSettings({ numberFormat: newFormat })}
+          visibleColumns={visibleColumns}
+          onVisibleColumnsChange={(newColumns) => updateSettings({ visibleColumns: newColumns })}
+          visibleProfits={visibleProfits}
+          onVisibleProfitsChange={(newProfits) => updateSettings({ visibleProfits: newProfits })}
+          showCategoryStats={showCategoryStats}
+          onShowCategoryStatsChange={(value) => updateSettings({ showCategoryStats: value })}
+          showUnrealisedProfitStats={showUnrealisedProfitStats}
+          onShowUnrealisedProfitStatsChange={(v) => updateSettings({ showUnrealisedProfitStats: v })}
+          showCategoryUnrealisedProfit={showCategoryUnrealisedProfit}
+          onShowCategoryUnrealisedProfitChange={(v) => updateSettings({ showCategoryUnrealisedProfit: v })}
+          notificationPreferences={notificationPreferences}
+          onNotificationTypeChange={updateNotificationPreference}
+          notificationVolume={notificationVolume}
+          onNotificationVolumeChange={(v) => updateSettings({ notificationVolume: v })}
+          onCancel={() => closeModal('settings')}
+          onChangePassword={() => {
+            closeModal('settings');
+            openModal('changePassword');
+          }}
+        />
+      </ModalContainer>
+
+      <ModalContainer isOpen={modals.changelog}>
+        <ChangelogModal onClose={handleCloseChangelog} />
+      </ModalContainer>
+
+      <ModalContainer isOpen={modals.archive}>
+        <ArchiveModal
+          archivedStocks={archivedStocks}
+          loading={archivedLoading}
+          geIconMap={geIconMap}
+          onRestore={handleRestore}
+          onClose={() => closeModal('archive')}
+        />
+      </ModalContainer>
+
+      <ModalContainer isOpen={modals.archiveConfirm}>
+        <ArchiveConfirmModal
+          stock={stockToArchive}
+          onConfirm={handleConfirmArchive}
+          onCancel={() => closeModal('archiveConfirm')}
+        />
+      </ModalContainer>
+
+      <ModalContainer isOpen={modals.milestone}>
+        <MilestoneTrackerModal
+          milestones={milestones}
+          currentProgress={milestoneProgress}
+          milestoneHistory={milestoneHistory}
+          initialView={milestoneInitialView}
+          onUpdateMilestone={handleUpdateMilestone}
+          onCancel={() => closeModal('milestone')}
+          numberFormat={numberFormat}
+          PRESET_GOALS={PRESET_GOALS}
+        />
+      </ModalContainer>
+    </>
+  );
+}

--- a/src/contexts/ModalContext.jsx
+++ b/src/contexts/ModalContext.jsx
@@ -1,0 +1,85 @@
+import { createContext, useContext, useState, useCallback, useMemo } from 'react';
+
+const ModalContext = createContext(null);
+
+const MODAL_DEFAULTS = {
+  buy: false,
+  bulkBuy: false,
+  bulkSell: false,
+  sell: false,
+  remove: false,
+  adjust: false,
+  delete: false,
+  milestone: false,
+  newStock: false,
+  category: false,
+  altTimer: false,
+  changePassword: false,
+  deleteCategory: false,
+  dumpProfit: false,
+  referralProfit: false,
+  bondsProfit: false,
+  notes: false,
+  profitChart: false,
+  categoryChart: false,
+  settings: false,
+  timeCalculator: false,
+  editCategory: false,
+  priceAlert: false,
+  archive: false,
+  archiveConfirm: false,
+  changelog: false,
+};
+
+export function ModalProvider({ children }) {
+  const [modals, setModals] = useState(MODAL_DEFAULTS);
+  const [selectedStock, setSelectedStock] = useState(null);
+  const [selectedCategory, setSelectedCategory] = useState(null);
+  const [newStockCategory, setNewStockCategory] = useState('');
+  const [selectedAlertItem, setSelectedAlertItem] = useState(null);
+  const [milestoneInitialView, setMilestoneInitialView] = useState('main');
+
+  const openModal = useCallback((type, payload) => {
+    if (payload?.stock) setSelectedStock(payload.stock);
+    if (payload?.category) setSelectedCategory(payload.category);
+    if (payload?.newStockCategory !== undefined) setNewStockCategory(payload.newStockCategory);
+    if (payload?.alertItem) setSelectedAlertItem(payload.alertItem);
+    if (payload?.milestoneView) setMilestoneInitialView(payload.milestoneView);
+
+    setModals(prev => ({ ...prev, [type]: true }));
+  }, []);
+
+  const closeModal = useCallback((type) => {
+    setModals(prev => ({ ...prev, [type]: false }));
+
+    if (type === 'priceAlert') setSelectedAlertItem(null);
+  }, []);
+
+  const value = useMemo(() => ({
+    modals,
+    openModal,
+    closeModal,
+    selectedStock,
+    setSelectedStock,
+    selectedCategory,
+    setSelectedCategory,
+    newStockCategory,
+    setNewStockCategory,
+    selectedAlertItem,
+    setSelectedAlertItem,
+    milestoneInitialView,
+    setMilestoneInitialView,
+  }), [modals, openModal, closeModal, selectedStock, selectedCategory, newStockCategory, selectedAlertItem, milestoneInitialView]);
+
+  return (
+    <ModalContext.Provider value={value}>
+      {children}
+    </ModalContext.Provider>
+  );
+}
+
+export function useModal() {
+  const ctx = useContext(ModalContext);
+  if (!ctx) throw new Error('useModal must be used within a ModalProvider');
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- Extracts all modal state (~30 `showXModal` booleans + selection state) into a `ModalContext` with `openModal(type, payload?)` / `closeModal(type)` dispatch API
- Moves all 27 `<ModalContainer>` JSX blocks from MainApp into a dedicated `ModalManager` component
- Replaces scattered `setSelectedStock(stock); setShowBuyModal(true)` calls with single `openModal('buy', { stock })` dispatches

**MainApp.jsx**: 1789 → 1464 lines (-325 lines)

Closes #208

## Test plan
- [ ] Stock actions: buy, sell, adjust, delete, notes on any stock
- [ ] Bulk buy/sell + summary modal + undo
- [ ] Category actions: add, edit, delete
- [ ] Cross-modal: Settings → Change Password
- [ ] Archive: archive stock, open archive list, restore
- [ ] Price alerts: from NotificationCenter and GraphsPage
- [ ] Milestone modal: from progress bar and HomePage
- [ ] Changelog: auto-opens on version mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)