### PR TITLE
[codex] Fix GE item search ranking

### DIFF
--- a/src/components/GlobalSearch.jsx
+++ b/src/components/GlobalSearch.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react'
 import { Search, Package, FolderOpen, ArrowLeftRight, BarChart3, X } from 'lucide-react';
 import { useGEData } from '../contexts/GEDataContext';
 import { useTrade } from '../contexts/TradeContext';
+import { searchGEItems } from '../utils/geItemSearch';
 import '../styles/global-search.css';
 
 export default function GlobalSearch({
@@ -104,9 +105,7 @@ export default function GlobalSearch({
         };
       });
 
-    const matchedItems = (geMapping || [])
-      .filter(item => item.name.toLowerCase().includes(q))
-      .slice(0, 5)
+    const matchedItems = searchGEItems(geMapping, q, 5)
       .map(item => ({
         type: 'ge-item',
         id: `ge-${item.id}`,

--- a/src/components/modals/AdjustModal.jsx
+++ b/src/components/modals/AdjustModal.jsx
@@ -3,6 +3,7 @@ import { handleMKInput } from '../../utils/formatters';
 import { useGEData } from '../../contexts/GEDataContext';
 import { useTrade } from '../../contexts/TradeContext';
 import StepInput from '../StepInput';
+import { searchGEItems } from '../../utils/geItemSearch';
 
 export default function AdjustModal({ stock, onConfirm, onCancel }) {
   const { geMapping: mapping } = useGEData();
@@ -32,9 +33,7 @@ export default function AdjustModal({ stock, onConfirm, onCancel }) {
   const currentCategories = categories.filter(c => c.isInvestment === (stock.isInvestment || false)).map(c => c.name);
 
   const filteredItems = useMemo(() => {
-    if (!searchQuery.trim()) return [];
-    const q = searchQuery.toLowerCase();
-    return mapping.filter(item => item.name.toLowerCase().includes(q)).slice(0, 50);
+    return searchGEItems(mapping, searchQuery, 50);
   }, [searchQuery, mapping]);
 
   useEffect(() => {

--- a/src/components/modals/NewStockModal.jsx
+++ b/src/components/modals/NewStockModal.jsx
@@ -3,6 +3,7 @@ import StepInput from '../StepInput';
 import { handleMKInput } from '../../utils/formatters';
 import { useGEData } from '../../contexts/GEDataContext';
 import { useTrade } from '../../contexts/TradeContext';
+import { searchGEItems } from '../../utils/geItemSearch';
 
 export default function NewStockModal({ defaultCategory = '', defaultIsInvestment = false, defaultItem = null, archivedStocks = [], onConfirm, onCancel, onRestoreFromArchive }) {
   const { geMapping: mapping } = useGEData();
@@ -23,9 +24,7 @@ export default function NewStockModal({ defaultCategory = '', defaultIsInvestmen
   const filteredCategories = categories.filter(c => c.isInvestment === isInvestment).map(c => c.name);
 
   const filteredItems = useMemo(() => {
-    if (!searchQuery.trim()) return [];
-    const q = searchQuery.toLowerCase();
-    return mapping.filter(item => item.name.toLowerCase().includes(q)).slice(0, 50);
+    return searchGEItems(mapping, searchQuery, 50);
   }, [searchQuery, mapping]);
 
   useEffect(() => {

--- a/src/pages/GraphsPage.jsx
+++ b/src/pages/GraphsPage.jsx
@@ -8,6 +8,7 @@ import { useGEData } from '../contexts/GEDataContext';
 import { useTrade } from '../contexts/TradeContext';
 import ModalContainer from '../components/modals/ModalContainer';
 import NotesModal from '../components/modals/NotesModal';
+import { searchGEItems } from '../utils/geItemSearch';
 import '../styles/graphs-page.css';
 
 const TIMEFRAMES = [
@@ -90,9 +91,7 @@ export default function GraphsPage({
   const { chartContainerRef, volumeContainerRef } = useChart({ chartData, candlestickData, chartMode, timeframe, selectedItem });
 
   const filteredItems = useMemo(() => {
-    if (!searchQuery.trim()) return [];
-    const q = searchQuery.toLowerCase();
-    return mapping.filter(item => item.name.toLowerCase().includes(q)).slice(0, 50);
+    return searchGEItems(mapping, searchQuery, 50);
   }, [searchQuery, mapping]);
 
   // Build dropdown sections

--- a/src/pages/WatchlistPage.jsx
+++ b/src/pages/WatchlistPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Bell, Eye, Plus, RefreshCw, ShoppingCart, Trash2 } from 'lucide-react';
 import { useGEData } from '../contexts/GEDataContext';
 import { formatNumber } from '../utils/formatters';
+import { searchGEItems } from '../utils/geItemSearch';
 import '../styles/watchlist-page.css';
 
 function parseTargetValue(value) {
@@ -37,9 +38,7 @@ export default function WatchlistPage({
   const dropdownRef = useRef(null);
 
   const filteredItems = useMemo(() => {
-    if (!searchQuery.trim()) return [];
-    const q = searchQuery.toLowerCase();
-    return geMapping.filter(item => item.name.toLowerCase().includes(q)).slice(0, 40);
+    return searchGEItems(geMapping, searchQuery, 40);
   }, [searchQuery, geMapping]);
 
   useEffect(() => {

--- a/src/utils/geItemSearch.js
+++ b/src/utils/geItemSearch.js
@@ -1,0 +1,37 @@
+const WORD_BOUNDARY = /[^a-z0-9]+/;
+
+function normalizeSearchValue(value) {
+  return String(value ?? '').trim().toLowerCase();
+}
+
+function getMatchRank(name, query) {
+  if (name === query) return 0;
+  if (name.startsWith(query)) return 1;
+
+  const words = name.split(WORD_BOUNDARY).filter(Boolean);
+  if (words.some(word => word === query)) return 2;
+  if (words.some(word => word.startsWith(query))) return 3;
+  if (name.includes(query)) return 4;
+
+  return null;
+}
+
+export function searchGEItems(items, query, limit = 50) {
+  const q = normalizeSearchValue(query);
+  if (!q) return [];
+
+  return (items || [])
+    .map((item, index) => {
+      const name = normalizeSearchValue(item.name);
+      const rank = getMatchRank(name, q);
+      return rank === null ? null : { item, rank, index, name };
+    })
+    .filter(Boolean)
+    .sort((a, b) => (
+      a.rank - b.rank ||
+      a.name.localeCompare(b.name) ||
+      a.index - b.index
+    ))
+    .slice(0, limit)
+    .map(result => result.item);
+}


### PR DESCRIPTION
﻿## Summary
- Add shared ranked GE item search helper.
- Use ranked search in add/edit stock, graphs, watchlist, and global GE search pickers.
- Prioritize exact and prefix item matches before broad substring matches.

## Root cause
Searching `pot` matched 184 GE items and the exact `Pot` item appeared after the dropdown result cap because results were filtered by substring in API order.

## Validation
- `npm run build`
- `node --input-type=module -e "import { searchGEItems } from './src/utils/geItemSearch.js'; const res = await fetch('https://prices.runescape.wiki/api/v1/osrs/mapping', { headers: { 'User-Agent': 'OSRSProfitTracker - osrsprofittracker@gmail.com' } }); const data = await res.json(); const first = searchGEItems(data, 'pot', 10)[0]; if (!first || first.name !== 'Pot') { console.error('Expected Pot first, got', first); process.exit(1); } console.log(first.id + ':' + first.name);"`
- `git diff --check -- src\components\GlobalSearch.jsx src\components\modals\AdjustModal.jsx src\components\modals\NewStockModal.jsx src\pages\GraphsPage.jsx src\pages\WatchlistPage.jsx src\utils\geItemSearch.js`

Closes #253
