### PR TITLE
refactor(contexts): extract UIStateContext for UI state and highlight

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { LogOut } from 'lucide-react';
 import HomePage from './pages/HomePage';
 import HistoryPage from './pages/HistoryPage';
@@ -11,6 +11,7 @@ import { useNotificationSettings } from './hooks/useNotificationSettings';
 import { useGEData } from './contexts/GEDataContext';
 import { TradeProvider } from './contexts/TradeContext';
 import { ModalProvider, useModal } from './contexts/ModalContext';
+import { UIStateProvider, useUIState, useHighlight } from './contexts/UIStateContext';
 import { StocksProvider, useStocksContext } from './contexts/StocksContext';
 import { TransactionsProvider, useTransactionsContext } from './contexts/TransactionsContext';
 import { CategoriesProvider, useCategoriesContext } from './contexts/CategoriesContext';
@@ -55,7 +56,9 @@ export default function MainApp(props) {
             <ProfitsProvider userId={userId}>
               <MilestonesProvider userId={userId}>
                 <ProfitHistoryProvider userId={userId}>
-                  <MainAppInner {...props} />
+                  <UIStateProvider userId={userId}>
+                    <MainAppInner {...props} />
+                  </UIStateProvider>
                 </ProfitHistoryProvider>
               </MilestonesProvider>
             </ProfitsProvider>
@@ -69,8 +72,18 @@ export default function MainApp(props) {
 function MainAppInner({ session, onLogout }) {
   const userId = session.user.id;
   const userEmail = session.user.email;
-  // Custom hooks for Supabase
-  const [tradeMode, setTradeMode] = useState('trade');
+  const {
+    tradeMode,
+    setTradeMode,
+    collapsedCategories,
+    setCollapsedCategories,
+    milestoneProgress,
+    setMilestoneProgress,
+    calculateMilestoneProgress,
+    firedTimerNotifs,
+    saveFiredTimers,
+  } = useUIState();
+  const { highlightedRows, highlightRow } = useHighlight();
   const { gePrices, geMapping, geIconMap, membershipMap, mappingLoading } = useGEData();
 
   const switchTradeMode = (mode) => {
@@ -105,8 +118,6 @@ function MainAppInner({ session, onLogout }) {
   const {
     currentPage,
     graphItemId,
-    collapsedCategories,
-    setCollapsedCategories,
     navigateToPage,
     toggleCategory,
     expandCategory,
@@ -114,7 +125,6 @@ function MainAppInner({ session, onLogout }) {
     handleNotificationNavigate,
   } = useNavigation({ refetch, fetchCategories, refetchGPStats, refetchProfitHistory, applyFilters, stocks, categories });
   const [sortConfig, setSortConfig] = useState({ key: null, direction: 'asc' });
-  const [highlightedRows, setHighlightedRows] = useState({});
   const [currentTime, setCurrentTime] = useState(Date.now());
   const dataLoaded = !stocksLoading && !categoriesLoading && !transactionsLoading && !notesLoading && !settingsLoading && !profitsLoading && !milestonesLoading && !profitHistoryLoading && !gpStatsLoading;
 
@@ -165,7 +175,6 @@ function MainAppInner({ session, onLogout }) {
   });
 
   // Track which timer notifications have already fired to avoid duplicates
-  const firedTimerNotifs = useRef(new Set(JSON.parse(localStorage.getItem(`osrs_fired_limit_timers_${userId}`) || '[]')));
   const firedAltTimerNotif = useRef(false);
   const firedMilestoneNotifs = useRef(new Set(JSON.parse(localStorage.getItem(`osrs_fired_milestones_${userId}`) || '[]')));
   const seenNewsGuids = useRef(new Set(JSON.parse(localStorage.getItem(`osrs_seen_news_${userId}`) || '[]')));
@@ -176,11 +185,6 @@ function MainAppInner({ session, onLogout }) {
   const newsNotifsInitialized = useRef(localStorage.getItem(`osrs_news_initialized_${userId}`) === 'true');
   const jmodNotifsInitialized = useRef(localStorage.getItem(`osrs_jmod_initialized_${userId}`) === 'true');
   const timerTimeoutsRef = useRef(new Map());
-
-  // Helper to persist firedTimerNotifs to localStorage
-  const saveFiredTimers = useCallback(() => {
-    localStorage.setItem(`osrs_fired_limit_timers_${userId}`, JSON.stringify(Array.from(firedTimerNotifs.current)));
-  }, [userId]);
 
   // Save when app closes
   useEffect(() => {
@@ -366,13 +370,6 @@ function MainAppInner({ session, onLogout }) {
     }
   }, [userId]); // Remove categoriesLoading and categories from dependencies
   // Helper functions
-  const highlightRow = (stockId) => {
-    setHighlightedRows({ ...highlightedRows, [stockId]: true });
-    setTimeout(() => {
-      setHighlightedRows({ ...highlightedRows, [stockId]: false });
-    }, 1000);
-  };
-
   const handleSort = (key) => {
     setSortConfig({
       key,
@@ -387,101 +384,10 @@ function MainAppInner({ session, onLogout }) {
     }
   };
 
-  const calculateMilestoneProgress = () => {
-    if (!dataLoaded || !profitHistory) return { day: 0, week: 0, month: 0, year: 0 };
-
-    const getStartOfPeriod = (period) => {
-      const date = new Date();
-      switch (period) {
-        case 'day':
-          date.setHours(0, 0, 0, 0);
-          return date;
-        case 'week':
-          const diff = date.getDate() - date.getDay() + (date.getDay() === 0 ? -6 : 1);
-          date.setDate(diff);
-          date.setHours(0, 0, 0, 0);
-          return date;
-        case 'month':
-          date.setDate(1);
-          date.setHours(0, 0, 0, 0);
-          return date;
-        case 'year':
-          date.setMonth(0, 1);
-          date.setHours(0, 0, 0, 0);
-          return date;
-        default:
-          return date;
-      }
-    };
-
-    const calculatePeriodProfit = (period) => {
-      const startDate = getStartOfPeriod(period);
-      const periodProfits = profitHistory.filter(entry => {
-        const entryDate = new Date(entry.created_at);
-        return entryDate >= startDate && entry.profit_type !== 'bonds';
-      });
-      const totalProfit = periodProfits.reduce((sum, entry) => sum + entry.amount, 0);
-      return totalProfit;
-    };
-
-    return {
-      day: calculatePeriodProfit('day'),
-      week: calculatePeriodProfit('week'),
-      month: calculatePeriodProfit('month'),
-      year: calculatePeriodProfit('year')
-    };
-  };
-
   useEffect(() => {
     if (!profitHistory || profitHistoryLoading) return;
 
-    const getStartOfPeriod = (period) => {
-      const date = new Date();
-      switch (period) {
-        case 'day':
-          date.setHours(0, 0, 0, 0);
-          return date;
-        case 'week':
-          const diff = date.getDate() - date.getDay() + (date.getDay() === 0 ? -6 : 1);
-          date.setDate(diff);
-          date.setHours(0, 0, 0, 0);
-          return date;
-        case 'month':
-          date.setDate(1);
-          date.setHours(0, 0, 0, 0);
-          return date;
-        case 'year':
-          date.setMonth(0, 1);
-          date.setHours(0, 0, 0, 0);
-          return date;
-        default:
-          return date;
-      }
-    };
-
-    const calculatePeriodProfit = (period) => {
-      const startDate = getStartOfPeriod(period);
-
-      const periodProfits = profitHistory.filter(entry => {
-        const entryDate = new Date(entry.created_at);
-        const isInPeriod = entryDate >= startDate;
-        const isNotBonds = entry.profit_type !== 'bonds';
-
-        return isInPeriod && isNotBonds;
-      });
-
-      const totalProfit = periodProfits.reduce((sum, entry) => sum + entry.amount, 0);
-
-      return Math.max(0, totalProfit);
-    };
-
-    const newProgress = {
-      day: calculatePeriodProfit('day'),
-      week: calculatePeriodProfit('week'),
-      month: calculatePeriodProfit('month'),
-      year: calculatePeriodProfit('year')
-    };
-
+    const newProgress = calculateMilestoneProgress();
     setMilestoneProgress(newProgress);
 
     // Check for milestone achievements and fire notifications
@@ -528,7 +434,7 @@ function MainAppInner({ session, onLogout }) {
     if (!milestonesLoading) {
       recordCompletedPeriods(profitHistory, milestones);
     }
-  }, [dataLoaded, profitHistory, milestones]);
+  }, [profitHistory, milestones, calculateMilestoneProgress, setMilestoneProgress]);
 
   // OSRS News notification effect
   useEffect(() => {
@@ -598,8 +504,6 @@ function MainAppInner({ session, onLogout }) {
   };
 
 
-  const [milestoneProgress, setMilestoneProgress] = useState({ day: 0, week: 0, month: 0, year: 0 });
-
   const {
     isSubmitting,
     bulkSummaryData,
@@ -630,15 +534,7 @@ function MainAppInner({ session, onLogout }) {
     handleConfirmArchive,
     handleRestore,
     refreshArchivedStocks,
-  } = useModalHandlers({
-    tradeMode,
-    highlightRow,
-    firedTimerNotifs,
-    saveFiredTimers,
-    setCollapsedCategories,
-    calculateMilestoneProgress,
-    setMilestoneProgress,
-  });
+  } = useModalHandlers();
 
   const handleInvestmentDateChange = async (stock, date) => {
     await updateStock(stock.id, { investmentStartDate: date });

--- a/src/contexts/UIStateContext.jsx
+++ b/src/contexts/UIStateContext.jsx
@@ -1,0 +1,108 @@
+import { createContext, useContext, useState, useCallback, useMemo, useRef } from 'react';
+import { useProfitHistoryContext } from './ProfitHistoryContext';
+
+const UIStateContext = createContext(null);
+const HighlightContext = createContext(null);
+
+export function UIStateProvider({ userId, children }) {
+  const { profitHistory } = useProfitHistoryContext();
+
+  const [tradeMode, setTradeMode] = useState('trade');
+
+  const [collapsedCategories, setCollapsedCategories] = useState(() => {
+    const saved = localStorage.getItem('collapsedCategories');
+    return saved ? JSON.parse(saved) : {};
+  });
+
+  const [milestoneProgress, setMilestoneProgress] = useState({ day: 0, week: 0, month: 0, year: 0 });
+
+  const firedTimerNotifs = useRef(
+    new Set(JSON.parse(localStorage.getItem(`osrs_fired_limit_timers_${userId}`) || '[]'))
+  );
+
+  const saveFiredTimers = useCallback(() => {
+    localStorage.setItem(
+      `osrs_fired_limit_timers_${userId}`,
+      JSON.stringify(Array.from(firedTimerNotifs.current))
+    );
+  }, [userId]);
+
+  const calculateMilestoneProgress = useCallback(() => {
+    if (!profitHistory) return { day: 0, week: 0, month: 0, year: 0 };
+
+    const getStartOfPeriod = (period) => {
+      const date = new Date();
+      if (period === 'day') { date.setHours(0, 0, 0, 0); return date; }
+      if (period === 'week') {
+        const diff = date.getDate() - date.getDay() + (date.getDay() === 0 ? -6 : 1);
+        date.setDate(diff);
+        date.setHours(0, 0, 0, 0);
+        return date;
+      }
+      if (period === 'month') { date.setDate(1); date.setHours(0, 0, 0, 0); return date; }
+      if (period === 'year') { date.setMonth(0, 1); date.setHours(0, 0, 0, 0); return date; }
+      return date;
+    };
+
+    const calcPeriod = (period) => {
+      const startDate = getStartOfPeriod(period);
+      const total = profitHistory
+        .filter(e => new Date(e.created_at) >= startDate && e.profit_type !== 'bonds')
+        .reduce((sum, e) => sum + e.amount, 0);
+      return Math.max(0, total);
+    };
+
+    return {
+      day: calcPeriod('day'),
+      week: calcPeriod('week'),
+      month: calcPeriod('month'),
+      year: calcPeriod('year'),
+    };
+  }, [profitHistory]);
+
+  const [highlightedRows, setHighlightedRows] = useState({});
+
+  const highlightRow = useCallback((stockId) => {
+    setHighlightedRows(prev => ({ ...prev, [stockId]: true }));
+    setTimeout(() => {
+      setHighlightedRows(prev => ({ ...prev, [stockId]: false }));
+    }, 1000);
+  }, []);
+
+  const uiValue = useMemo(() => ({
+    tradeMode,
+    setTradeMode,
+    collapsedCategories,
+    setCollapsedCategories,
+    milestoneProgress,
+    setMilestoneProgress,
+    calculateMilestoneProgress,
+    firedTimerNotifs,
+    saveFiredTimers,
+  }), [tradeMode, collapsedCategories, milestoneProgress, calculateMilestoneProgress, saveFiredTimers]);
+
+  const highlightValue = useMemo(() => ({
+    highlightedRows,
+    highlightRow,
+  }), [highlightedRows, highlightRow]);
+
+  return (
+    <UIStateContext.Provider value={uiValue}>
+      <HighlightContext.Provider value={highlightValue}>
+        {children}
+      </HighlightContext.Provider>
+    </UIStateContext.Provider>
+  );
+}
+
+export function useUIState() {
+  const ctx = useContext(UIStateContext);
+  if (!ctx) throw new Error('useUIState must be used within UIStateProvider');
+  return ctx;
+}
+
+export function useHighlight() {
+  const ctx = useContext(HighlightContext);
+  if (!ctx) throw new Error('useHighlight must be used within UIStateProvider');
+  return ctx;
+}

--- a/src/hooks/useModalHandlers.js
+++ b/src/hooks/useModalHandlers.js
@@ -8,26 +8,18 @@ import { useProfitsContext } from '../contexts/ProfitsContext';
 import { useMilestonesContext } from '../contexts/MilestonesContext';
 import { useProfitHistoryContext } from '../contexts/ProfitHistoryContext';
 import { useModal } from '../contexts/ModalContext';
+import { useUIState, useHighlight } from '../contexts/UIStateContext';
 
-/**
- * @param {Object} opts
- * @param {string} opts.tradeMode
- * @param {Function} opts.highlightRow
- * @param {React.MutableRefObject<Set>} opts.firedTimerNotifs
- * @param {Function} opts.saveFiredTimers
- * @param {Function} opts.setCollapsedCategories
- * @param {Function} opts.calculateMilestoneProgress
- * @param {Function} opts.setMilestoneProgress
- */
-export function useModalHandlers({
-  tradeMode,
-  highlightRow,
-  firedTimerNotifs,
-  saveFiredTimers,
-  setCollapsedCategories,
-  calculateMilestoneProgress,
-  setMilestoneProgress,
-}) {
+export function useModalHandlers() {
+  const {
+    tradeMode,
+    setCollapsedCategories,
+    calculateMilestoneProgress,
+    setMilestoneProgress,
+    firedTimerNotifs,
+    saveFiredTimers,
+  } = useUIState();
+  const { highlightRow } = useHighlight();
   const {
     updateStock,
     deleteStock,

--- a/src/hooks/useNavigation.js
+++ b/src/hooks/useNavigation.js
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { useUIState } from '../contexts/UIStateContext';
 
 const PAGE_PATHS = { home: '/', trade: '/trade', history: '/history', graphs: '/graphs' };
 
@@ -28,10 +29,7 @@ export function useNavigation({
 }) {
   const [currentPage, setCurrentPage] = useState(getPageFromURL);
   const [graphItemId, setGraphItemId] = useState(() => new URLSearchParams(window.location.search).get('item'));
-  const [collapsedCategories, setCollapsedCategories] = useState(() => {
-    const saved = localStorage.getItem('collapsedCategories');
-    return saved ? JSON.parse(saved) : {};
-  });
+  const { collapsedCategories, setCollapsedCategories } = useUIState();
 
   const navigateToPage = useCallback((page, options = {}) => {
     if (page === 'trade') {
@@ -171,8 +169,6 @@ export function useNavigation({
   return {
     currentPage,
     graphItemId,
-    collapsedCategories,
-    setCollapsedCategories,
     navigateToPage,
     toggleCategory,
     expandCategory,


### PR DESCRIPTION
## Summary
- Creates `UIStateContext` owning `tradeMode`, `collapsedCategories`, `milestoneProgress`, `calculateMilestoneProgress`, `firedTimerNotifs`, and `saveFiredTimers`
- Creates `HighlightContext` (separate context in same file) owning `highlightedRows` and `highlightRow`, isolated to avoid re-renders on every trade flash propagating to unrelated consumers
- `useModalHandlers` signature drops from 7 params → 0; consumes both contexts internally
- `useNavigation` no longer owns `collapsedCategories` state; consumes `useUIState()` instead
- Milestone `useEffect` in `MainApp` collapsed from ~50 lines to 5 by replacing duplicate inline calculation with `calculateMilestoneProgress()` from context
- Fixes stale closure bug on the old `highlightRow` function (now uses functional `setState` updates)

Closes #229

## Test plan
- [ ] Buy / sell / bulk buy / bulk sell — row highlight flashes, timer notification not re-fired
- [ ] Delete category / edit category — collapsed state updates correctly, trade mode respected
- [ ] Collapse/expand categories — persists across reload
- [ ] Milestone modal — update a goal, progress bar reflects new value immediately
- [ ] Sell something — milestone progress bar updates
- [ ] Trade / Investment mode toggle — stocks and categories filter correctly
- [ ] Category quick nav — clicking a collapsed category expands and scrolls
- [ ] Notification navigate to stock — expands correct category and scrolls to stock
- [ ] Drag-and-drop stock / category — row highlight fires after drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)