### PR TITLE
refactor(hooks): memoize mutation and fetch functions with useCallback

### DIFF
--- a/src/hooks/useCategories.js
+++ b/src/hooks/useCategories.js
@@ -1,11 +1,11 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { supabase } from '../lib/supabase';
 
 export function useCategories(userId) {
   const [categories, setCategories] = useState([]);
   const [loading, setLoading] = useState(true);
 
-  const fetchCategories = async () => {
+  const fetchCategories = useCallback(async () => {
     try {
       if (!userId) return;
 
@@ -30,9 +30,13 @@ export function useCategories(userId) {
       console.error('Error fetching categories:', error);
     }
     setLoading(false);
-  };
+  }, [userId]);
 
-  const reorderCategories = async (categoryName, newPosition, isInvestment = false) => {
+  useEffect(() => {
+    fetchCategories();
+  }, [userId, fetchCategories]);
+
+  const reorderCategories = useCallback(async (categoryName, newPosition, isInvestment = false) => {
     try {
       const { data: allCategories, error: fetchError } = await supabase
         .from('categories')
@@ -79,9 +83,9 @@ export function useCategories(userId) {
       console.error('Error reordering categories:', error);
       throw error;
     }
-  };
+  }, [userId]);
 
-  const addCategory = async (name, isInvestment = false) => {
+  const addCategory = useCallback(async (name, isInvestment = false) => {
     try {
       const { data, error } = await supabase
         .from('categories')
@@ -101,13 +105,9 @@ export function useCategories(userId) {
       console.error('Error adding category:', error);
       throw error;
     }
-  };
-
-  useEffect(() => {
-    fetchCategories();
   }, [userId]);
 
-  const updateCategory = async (oldName, newName, isInvestment = false) => {
+  const updateCategory = useCallback(async (oldName, newName, isInvestment = false) => {
     try {
       const { error: categoryError } = await supabase
         .from('categories')
@@ -134,9 +134,9 @@ export function useCategories(userId) {
       console.error('Error updating category:', error);
       throw error;
     }
-  };
+  }, [userId]);
 
-  const deleteCategory = async (name, isInvestment = false) => {
+  const deleteCategory = useCallback(async (name, isInvestment = false) => {
     if (name === 'Uncategorized') {
       throw new Error('Cannot delete Uncategorized category');
     }
@@ -172,7 +172,7 @@ export function useCategories(userId) {
       console.error('Error in deleteCategory:', error);
       throw error;
     }
-  };
+  }, [userId]);
 
   return {
     categories,

--- a/src/hooks/useMilestones.js
+++ b/src/hooks/useMilestones.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { supabase } from '../lib/supabase';
 
 const PRESET_GOALS = [10000000, 50000000, 100000000, 500000000, 1000000000]; // 10M, 50M, 100M, 500M, 1B
@@ -86,13 +86,22 @@ export function useMilestones(userId) {
   const [milestoneHistory, setMilestoneHistory] = useState([]);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    if (!userId) return;
-    fetchMilestones();
-    fetchMilestoneHistory();
+  const fetchMilestoneHistory = useCallback(async () => {
+    const { data, error } = await supabase
+      .from('milestone_history')
+      .select('*')
+      .eq('user_id', userId)
+      .order('period_start', { ascending: false });
+
+    if (error) {
+      console.error('Error fetching milestone history:', error);
+      return;
+    }
+
+    setMilestoneHistory(data || []);
   }, [userId]);
 
-  const fetchMilestones = async () => {
+  const fetchMilestones = useCallback(async () => {
     const { data, error } = await supabase
       .from('milestones')
       .select('*')
@@ -123,24 +132,15 @@ export function useMilestones(userId) {
       }]);
     }
     setLoading(false);
-  };
+  }, [userId]);
 
-  const fetchMilestoneHistory = async () => {
-    const { data, error } = await supabase
-      .from('milestone_history')
-      .select('*')
-      .eq('user_id', userId)
-      .order('period_start', { ascending: false });
+  useEffect(() => {
+    if (!userId) return;
+    fetchMilestones();
+    fetchMilestoneHistory();
+  }, [userId, fetchMilestones, fetchMilestoneHistory]);
 
-    if (error) {
-      console.error('Error fetching milestone history:', error);
-      return;
-    }
-
-    setMilestoneHistory(data || []);
-  };
-
-  const updateMilestone = async (period, goal, enabled) => {
+  const updateMilestone = useCallback(async (period, goal, enabled) => {
     const newMilestones = {
       ...milestones,
       [period]: { goal, enabled }
@@ -165,9 +165,9 @@ export function useMilestones(userId) {
 
     setMilestones(newMilestones);
     return true;
-  };
+  }, [userId, milestones]);
 
-  const recordMilestoneAchievement = async (period, goalAmount, actualAmount) => {
+  const recordMilestoneAchievement = useCallback(async (period, goalAmount, actualAmount) => {
     const { error } = await supabase
       .from('milestone_history')
       .insert([{
@@ -185,11 +185,11 @@ export function useMilestones(userId) {
 
     await fetchMilestoneHistory();
     return true;
-  };
+  }, [userId, fetchMilestoneHistory]);
 
   // Scans profitHistory to backfill milestone_history for all completed past periods.
   // Safe to call repeatedly — skips periods already recorded.
-  const recordCompletedPeriods = async (profitHistory, currentMilestones) => {
+  const recordCompletedPeriods = useCallback(async (profitHistory, currentMilestones) => {
     if (!profitHistory || profitHistory.length === 0) return;
 
     // Earliest entry date, capped at 1 year back
@@ -251,7 +251,7 @@ export function useMilestones(userId) {
     }
 
     await fetchMilestoneHistory();
-  };
+  }, [userId, fetchMilestoneHistory]);
 
   return {
     milestones,

--- a/src/hooks/useProfits.js
+++ b/src/hooks/useProfits.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { supabase } from '../lib/supabase';
 
 export function useProfits(userId) {
@@ -9,12 +9,7 @@ export function useProfits(userId) {
   });
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    if (!userId) return;
-    fetchProfits();
-  }, [userId]);
-
-  const fetchProfits = async () => {
+  const fetchProfits = useCallback(async () => {
     const { data, error } = await supabase
       .from('profits')
       .select('*')
@@ -60,9 +55,14 @@ export function useProfits(userId) {
       }
     }
     setLoading(false);
-  };
+  }, [userId]);
 
-  const updateProfit = async (profitType, amount) => {
+  useEffect(() => {
+    if (!userId) return;
+    fetchProfits();
+  }, [userId, fetchProfits]);
+
+  const updateProfit = useCallback(async (profitType, amount) => {
     // Convert camelCase to snake_case
     const dbColumnMap = {
       dumpProfit: 'dump_profit',
@@ -89,7 +89,7 @@ export function useProfits(userId) {
       setProfits({ ...profits, [profitType]: newValue });
       return true;
     }
-  };
+  }, [userId, profits]);
 
   return { profits, loading, updateProfit, refetch: fetchProfits };
 }

--- a/src/hooks/useStocks.js
+++ b/src/hooks/useStocks.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { supabase } from '../lib/supabase';
 import { mapRow } from '../utils/mapRow';
 
@@ -27,12 +27,7 @@ export function useStocks(userId) {
   const [stocks, setStocks] = useState([]);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    if (!userId) return;
-    fetchStocks();
-  }, [userId]);
-
-  const fetchStocks = async () => {
+  const fetchStocks = useCallback(async () => {
     const { data, error } = await supabase
       .from('stocks')
       .select('*')
@@ -47,9 +42,14 @@ export function useStocks(userId) {
       setStocks((data || []).map(formatStock));
     }
     setLoading(false);
-  };
+  }, [userId]);
 
-  const reorderStocks = async (stockId, targetStockId, category) => {
+  useEffect(() => {
+    if (!userId) return;
+    fetchStocks();
+  }, [userId, fetchStocks]);
+
+  const reorderStocks = useCallback(async (stockId, targetStockId, category) => {
     try {
       // Optimistically update UI first
       const categoryStocks = stocks.filter(s => s.category === category);
@@ -93,9 +93,9 @@ export function useStocks(userId) {
       console.error('Error reordering stocks:', error);
       throw error;
     }
-  };
+  }, [userId, stocks]);
 
-  const addStock = async (stock) => {
+  const addStock = useCallback(async (stock) => {
     // Convert camelCase to snake_case for database
     const dbStock = {
       user_id: userId,
@@ -126,9 +126,9 @@ export function useStocks(userId) {
       // Don't update local state - let caller refetch
       return data[0];
     }
-  };
+  }, [userId]);
 
-  const updateStock = async (id, updates) => {
+  const updateStock = useCallback(async (id, updates) => {
     // Convert camelCase to snake_case for database
     const dbUpdates = {};
     if (updates.totalCost !== undefined) dbUpdates.total_cost = updates.totalCost;
@@ -159,9 +159,9 @@ export function useStocks(userId) {
       // Don't update local state - let caller refetch
       return true;
     }
-  };
+  }, [userId]);
 
-  const deleteStock = async (id) => {
+  const deleteStock = useCallback(async (id) => {
     try {
       // First, delete all related transactions
       const { error: transError } = await supabase
@@ -202,9 +202,9 @@ export function useStocks(userId) {
       console.error('Error in deleteStock:', error);
       return false;
     }
-  };
+  }, [userId]);
 
-  const archiveStock = async (id) => {
+  const archiveStock = useCallback(async (id) => {
     const { error } = await supabase
       .from('stocks')
       .update({ archived: true })
@@ -212,9 +212,9 @@ export function useStocks(userId) {
       .eq('user_id', userId);
     if (error) { console.error('Error archiving stock:', error); return false; }
     return true;
-  };
+  }, [userId]);
 
-  const restoreStock = async (id) => {
+  const restoreStock = useCallback(async (id) => {
     const { error } = await supabase
       .from('stocks')
       .update({ archived: false })
@@ -222,9 +222,9 @@ export function useStocks(userId) {
       .eq('user_id', userId);
     if (error) { console.error('Error restoring stock:', error); return false; }
     return true;
-  };
+  }, [userId]);
 
-  const fetchArchivedStocks = async () => {
+  const fetchArchivedStocks = useCallback(async () => {
     const { data, error } = await supabase
       .from('stocks')
       .select('*')
@@ -233,7 +233,7 @@ export function useStocks(userId) {
       .order('name', { ascending: true });
     if (error) { console.error('Error fetching archived stocks:', error); return []; }
     return (data || []).map(formatStock);
-  };
+  }, [userId]);
 
-    return { stocks, loading, addStock, updateStock, deleteStock, refetch: fetchStocks, reorderStocks, archiveStock, restoreStock, fetchArchivedStocks };
+  return { stocks, loading, addStock, updateStock, deleteStock, refetch: fetchStocks, reorderStocks, archiveStock, restoreStock, fetchArchivedStocks };
 }

--- a/src/hooks/useTransactions.js
+++ b/src/hooks/useTransactions.js
@@ -14,12 +14,7 @@ export function useTransactions(userId) {
   const [pagedTransactions, setPagedTransactions] = useState([]);
   const [pagedLoading, setPagedLoading] = useState(false);
 
-  useEffect(() => {
-    if (!userId) return;
-    fetchTransactions();
-  }, [userId]);
-
-  const fetchTransactions = async () => {
+  const fetchTransactions = useCallback(async () => {
     const { data, error } = await supabase
       .from('transactions')
       .select('*')
@@ -34,7 +29,12 @@ export function useTransactions(userId) {
       setTransactions((data || []).map(formatRow));
     }
     setLoading(false);
-  };
+  }, [userId]);
+
+  useEffect(() => {
+    if (!userId) return;
+    fetchTransactions();
+  }, [userId, fetchTransactions]);
 
   // Paginated fetch - used by HistoryPage
   const fetchPage = useCallback(async (targetPage, size, activeFilters, activeSort = sortConfig) => {
@@ -116,41 +116,41 @@ export function useTransactions(userId) {
     setPagedLoading(false);
   }, [userId]);
 
-  const goToPage = (targetPage) => {
+  const goToPage = useCallback((targetPage) => {
     setPage(targetPage);
     fetchPage(targetPage, pageSize, filters);
-  };
+  }, [fetchPage, pageSize, filters]);
 
-  const changePageSize = (size) => {
+  const changePageSize = useCallback((size) => {
     setPageSize(size);
     setPage(1);
     fetchPage(1, size, filters);
-  };
+  }, [fetchPage, filters]);
 
-  const applyFilters = (newFilters) => {
+  const applyFilters = useCallback((newFilters) => {
     setFilters(newFilters);
     setPage(1);
     fetchPage(1, pageSize, newFilters);
-  };
+  }, [fetchPage, pageSize]);
 
-  const initPaged = () => fetchPage(1, pageSize, filters);
+  const initPaged = useCallback(() => fetchPage(1, pageSize, filters), [fetchPage, pageSize, filters]);
 
-  const applySort = (newSort) => {
+  const applySort = useCallback((newSort) => {
     setSortConfig(newSort);
     setPage(1);
     fetchPage(1, pageSize, filters, newSort);
-  };
+  }, [fetchPage, pageSize, filters]);
 
-  const resetPaged = () => {
+  const resetPaged = useCallback(() => {
     const defaultSort = { key: 'date', dir: 'desc' };
     const defaultFilters = { type: 'all', stockName: '', category: '', dateFrom: '', dateTo: '', gpMin: '', gpMax: '', priceMin: '', priceMax: '', profitMin: '', profitMax: '', qtyMin: '', qtyMax: '', marginMin: '', marginMax: '' };
     setSortConfig(defaultSort);
     setFilters(defaultFilters);
     setPage(1);
     fetchPage(1, pageSize, defaultFilters, defaultSort);
-  };
+  }, [fetchPage, pageSize]);
 
-  const addTransaction = async (transaction) => {
+  const addTransaction = useCallback(async (transaction) => {
     const dbTransaction = {
       user_id: userId,
       stock_id: transaction.stockId,
@@ -175,11 +175,11 @@ export function useTransactions(userId) {
       setTransactions(prev => [formatted, ...prev]);
       return formatted;
     }
-  };
+  }, [userId]);
 
   const totalPages = Math.ceil(totalCount / pageSize);
 
-  const undoTransaction = async (transaction) => {
+  const undoTransaction = useCallback(async (transaction) => {
     if (transaction.type === 'buy') {
       const { data: laterSells } = await supabase
         .from('transactions')
@@ -267,7 +267,7 @@ export function useTransactions(userId) {
       console.error('Error undoing transaction:', err);
       return { success: false, error: err.message };
     }
-  };
+  }, [userId, fetchTransactions, fetchPage, pageSize, filters]);
 
   return {
     // Original API - unchanged


### PR DESCRIPTION
## Summary
- Wraps all mutation and fetch functions in `useStocks`, `useTransactions`, `useCategories`, `useProfits`, and `useMilestones` with `useCallback`
- Moves fetch function declarations before their `useEffect` calls and adds them to effect dep arrays
- `reorderStocks` gets `[userId, stocks]`; `updateProfit` and `updateMilestone` get their respective state in deps due to direct state reads; all others key on `[userId]`

## Motivation
After #217 wrapped these hooks in context providers, bare function identities changed on every provider render, redistributing fresh references to all consumers. `useModalHandlers`' own `useCallback`s were effectively never hitting cache. This makes context value churn proportional to actual data changes rather than every render.

Closes #230

## Test plan
- [ ] Add, update, delete, archive, restore a stock
- [ ] Drag to reorder stocks and categories
- [ ] Log buy and sell transactions; undo a sell
- [ ] Open HistoryPage — paginate, filter, sort, reset
- [ ] Add a dump/referral/bonds profit entry
- [ ] Update a milestone goal
- [ ] Check no double-fetch on load and no infinite loops in any useEffect

🤖 Generated with [Claude Code](https://claude.com/claude-code)