### PR TITLE
[codex] Fix analytics profit margin basis

### DIFF
--- a/src/components/analytics/widgets/ProfitKpiStrip.jsx
+++ b/src/components/analytics/widgets/ProfitKpiStrip.jsx
@@ -4,7 +4,7 @@ import { formatNumber } from '../../../utils/formatters';
 const sumSells = (buckets = []) => buckets.reduce((sum, bucket) => sum + Number(bucket.sells_count || 0), 0);
 const sumWins = (buckets = []) => buckets.reduce((sum, bucket) => sum + Number(bucket.wins_count || 0), 0);
 const sumProfitItems = (buckets = []) => buckets.reduce((sum, bucket) => sum + Number(bucket.profit_items || 0), 0);
-const sumGp = (buckets = []) => buckets.reduce((sum, bucket) => sum + Number(bucket.gp_traded || 0), 0);
+const sumSellBasis = (buckets = []) => buckets.reduce((sum, bucket) => sum + Number(bucket.sell_basis || 0), 0);
 
 const fmtPct = (value) => (Number.isFinite(value) ? `${value.toFixed(1)}%` : '-');
 const pctDelta = (current, prior) => (prior > 0 ? ((current - prior) / Math.abs(prior)) * 100 : null);
@@ -29,17 +29,17 @@ export default function ProfitKpiStrip({ currentBuckets = [], priorBuckets = [],
   const sells = sumSells(currentBuckets);
   const wins = sumWins(currentBuckets);
   const itemProfit = sumProfitItems(currentBuckets);
-  const gp = sumGp(currentBuckets);
+  const sellBasis = sumSellBasis(currentBuckets);
 
   const priorSells = sumSells(priorBuckets);
   const priorWins = sumWins(priorBuckets);
   const priorItemProfit = sumProfitItems(priorBuckets);
-  const priorGp = sumGp(priorBuckets);
+  const priorSellBasis = sumSellBasis(priorBuckets);
 
   const avgPerSell = sells > 0 ? itemProfit / sells : 0;
   const priorAvgPerSell = priorSells > 0 ? priorItemProfit / priorSells : 0;
-  const avgMargin = gp > 0 ? (itemProfit / gp) * 100 : 0;
-  const priorAvgMargin = priorGp > 0 ? (priorItemProfit / priorGp) * 100 : 0;
+  const avgMargin = sellBasis > 0 ? (itemProfit / sellBasis) * 100 : 0;
+  const priorAvgMargin = priorSellBasis > 0 ? (priorItemProfit / priorSellBasis) * 100 : 0;
   const winRate = sells > 0 ? (wins / sells) * 100 : 0;
   const priorWinRate = priorSells > 0 ? (priorWins / priorSells) * 100 : 0;
 
@@ -64,7 +64,7 @@ export default function ProfitKpiStrip({ currentBuckets = [], priorBuckets = [],
           label="Avg margin"
           value={fmtPct(avgMargin)}
           delta={pctDelta(avgMargin, priorAvgMargin)}
-          tooltip="Item profit divided by GP traded in the selected timeframe. Delta compares against the immediately previous timeframe of the same length."
+          tooltip="Item profit divided by the sold cost basis in the selected timeframe. Delta compares against the immediately previous timeframe of the same length."
         />
         <Mini
           label="Win rate"

--- a/src/hooks/useAnalytics.js
+++ b/src/hooks/useAnalytics.js
@@ -48,6 +48,7 @@ const mergeGpTraded = (buckets, gpTotals) => {
       profit_referral: 0,
       profit_bonds: 0,
       gp_traded: 0,
+      sell_basis: 0,
       by_category: {},
       sells_count: 0,
       wins_count: 0,
@@ -68,7 +69,7 @@ const signatureFor = (rows = []) => (
 
 export function aggregateBucketsLocally({ transactions, stocks, profitHistory, start, end, bucket }) {
   const stockMap = new Map((stocks || []).map((stock) => [stock.id, stock]));
-  const txMap = new Map((transactions || []).map((tx) => [tx.id, tx]));
+  const txMap = new Map((transactions || []).map((tx) => [String(tx.id), tx]));
   const inWindow = (iso) => iso >= start && iso <= end;
   const buckets = new Map();
 
@@ -81,6 +82,7 @@ export function aggregateBucketsLocally({ transactions, stocks, profitHistory, s
         profit_referral: 0,
         profit_bonds: 0,
         gp_traded: 0,
+        sell_basis: 0,
         by_category: {},
         sells_count: 0,
         wins_count: 0,
@@ -100,7 +102,7 @@ export function aggregateBucketsLocally({ transactions, stocks, profitHistory, s
   }
 
   for (const profit of profitHistory || []) {
-    const tx = txMap.get(profit.transaction_id);
+    const tx = txMap.get(String(profit.transaction_id ?? profit.transactionId ?? ''));
     const isoSource = profit.profit_type === 'stock' && tx?.date ? tx.date : profit.created_at;
     const iso = String(isoSource || '').slice(0, 10);
     if (!inWindow(iso)) continue;
@@ -112,8 +114,10 @@ export function aggregateBucketsLocally({ transactions, stocks, profitHistory, s
     if (profit.profit_type === 'stock') {
       const stockId = profit.stock_id ?? tx?.stock_id ?? tx?.stockId;
       const category = stockMap.get(stockId)?.category || 'Uncategorized';
+      const sellTotal = Number(tx?.total) || 0;
 
       row.profit_items += amount;
+      row.sell_basis += Math.max(0, sellTotal - amount);
       row.sells_count += 1;
       if (amount > 0) row.wins_count += 1;
       row.by_category[category] = (row.by_category[category] || 0) + amount;


### PR DESCRIPTION
## Summary

- Adds sold cost basis to locally aggregated analytics buckets.
- Changes the Profit page Avg margin KPI from profit divided by all GP traded to profit divided by sold cost basis.
- Updates the KPI tooltip to describe the corrected denominator.

## Root cause

The Profit page used `profit_items / gp_traded`, while `gp_traded` includes both buy and sell transaction totals. That made the displayed value a throughput ratio instead of a realized margin.

## Validation

- `npm run build` passes.
- `git diff --check -- src/hooks/useAnalytics.js src/components/analytics/widgets/ProfitKpiStrip.jsx` reports no whitespace errors.

Note: no automated tests were added because this repo's agent instructions say not to add tests unless explicitly requested.