### PR TITLE
refactor(contexts): wrap useProfitHistory in context provider

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -8,7 +8,6 @@ import { useGPTradedStats } from './hooks/useGPTradedStats';
 import { useStockNotes } from './hooks/useStockNotes.js';
 import { useSettings } from './hooks/useSettings';
 import { useNotificationSettings } from './hooks/useNotificationSettings';
-import { useProfitHistory } from './hooks/useProfitHistory';
 import { useGEData } from './contexts/GEDataContext';
 import { TradeProvider } from './contexts/TradeContext';
 import { ModalProvider, useModal } from './contexts/ModalContext';
@@ -17,6 +16,7 @@ import { TransactionsProvider, useTransactionsContext } from './contexts/Transac
 import { CategoriesProvider, useCategoriesContext } from './contexts/CategoriesContext';
 import { ProfitsProvider, useProfitsContext } from './contexts/ProfitsContext';
 import { MilestonesProvider, useMilestonesContext } from './contexts/MilestonesContext';
+import { ProfitHistoryProvider, useProfitHistoryContext } from './contexts/ProfitHistoryContext';
 import { useNotifications } from './hooks/useNotifications';
 import { useOSRSNews } from './hooks/useOSRSNews';
 import { useJmodComments } from './hooks/useJmodComments';
@@ -54,7 +54,9 @@ export default function MainApp(props) {
           <CategoriesProvider userId={userId}>
             <ProfitsProvider userId={userId}>
               <MilestonesProvider userId={userId}>
-                <MainAppInner {...props} />
+                <ProfitHistoryProvider userId={userId}>
+                  <MainAppInner {...props} />
+                </ProfitHistoryProvider>
               </MilestonesProvider>
             </ProfitsProvider>
           </CategoriesProvider>
@@ -89,7 +91,7 @@ function MainAppInner({ session, onLogout }) {
   const { settings, loading: settingsLoading, updateSettings } = useSettings(userId);
   const { notificationPreferences, updateNotificationPreference, loading: notificationSettingsLoading } = useNotificationSettings(userId);
   const { profits, loading: profitsLoading, updateProfit } = useProfitsContext();
-  const { profitHistory, loading: profitHistoryLoading, addProfitEntry, refetch: refetchProfitHistory } = useProfitHistory(userId);
+  const { profitHistory, loading: profitHistoryLoading, refetch: refetchProfitHistory } = useProfitHistoryContext();
   const { milestones, milestoneHistory, loading: milestonesLoading, updateMilestone, recordMilestoneAchievement, recordCompletedPeriods, PRESET_GOALS } = useMilestonesContext();
   const { alerts: priceAlerts, allAlerts: allPriceAlerts, loading: priceAlertsLoading, saveAlert: savePriceAlert, dismissAlert: dismissPriceAlert, deactivateAlert: deactivatePriceAlert, updateLastChecked: updatePriceAlertLastChecked, refetch: refetchPriceAlerts } = usePriceAlerts(userId);
 
@@ -636,7 +638,6 @@ function MainAppInner({ session, onLogout }) {
     setCollapsedCategories,
     calculateMilestoneProgress,
     setMilestoneProgress,
-    addProfitEntry,
   });
 
   const handleInvestmentDateChange = async (stock, date) => {

--- a/src/contexts/ProfitHistoryContext.jsx
+++ b/src/contexts/ProfitHistoryContext.jsx
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react';
+import { useProfitHistory } from '../hooks/useProfitHistory';
+
+const ProfitHistoryContext = createContext(null);
+
+export function ProfitHistoryProvider({ userId, children }) {
+  const value = useProfitHistory(userId);
+  return <ProfitHistoryContext.Provider value={value}>{children}</ProfitHistoryContext.Provider>;
+}
+
+export function useProfitHistoryContext() {
+  const ctx = useContext(ProfitHistoryContext);
+  if (!ctx) throw new Error('useProfitHistoryContext must be used within ProfitHistoryProvider');
+  return ctx;
+}

--- a/src/hooks/useModalHandlers.js
+++ b/src/hooks/useModalHandlers.js
@@ -6,12 +6,10 @@ import { useTransactionsContext } from '../contexts/TransactionsContext';
 import { useCategoriesContext } from '../contexts/CategoriesContext';
 import { useProfitsContext } from '../contexts/ProfitsContext';
 import { useMilestonesContext } from '../contexts/MilestonesContext';
+import { useProfitHistoryContext } from '../contexts/ProfitHistoryContext';
 import { useModal } from '../contexts/ModalContext';
 
 /**
- * Remaining params are ephemeral MainApp state that doesn't belong in data contexts,
- * plus addProfitEntry from useProfitHistory (not wrapped per issue #217 scope).
- *
  * @param {Object} opts
  * @param {string} opts.tradeMode
  * @param {Function} opts.highlightRow
@@ -20,7 +18,6 @@ import { useModal } from '../contexts/ModalContext';
  * @param {Function} opts.setCollapsedCategories
  * @param {Function} opts.calculateMilestoneProgress
  * @param {Function} opts.setMilestoneProgress
- * @param {Function} opts.addProfitEntry
  */
 export function useModalHandlers({
   tradeMode,
@@ -30,7 +27,6 @@ export function useModalHandlers({
   setCollapsedCategories,
   calculateMilestoneProgress,
   setMilestoneProgress,
-  addProfitEntry,
 }) {
   const {
     updateStock,
@@ -51,6 +47,7 @@ export function useModalHandlers({
   } = useCategoriesContext();
   const { updateProfit } = useProfitsContext();
   const { updateMilestone } = useMilestonesContext();
+  const { addProfitEntry } = useProfitHistoryContext();
   const { closeModal, selectedStock, selectedCategory, setNewStockCategory } = useModal();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [bulkSummaryData, setBulkSummaryData] = useState(null);


### PR DESCRIPTION
## Summary
- Wraps `useProfitHistory` in `ProfitHistoryContext` / `ProfitHistoryProvider`, matching the pattern used by the other 5 data hooks
- `useModalHandlers` now pulls `addProfitEntry` via `useProfitHistoryContext()` instead of receiving it as a param (param count 8 → 7)
- `MainAppInner` reads `profitHistory` / `refetchProfitHistory` from context; direct `useProfitHistory(userId)` call removed

Closes #228

## Test plan
- [ ] Sell a stock — profit_history row written, period stats update without reload
- [ ] Bulk sell — multiple rows write correctly
- [ ] Add dump / referral / bonds profit from extra income modal
- [ ] Cold app load — no "must be used within ProfitHistoryProvider" crash, profit tiles populate
- [ ] Milestone progress bar reflects historical profit
- [ ] HomePage recent activity shows profit badges on transactions
- [ ] GraphsPage profit-over-time chart renders
- [ ] Switch trade/investment mode — `refetchProfitHistory` still fires via `useNavigation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)