### PR TITLE
Include archived stocks in stats while keeping archive hidden

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -91,7 +91,7 @@ function MainAppInner({ session, onLogout }) {
     fetchCategories();
     setTradeMode(mode);
   };
-  const { stocks, loading: stocksLoading, addStock: addStockToDB, updateStock, deleteStock, refetch, reorderStocks, archiveStock, restoreStock, fetchArchivedStocks } = useStocksContext();
+  const { stocks, allStocks, loading: stocksLoading, addStock: addStockToDB, updateStock, deleteStock, refetch, reorderStocks, archiveStock, restoreStock, fetchArchivedStocks } = useStocksContext();
   const { categories, loading: categoriesLoading, addCategory, deleteCategory, updateCategory, fetchCategories, reorderCategories } = useCategoriesContext();
   const {
     transactions, loading: transactionsLoading, addTransaction,
@@ -713,6 +713,9 @@ function MainAppInner({ session, onLogout }) {
   const filteredStocks = stocks.filter(s =>
     tradeMode === 'investment' ? s.isInvestment : !s.isInvestment
   );
+  const filteredAllStocks = allStocks.filter(s =>
+    tradeMode === 'investment' ? s.isInvestment : !s.isInvestment
+  );
   const filteredCategories = categories.filter(c =>
     tradeMode === 'investment' ? c.isInvestment : !c.isInvestment
   );
@@ -723,6 +726,10 @@ function MainAppInner({ session, onLogout }) {
     acc[cat.name] = filteredStocks.filter(s => s.category === cat.name);
     return acc;
   }, {});
+  const groupedStatsStocks = filteredCategories.reduce((acc, cat) => {
+    acc[cat.name] = filteredAllStocks.filter(s => s.category === cat.name);
+    return acc;
+  }, {});
 
   // Add uncategorized investment/trade stocks that have no matching category
   const uncategorizedFiltered = filteredStocks.filter(s =>
@@ -731,11 +738,17 @@ function MainAppInner({ session, onLogout }) {
   if (uncategorizedFiltered.length > 0 && !filteredCategories.some(c => c.name === 'Uncategorized')) {
     groupedStocks['Uncategorized'] = uncategorizedFiltered;
   }
+  const uncategorizedStats = filteredAllStocks.filter(s =>
+    s.category === 'Uncategorized' || !s.category || !categoryNames.includes(s.category)
+  );
+  if (uncategorizedStats.length > 0 && !filteredCategories.some(c => c.name === 'Uncategorized')) {
+    groupedStatsStocks['Uncategorized'] = uncategorizedStats;
+  }
 
 
 
   return (
-    <TradeProvider stocks={stocks} categories={categories} refetchStocks={refetch} refetchCategories={fetchCategories}>
+    <TradeProvider stocks={stocks} allStocks={allStocks} categories={categories} refetchStocks={refetch} refetchCategories={fetchCategories}>
     <div style={{
       minHeight: '100vh',
       background: 'rgb(15, 23, 42)',
@@ -947,6 +960,7 @@ function MainAppInner({ session, onLogout }) {
             profitHistory={profitHistory}
             gpTradedStats={gpTradedStats}
             profits={profits}
+            statsStocks={allStocks}
             numberFormat={numberFormat}
             milestones={milestones}
             milestoneProgress={milestoneProgress}
@@ -997,6 +1011,7 @@ function MainAppInner({ session, onLogout }) {
               dumpProfit={dumpProfit}
               referralProfit={referralProfit}
               bondsProfit={bondsProfit}
+              statsStocks={allStocks}
               visibleProfits={visibleProfits}
               onAddDumpProfit={() => openModal('dumpProfit')}
               onAddReferralProfit={() => openModal('referralProfit')}
@@ -1096,6 +1111,7 @@ function MainAppInner({ session, onLogout }) {
                 key={category}
                 category={category}
                 stocks={categoryStocks}
+                statsStocks={groupedStatsStocks[category] || []}
                 isCollapsed={collapsedCategories[category]}
                 onToggleCollapse={toggleCategory}
                 onAddStock={(cat) => openModal('newStock', { newStockCategory: cat })}
@@ -1178,6 +1194,7 @@ function MainAppInner({ session, onLogout }) {
           bondsProfit={bondsProfit}
           numberFormat={numberFormat}
           groupedStocks={groupedStocks}
+          groupedStatsStocks={groupedStatsStocks}
           categoryNames={categoryNames}
           geIconMap={geIconMap}
           gePrices={gePrices}

--- a/src/components/CategorySection.jsx
+++ b/src/components/CategorySection.jsx
@@ -9,6 +9,7 @@ import '../styles/category-section.css';
 export default function CategorySection({
   category,
   stocks,
+  statsStocks = null,
   isCollapsed,
   onToggleCollapse,
   onAddStock,
@@ -47,6 +48,7 @@ export default function CategorySection({
 }) {
   const { gePrices: geData, geIconMap, membershipMap } = useGEData();
   const categoryStocks = stocks.filter(s => s.category === category);
+  const categoryStatsStocks = (statsStocks || stocks).filter(s => s.category === category);
 
   return (
     <div className="category-container" data-category={category}>
@@ -67,14 +69,14 @@ export default function CategorySection({
               {category} ({categoryStocks.length})
             </h2>
             {showCategoryStats && (() => {
-              const timerCount = categoryStocks.filter(s => s.timerEndTime && s.timerEndTime > Date.now()).length;
-              const okCount = categoryStocks.filter(s =>
+              const timerCount = categoryStatsStocks.filter(s => s.timerEndTime && s.timerEndTime > Date.now()).length;
+              const okCount = categoryStatsStocks.filter(s =>
                 (!s.timerEndTime || s.timerEndTime <= Date.now()) &&
                 s.shares >= s.needed &&
                 !s.onHold
               ).length;
-              const holdCount = categoryStocks.filter(s => s.onHold).length;
-              const lowCount = categoryStocks.filter(s =>
+              const holdCount = categoryStatsStocks.filter(s => s.onHold).length;
+              const lowCount = categoryStatsStocks.filter(s =>
                 (!s.timerEndTime || s.timerEndTime <= Date.now()) &&
                 s.shares < s.needed &&
                 !s.onHold
@@ -191,31 +193,31 @@ export default function CategorySection({
           <div className="category-stats">
             <StatItem
               label="Total Cost"
-              value={formatNumber(categoryStocks.reduce((sum, s) => sum + s.totalCost, 0), numberFormat)}
+              value={formatNumber(categoryStatsStocks.reduce((sum, s) => sum + s.totalCost, 0), numberFormat)}
               color="rgb(96, 165, 250)"
             />
             <StatItem
               label="Total Shares"
-              value={formatNumber(categoryStocks.reduce((sum, s) => sum + s.shares, 0), numberFormat)}
+              value={formatNumber(categoryStatsStocks.reduce((sum, s) => sum + s.shares, 0), numberFormat)}
               color="rgb(251, 146, 60)"
             />
             <StatItem
               label="Total Profit"
-              value={formatNumber(categoryStocks.reduce((sum, s) => sum + (s.totalCostSold - (s.totalCostBasisSold || 0)), 0), numberFormat)}
+              value={formatNumber(categoryStatsStocks.reduce((sum, s) => sum + (s.totalCostSold - (s.totalCostBasisSold || 0)), 0), numberFormat)}
               color="rgb(52, 211, 153)"
             />
             <StatItem
               label="Sold Shares"
-              value={formatNumber(categoryStocks.reduce((sum, s) => sum + s.sharesSold, 0), numberFormat)}
+              value={formatNumber(categoryStatsStocks.reduce((sum, s) => sum + s.sharesSold, 0), numberFormat)}
               color="rgb(168, 85, 247)"
             />
             <StatItem
               label="Sold Cost"
-              value={formatNumber(categoryStocks.reduce((sum, s) => sum + s.totalCostSold, 0), numberFormat)}
+              value={formatNumber(categoryStatsStocks.reduce((sum, s) => sum + s.totalCostSold, 0), numberFormat)}
               color="rgb(192, 132, 252)"
             />
             {showCategoryUnrealisedProfit && (() => {
-              const total = categoryStocks.reduce((sum, s) => {
+              const total = categoryStatsStocks.reduce((sum, s) => {
                 const high = s.itemId ? geData[s.itemId]?.high : null;
                 const val = calculateUnrealizedProfit(s, high, s.itemId);
                 return sum + (val ?? 0);

--- a/src/components/ModalManager.jsx
+++ b/src/components/ModalManager.jsx
@@ -65,6 +65,7 @@ export default function ModalManager({
   bondsProfit,
   numberFormat,
   groupedStocks,
+  groupedStatsStocks,
   categoryNames,
   geIconMap,
   gePrices,
@@ -255,7 +256,7 @@ export default function ModalManager({
 
       <ModalContainer isOpen={modals.categoryChart}>
         <CategoryChartModal
-          groupedStocks={groupedStocks}
+          groupedStocks={groupedStatsStocks || groupedStocks}
           onCancel={() => closeModal('categoryChart')}
           numberFormat={numberFormat}
         />

--- a/src/components/PortfolioSummary.jsx
+++ b/src/components/PortfolioSummary.jsx
@@ -10,6 +10,7 @@ export default function PortfolioSummary({
   dumpProfit,
   referralProfit,
   bondsProfit,
+  statsStocks = null,
   visibleProfits = { dumpProfit: true, referralProfit: true, bondsProfit: true },
   onAddDumpProfit,
   onAddReferralProfit,
@@ -18,21 +19,22 @@ export default function PortfolioSummary({
   showUnrealisedProfitStats = false
 }) {
   const { gePrices: geData } = useGEData();
-  const { stocks } = useTrade();
-  const stocksProfit = calculateStocksProfit(stocks);
-  const totalProfit = calculateTotalProfit(stocks, dumpProfit, referralProfit, bondsProfit);
+  const { stocks, allStocks } = useTrade();
+  const stocksForStats = statsStocks || (allStocks?.length > 0 ? allStocks : stocks);
+  const stocksProfit = calculateStocksProfit(stocksForStats);
+  const totalProfit = calculateTotalProfit(stocksForStats, dumpProfit, referralProfit, bondsProfit);
 
   const totalUnrealised = showUnrealisedProfitStats
-    ? stocks.reduce((sum, s) => {
+    ? stocksForStats.reduce((sum, s) => {
         const high = s.itemId ? geData[s.itemId]?.high : null;
         const val = calculateUnrealizedProfit(s, high, s.itemId);
         return sum + (val ?? 0);
       }, 0)
     : null;
 
-  const totalPortfolio = stocks.reduce((sum, s) => sum + s.totalCost, 0);
-  const totalShares = stocks.reduce((sum, s) => sum + s.shares, 0);
-  const totalSales = stocks.reduce((sum, s) => sum + s.totalCostSold, 0);
+  const totalPortfolio = stocksForStats.reduce((sum, s) => sum + s.totalCost, 0);
+  const totalShares = stocksForStats.reduce((sum, s) => sum + s.shares, 0);
+  const totalSales = stocksForStats.reduce((sum, s) => sum + s.totalCostSold, 0);
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', width: '100%' }}>

--- a/src/components/modals/ProfitChartModal.jsx
+++ b/src/components/modals/ProfitChartModal.jsx
@@ -4,8 +4,9 @@ import { calculateStocksProfit } from '../../utils/calculations';
 import { useTrade } from '../../contexts/TradeContext';
 
 export default function ProfitChartModal({ dumpProfit, referralProfit, bondsProfit, onCancel, numberFormat }) {
-  const { stocks } = useTrade();
-  const stocksProfit = calculateStocksProfit(stocks);
+  const { stocks, allStocks } = useTrade();
+  const stocksForStats = allStocks?.length > 0 ? allStocks : stocks;
+  const stocksProfit = calculateStocksProfit(stocksForStats);
   const totalProfit = stocksProfit + dumpProfit + referralProfit + bondsProfit;
 
   const segments = [];

--- a/src/contexts/TradeContext.jsx
+++ b/src/contexts/TradeContext.jsx
@@ -1,12 +1,18 @@
 import { createContext, useContext, useMemo } from 'react';
 
-const TRADE_DEFAULT = { stocks: [], categories: [], refetchStocks: () => {}, refetchCategories: () => {} };
+const TRADE_DEFAULT = {
+  stocks: [],
+  allStocks: [],
+  categories: [],
+  refetchStocks: () => {},
+  refetchCategories: () => {},
+};
 const TradeContext = createContext(TRADE_DEFAULT);
 
-export function TradeProvider({ stocks, categories, refetchStocks, refetchCategories, children }) {
+export function TradeProvider({ stocks, allStocks = [], categories, refetchStocks, refetchCategories, children }) {
   const value = useMemo(
-    () => ({ stocks, categories, refetchStocks, refetchCategories }),
-    [stocks, categories, refetchStocks, refetchCategories]
+    () => ({ stocks, allStocks, categories, refetchStocks, refetchCategories }),
+    [stocks, allStocks, categories, refetchStocks, refetchCategories]
   );
 
   return (

--- a/src/hooks/useStocks.js
+++ b/src/hooks/useStocks.js
@@ -19,12 +19,14 @@ const STOCK_KEY_MAP = {
   isInvestment: ['is_investment', false],
   itemId: ['item_id', null],
   investmentStartDate: ['investment_start_date', null],
+  archived: ['archived', false],
 };
 
 const formatStock = (row) => mapRow(row, STOCK_KEY_MAP);
 
 export function useStocks(userId) {
   const [stocks, setStocks] = useState([]);
+  const [allStocks, setAllStocks] = useState([]);
   const [loading, setLoading] = useState(true);
 
   const fetchStocks = useCallback(async () => {
@@ -32,14 +34,16 @@ export function useStocks(userId) {
       .from('stocks')
       .select('*')
       .eq('user_id', userId)
-      .eq('archived', false)
       .order('position', { ascending: true });
 
     if (error) {
       console.error('Error fetching stocks:', error);
       setStocks([]);
+      setAllStocks([]);
     } else {
-      setStocks((data || []).map(formatStock));
+      const formattedStocks = (data || []).map(formatStock);
+      setAllStocks(formattedStocks);
+      setStocks(formattedStocks.filter(stock => !stock.archived));
     }
     setLoading(false);
   }, [userId]);
@@ -235,5 +239,5 @@ export function useStocks(userId) {
     return (data || []).map(formatStock);
   }, [userId]);
 
-  return { stocks, loading, addStock, updateStock, deleteStock, refetch: fetchStocks, reorderStocks, archiveStock, restoreStock, fetchArchivedStocks };
+  return { stocks, allStocks, loading, addStock, updateStock, deleteStock, refetch: fetchStocks, reorderStocks, archiveStock, restoreStock, fetchArchivedStocks };
 }

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -19,6 +19,7 @@ export default function HomePage({
   transactions,
   gpTradedStats,
   profits,
+  statsStocks = null,
   numberFormat,
   milestones,
   milestoneProgress,
@@ -28,7 +29,8 @@ export default function HomePage({
   profitHistory,
 }) {
   const { gePrices: geData } = useGEData();
-  const { stocks } = useTrade();
+  const { stocks, allStocks } = useTrade();
+  const stocksForStats = statsStocks || (allStocks?.length > 0 ? allStocks : stocks);
   const [topItemsSortBy, setTopItemsSortBy] = useState('profit');
   // Use milestoneProgress for period profits (already calculated in MainApp)
   const dayProfit = milestoneProgress?.day || 0;
@@ -37,7 +39,7 @@ export default function HomePage({
   const yearProfit = milestoneProgress?.year || 0;
 
   // Calculate total realized profit (from sells) FIRST
-  const totalRealizedProfit = stocks?.reduce((sum, stock) => {
+  const totalRealizedProfit = stocksForStats?.reduce((sum, stock) => {
     return sum + (stock.totalCostSold - (stock.totalCostBasisSold || 0));
   }, 0) || 0;
 
@@ -54,20 +56,20 @@ export default function HomePage({
   const totalGPTraded = gpTradedStats?.total || 0;
 
   // Calculate inventory metrics
-  const inventoryValue = stocks?.reduce((sum, stock) =>
+  const inventoryValue = stocksForStats?.reduce((sum, stock) =>
     sum + stock.totalCost, 0
   ) || 0;
 
-  const itemsInStock = stocks?.reduce((sum, stock) => sum + stock.shares, 0) || 0;
+  const itemsInStock = stocksForStats?.reduce((sum, stock) => sum + stock.shares, 0) || 0;
 
-  const uniqueItems = stocks?.filter(s => s.shares > 0).length || 0;
+  const uniqueItems = stocksForStats?.filter(s => s.shares > 0).length || 0;
 
   const averageValuePerItem = itemsInStock > 0 ? inventoryValue / itemsInStock : 0;
 
   // Recent activity (last 10 transactions)
   const recentActivity = transactions?.slice(0, 10) || [];
 
-  const topItems = stocks
+  const topItems = stocksForStats
     ?.map(stock => {
       const realizedProfit = stock.totalCostSold - (stock.totalCostBasisSold || 0);
       const margin = stock.totalCostBasisSold > 0


### PR DESCRIPTION
## Summary
- keep archived stocks hidden from trade/archive-active UI lists
- include archived stocks in portfolio and category stat calculations
- update profit/category chart stats data source to include archived stocks

## Verification
- npm.cmd run build