### PR TITLE
refactor(contexts): wrap data hooks in providers for self-wiring handlers

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -4,19 +4,19 @@ import HomePage from './pages/HomePage';
 import HistoryPage from './pages/HistoryPage';
 import GraphsPage from './pages/GraphsPage';
 import { supabase } from './lib/supabase';
-import { useStocks } from './hooks/useStocks';
-import { useCategories } from './hooks/useCategories';
-import { useTransactions } from './hooks/useTransactions';
 import { useGPTradedStats } from './hooks/useGPTradedStats';
 import { useStockNotes } from './hooks/useStockNotes.js';
 import { useSettings } from './hooks/useSettings';
 import { useNotificationSettings } from './hooks/useNotificationSettings';
-import { useProfits } from './hooks/useProfits';
-import { useMilestones } from './hooks/useMilestones';
 import { useProfitHistory } from './hooks/useProfitHistory';
 import { useGEData } from './contexts/GEDataContext';
 import { TradeProvider } from './contexts/TradeContext';
 import { ModalProvider, useModal } from './contexts/ModalContext';
+import { StocksProvider, useStocksContext } from './contexts/StocksContext';
+import { TransactionsProvider, useTransactionsContext } from './contexts/TransactionsContext';
+import { CategoriesProvider, useCategoriesContext } from './contexts/CategoriesContext';
+import { ProfitsProvider, useProfitsContext } from './contexts/ProfitsContext';
+import { MilestonesProvider, useMilestonesContext } from './contexts/MilestonesContext';
 import { useNotifications } from './hooks/useNotifications';
 import { useOSRSNews } from './hooks/useOSRSNews';
 import { useJmodComments } from './hooks/useJmodComments';
@@ -46,9 +46,20 @@ import { useModalHandlers } from './hooks/useModalHandlers';
 import { useNavigation } from './hooks/useNavigation';
 
 export default function MainApp(props) {
+  const userId = props.session.user.id;
   return (
     <ModalProvider>
-      <MainAppInner {...props} />
+      <StocksProvider userId={userId}>
+        <TransactionsProvider userId={userId}>
+          <CategoriesProvider userId={userId}>
+            <ProfitsProvider userId={userId}>
+              <MilestonesProvider userId={userId}>
+                <MainAppInner {...props} />
+              </MilestonesProvider>
+            </ProfitsProvider>
+          </CategoriesProvider>
+        </TransactionsProvider>
+      </StocksProvider>
     </ModalProvider>
   );
 }
@@ -65,21 +76,21 @@ function MainAppInner({ session, onLogout }) {
     fetchCategories();
     setTradeMode(mode);
   };
-  const { stocks, loading: stocksLoading, addStock: addStockToDB, updateStock, deleteStock, refetch, reorderStocks, archiveStock, restoreStock, fetchArchivedStocks } = useStocks(userId);
-  const { categories, loading: categoriesLoading, addCategory, deleteCategory, updateCategory, fetchCategories, reorderCategories } = useCategories(userId);
+  const { stocks, loading: stocksLoading, addStock: addStockToDB, updateStock, deleteStock, refetch, reorderStocks, archiveStock, restoreStock, fetchArchivedStocks } = useStocksContext();
+  const { categories, loading: categoriesLoading, addCategory, deleteCategory, updateCategory, fetchCategories, reorderCategories } = useCategoriesContext();
   const {
     transactions, loading: transactionsLoading, addTransaction,
     pagedTransactions, pagedLoading, totalCount, totalPages,
     page, pageSize, filters, goToPage, changePageSize, applyFilters, initPaged,
     sortConfig: historySortConfig, applySort, resetPaged, undoTransaction
-  } = useTransactions(userId);
+  } = useTransactionsContext();
  const { stats: gpTradedStats, loading: gpStatsLoading, refetch: refetchGPStats } = useGPTradedStats(userId);
   const { notes: stockNotes, loading: notesLoading, saveNote, deleteNote } = useStockNotes(userId);
   const { settings, loading: settingsLoading, updateSettings } = useSettings(userId);
   const { notificationPreferences, updateNotificationPreference, loading: notificationSettingsLoading } = useNotificationSettings(userId);
-  const { profits, loading: profitsLoading, updateProfit } = useProfits(userId);
+  const { profits, loading: profitsLoading, updateProfit } = useProfitsContext();
   const { profitHistory, loading: profitHistoryLoading, addProfitEntry, refetch: refetchProfitHistory } = useProfitHistory(userId);
-  const { milestones, milestoneHistory, loading: milestonesLoading, updateMilestone, recordMilestoneAchievement, recordCompletedPeriods, PRESET_GOALS } = useMilestones(userId);
+  const { milestones, milestoneHistory, loading: milestonesLoading, updateMilestone, recordMilestoneAchievement, recordCompletedPeriods, PRESET_GOALS } = useMilestonesContext();
   const { alerts: priceAlerts, allAlerts: allPriceAlerts, loading: priceAlertsLoading, saveAlert: savePriceAlert, dismissAlert: dismissPriceAlert, deactivateAlert: deactivatePriceAlert, updateLastChecked: updatePriceAlertLastChecked, refetch: refetchPriceAlerts } = usePriceAlerts(userId);
 
   // Destructure profits
@@ -618,34 +629,14 @@ function MainAppInner({ session, onLogout }) {
     handleRestore,
     refreshArchivedStocks,
   } = useModalHandlers({
-    updateStock,
-    addTransaction,
-    deleteStock,
-    addStockToDB: addStockToDB,
-    refetch,
-    addCategory,
-    deleteCategory,
-    updateCategory,
-    fetchCategories,
-    updateProfit,
-    addProfitEntry,
-    updateMilestone,
-    undoTransaction,
-    selectedStock,
-    selectedCategory,
-    categories,
     tradeMode,
-    closeModal,
     highlightRow,
     firedTimerNotifs,
     saveFiredTimers,
     setCollapsedCategories,
-    setNewStockCategory,
     calculateMilestoneProgress,
     setMilestoneProgress,
-    archiveStock,
-    restoreStock,
-    fetchArchivedStocks,
+    addProfitEntry,
   });
 
   const handleInvestmentDateChange = async (stock, date) => {

--- a/src/contexts/CategoriesContext.jsx
+++ b/src/contexts/CategoriesContext.jsx
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react';
+import { useCategories } from '../hooks/useCategories';
+
+const CategoriesContext = createContext(null);
+
+export function CategoriesProvider({ userId, children }) {
+  const value = useCategories(userId);
+  return <CategoriesContext.Provider value={value}>{children}</CategoriesContext.Provider>;
+}
+
+export function useCategoriesContext() {
+  const ctx = useContext(CategoriesContext);
+  if (!ctx) throw new Error('useCategoriesContext must be used within CategoriesProvider');
+  return ctx;
+}

--- a/src/contexts/MilestonesContext.jsx
+++ b/src/contexts/MilestonesContext.jsx
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react';
+import { useMilestones } from '../hooks/useMilestones';
+
+const MilestonesContext = createContext(null);
+
+export function MilestonesProvider({ userId, children }) {
+  const value = useMilestones(userId);
+  return <MilestonesContext.Provider value={value}>{children}</MilestonesContext.Provider>;
+}
+
+export function useMilestonesContext() {
+  const ctx = useContext(MilestonesContext);
+  if (!ctx) throw new Error('useMilestonesContext must be used within MilestonesProvider');
+  return ctx;
+}

--- a/src/contexts/ProfitsContext.jsx
+++ b/src/contexts/ProfitsContext.jsx
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react';
+import { useProfits } from '../hooks/useProfits';
+
+const ProfitsContext = createContext(null);
+
+export function ProfitsProvider({ userId, children }) {
+  const value = useProfits(userId);
+  return <ProfitsContext.Provider value={value}>{children}</ProfitsContext.Provider>;
+}
+
+export function useProfitsContext() {
+  const ctx = useContext(ProfitsContext);
+  if (!ctx) throw new Error('useProfitsContext must be used within ProfitsProvider');
+  return ctx;
+}

--- a/src/contexts/StocksContext.jsx
+++ b/src/contexts/StocksContext.jsx
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react';
+import { useStocks } from '../hooks/useStocks';
+
+const StocksContext = createContext(null);
+
+export function StocksProvider({ userId, children }) {
+  const value = useStocks(userId);
+  return <StocksContext.Provider value={value}>{children}</StocksContext.Provider>;
+}
+
+export function useStocksContext() {
+  const ctx = useContext(StocksContext);
+  if (!ctx) throw new Error('useStocksContext must be used within StocksProvider');
+  return ctx;
+}

--- a/src/contexts/TransactionsContext.jsx
+++ b/src/contexts/TransactionsContext.jsx
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react';
+import { useTransactions } from '../hooks/useTransactions';
+
+const TransactionsContext = createContext(null);
+
+export function TransactionsProvider({ userId, children }) {
+  const value = useTransactions(userId);
+  return <TransactionsContext.Provider value={value}>{children}</TransactionsContext.Provider>;
+}
+
+export function useTransactionsContext() {
+  const ctx = useContext(TransactionsContext);
+  if (!ctx) throw new Error('useTransactionsContext must be used within TransactionsProvider');
+  return ctx;
+}

--- a/src/hooks/useModalHandlers.js
+++ b/src/hooks/useModalHandlers.js
@@ -1,68 +1,57 @@
 import { useState, useCallback } from 'react';
 import { supabase } from '../lib/supabase';
 import { calculateCostBasis, calculateSellProfit, calculateAvgBuyPrice } from '../utils/calculations';
+import { useStocksContext } from '../contexts/StocksContext';
+import { useTransactionsContext } from '../contexts/TransactionsContext';
+import { useCategoriesContext } from '../contexts/CategoriesContext';
+import { useProfitsContext } from '../contexts/ProfitsContext';
+import { useMilestonesContext } from '../contexts/MilestonesContext';
+import { useModal } from '../contexts/ModalContext';
 
 /**
+ * Remaining params are ephemeral MainApp state that doesn't belong in data contexts,
+ * plus addProfitEntry from useProfitHistory (not wrapped per issue #217 scope).
+ *
  * @param {Object} opts
- * @param {Function} opts.updateStock
- * @param {Function} opts.addTransaction
- * @param {Function} opts.deleteStock
- * @param {Function} opts.addStockToDB
- * @param {Function} opts.refetch
- * @param {Function} opts.addCategory
- * @param {Function} opts.deleteCategory
- * @param {Function} opts.updateCategory
- * @param {Function} opts.fetchCategories
- * @param {Function} opts.updateProfit
- * @param {Function} opts.addProfitEntry
- * @param {Function} opts.updateMilestone
- * @param {Function} opts.undoTransaction
- * @param {Object|null} opts.selectedStock
- * @param {string|null} opts.selectedCategory
- * @param {Array} opts.categories
  * @param {string} opts.tradeMode
- * @param {Function} opts.closeModal - closeModal(type) to close a modal by type key
  * @param {Function} opts.highlightRow
  * @param {React.MutableRefObject<Set>} opts.firedTimerNotifs
  * @param {Function} opts.saveFiredTimers
  * @param {Function} opts.setCollapsedCategories
- * @param {Function} opts.setNewStockCategory
  * @param {Function} opts.calculateMilestoneProgress
  * @param {Function} opts.setMilestoneProgress
- * @param {Function} opts.archiveStock
- * @param {Function} opts.restoreStock
- * @param {Function} opts.fetchArchivedStocks
+ * @param {Function} opts.addProfitEntry
  */
 export function useModalHandlers({
-  updateStock,
-  addTransaction,
-  deleteStock,
-  addStockToDB,
-  refetch,
-  addCategory,
-  deleteCategory: deleteCategoryMutation,
-  updateCategory,
-  fetchCategories,
-  updateProfit,
-  addProfitEntry,
-  updateMilestone,
-  undoTransaction,
-  selectedStock,
-  selectedCategory,
-  categories,
   tradeMode,
-  closeModal,
   highlightRow,
   firedTimerNotifs,
   saveFiredTimers,
   setCollapsedCategories,
-  setNewStockCategory,
   calculateMilestoneProgress,
   setMilestoneProgress,
-  archiveStock,
-  restoreStock,
-  fetchArchivedStocks,
+  addProfitEntry,
 }) {
+  const {
+    updateStock,
+    deleteStock,
+    addStock: addStockToDB,
+    refetch,
+    archiveStock,
+    restoreStock,
+    fetchArchivedStocks,
+  } = useStocksContext();
+  const { addTransaction, undoTransaction } = useTransactionsContext();
+  const {
+    categories,
+    addCategory,
+    deleteCategory: deleteCategoryMutation,
+    updateCategory,
+    fetchCategories,
+  } = useCategoriesContext();
+  const { updateProfit } = useProfitsContext();
+  const { updateMilestone } = useMilestonesContext();
+  const { closeModal, selectedStock, selectedCategory, setNewStockCategory } = useModal();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [bulkSummaryData, setBulkSummaryData] = useState(null);
   const [isUndoing, setIsUndoing] = useState(false);


### PR DESCRIPTION
## Summary
- Wraps `useStocks`, `useTransactions`, `useCategories`, `useProfits`, and `useMilestones` in context providers so `useModalHandlers` self-wires via `useContext` instead of prop threading.
- Drops `useModalHandlers` param count from **29 → 8** (remaining params are ephemeral MainApp UI state and `addProfitEntry` from the out-of-scope `useProfitHistory`).
- Closes osrsprofittracker/OSRSProfitTracker#217.

Follow-ups tracked in osrsprofittracker/OSRSProfitTracker#228, osrsprofittracker/OSRSProfitTracker#229, osrsprofittracker/OSRSProfitTracker#230.

## Test plan
- [x] `npm run build` clean
- [x] Manual smoke test — buy, sell, bulk buy/sell + undo, add/edit/delete stocks, add/edit/delete/reorder categories, drag stocks across categories, archive/restore, history filters + undo, profits (dump/referral/bonds), milestone edits
- [x] No console errors; no "must be used within Provider" throws

🤖 Generated with [Claude Code](https://claude.com/claude-code)