### PR TITLE
refactor(utils): extract notification helpers to shared utils

### DIFF
--- a/src/components/NotificationCenter.jsx
+++ b/src/components/NotificationCenter.jsx
@@ -1,63 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
-import { Bell, Clock, Trophy, User, Check, X, CheckCheck, Trash2, Newspaper, ExternalLink, MessageSquare, Filter, TrendingUp, TrendingDown, Edit3 } from 'lucide-react';
-import { formatNumber } from '../utils/formatters';
+import { Bell, Check, X, CheckCheck, Trash2, Newspaper, ExternalLink, MessageSquare, TrendingUp, TrendingDown, Edit3 } from 'lucide-react';
+import { formatNumber, getTimeAgo } from '../utils/formatters';
+import { getTypeIcon, getTypeColor } from '../utils/notificationUtils';
 import { useGEData } from '../contexts/GEDataContext';
 import '../styles/notification-center.css';
-
-function getTimeAgo(timestamp) {
-  const seconds = Math.floor((Date.now() - timestamp) / 1000);
-  if (seconds < 60) return 'just now';
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
-}
-
-function getTypeIcon(type) {
-  switch (type) {
-    case 'limitTimer':
-      return <Clock size={16} />;
-    case 'altAccountTimer':
-      return <User size={16} />;
-    case 'milestone':
-      return <Trophy size={16} />;
-    case 'osrsNews':
-      return <Newspaper size={16} />;
-    case 'jmodReddit':
-      return <MessageSquare size={16} />;
-    case 'priceAlert':
-    case 'priceAlertHigh':
-      return <TrendingUp size={16} />;
-    case 'priceAlertLow':
-      return <TrendingDown size={16} />;
-    default:
-      return <Bell size={16} />;
-  }
-}
-
-function getTypeColor(type) {
-  switch (type) {
-    case 'limitTimer':
-      return 'var(--notification-timer-color, rgb(202, 138, 4))';
-    case 'altAccountTimer':
-      return 'var(--notification-alt-color, rgb(168, 85, 247))';
-    case 'milestone':
-      return 'var(--notification-milestone-color, rgb(34, 197, 94))';
-    case 'osrsNews':
-      return 'var(--notification-news-color, rgb(14, 165, 233))';
-    case 'jmodReddit':
-      return 'var(--notification-jmod-color, rgb(255, 149, 0))';
-    case 'priceAlert':
-    case 'priceAlertLow':
-      return 'rgb(239, 68, 68)';
-    case 'priceAlertHigh':
-      return 'rgb(74, 222, 128)';
-    default:
-      return 'rgb(148, 163, 184)';
-  }
-}
 
 export default function NotificationCenter({
   notifications = [],

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -60,6 +60,17 @@ export function formatAvgPrice(value, numberFormat) {
   }
 }
 
+export function getTimeAgo(timestamp) {
+  const seconds = Math.floor((Date.now() - timestamp) / 1000);
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
 export const formatTimer = (endTime) => {
   if (!endTime) return '--:--:--';
   const remaining = endTime - Date.now();

--- a/src/utils/notificationUtils.jsx
+++ b/src/utils/notificationUtils.jsx
@@ -1,0 +1,45 @@
+import { Bell, Clock, Trophy, User, Newspaper, MessageSquare, TrendingUp, TrendingDown } from 'lucide-react';
+
+export function getTypeIcon(type) {
+  switch (type) {
+    case 'limitTimer':
+      return <Clock size={16} />;
+    case 'altAccountTimer':
+      return <User size={16} />;
+    case 'milestone':
+      return <Trophy size={16} />;
+    case 'osrsNews':
+      return <Newspaper size={16} />;
+    case 'jmodReddit':
+      return <MessageSquare size={16} />;
+    case 'priceAlert':
+    case 'priceAlertHigh':
+      return <TrendingUp size={16} />;
+    case 'priceAlertLow':
+      return <TrendingDown size={16} />;
+    default:
+      return <Bell size={16} />;
+  }
+}
+
+export function getTypeColor(type) {
+  switch (type) {
+    case 'limitTimer':
+      return 'var(--notification-timer-color, rgb(202, 138, 4))';
+    case 'altAccountTimer':
+      return 'var(--notification-alt-color, rgb(168, 85, 247))';
+    case 'milestone':
+      return 'var(--notification-milestone-color, rgb(34, 197, 94))';
+    case 'osrsNews':
+      return 'var(--notification-news-color, rgb(14, 165, 233))';
+    case 'jmodReddit':
+      return 'var(--notification-jmod-color, rgb(255, 149, 0))';
+    case 'priceAlert':
+    case 'priceAlertLow':
+      return 'rgb(239, 68, 68)';
+    case 'priceAlertHigh':
+      return 'rgb(74, 222, 128)';
+    default:
+      return 'rgb(148, 163, 184)';
+  }
+}


### PR DESCRIPTION
## Summary
- Moved `getTimeAgo` from `NotificationCenter.jsx` to `src/utils/formatters.js` for general reuse
- Extracted `getTypeIcon` and `getTypeColor` to new `src/utils/notificationUtils.jsx`
- Cleaned up unused icon imports from `NotificationCenter.jsx`

Closes #221

## Test plan
- [ ] Verify notifications render with correct icons and colors
- [ ] Verify relative timestamps display correctly across all tabs (inbox, news, alerts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)