### PR TITLE
Fix analytics period day counts

### DIFF
--- a/src/components/analytics/ProfitTab.jsx
+++ b/src/components/analytics/ProfitTab.jsx
@@ -11,7 +11,7 @@ import ProfitKpiStrip from './widgets/ProfitKpiStrip';
 import ProfitHeatmap from './widgets/ProfitHeatmap';
 import {
   addDays,
-  daysBetween,
+  inclusiveDayCount,
   subtractDays,
   subtractYears,
   totalProfit,
@@ -48,7 +48,7 @@ export default function ProfitTab({
   totalProfitValue,
   fallbackData,
 }) {
-  const span = daysBetween(timeframe.start, timeframe.end);
+  const span = inclusiveDayCount(timeframe.start, timeframe.end);
   const lastPeriodStart = subtractDays(timeframe.start, span);
   const lastPeriodEnd = addDays(timeframe.start, -1);
   const samePeriodLastYearStart = subtractYears(timeframe.start, 1);

--- a/src/pages/AnalyticsPage.jsx
+++ b/src/pages/AnalyticsPage.jsx
@@ -9,7 +9,7 @@ import ItemsTab from '../components/analytics/ItemsTab';
 import CategoriesTab from '../components/analytics/CategoriesTab';
 import GoalsTab from '../components/analytics/GoalsTab';
 import { useTrade } from '../contexts/TradeContext';
-import { addDays, daysBetween, subtractDays, sumProfit } from '../utils/analyticsHelpers';
+import { addDays, inclusiveDayCount, subtractDays, sumProfit } from '../utils/analyticsHelpers';
 import '../styles/analytics-page.css';
 import '../styles/analytics-widgets.css';
 
@@ -48,7 +48,7 @@ export default function AnalyticsPage({
 
   const timeframe = useAnalyticsTimeframe(userId, allTimeStart);
   const priorStart = useMemo(
-    () => subtractDays(timeframe.start, daysBetween(timeframe.start, timeframe.end)),
+    () => subtractDays(timeframe.start, inclusiveDayCount(timeframe.start, timeframe.end)),
     [timeframe.start, timeframe.end]
   );
   const priorEnd = useMemo(() => addDays(timeframe.start, -1), [timeframe.start]);

--- a/src/utils/analyticsHelpers.js
+++ b/src/utils/analyticsHelpers.js
@@ -22,14 +22,18 @@ export const subtractYears = (iso, years) => {
   return toIsoDate(date);
 };
 
-export const daysBetween = (startIso, endIso) => {
+export const dayDifference = (startIso, endIso) => {
   const ms = parseIsoDateUtc(endIso) - parseIsoDateUtc(startIso);
-  return Math.max(1, Math.round(ms / MS_PER_DAY));
+  return Math.max(0, Math.round(ms / MS_PER_DAY));
+};
+
+export const inclusiveDayCount = (startIso, endIso) => {
+  if (!startIso || !endIso) return 0;
+  return dayDifference(startIso, endIso) + 1;
 };
 
 export const periodSpanDays = (startIso, endIso) => {
-  if (!startIso || !endIso) return 0;
-  return daysBetween(startIso, endIso) + 1;
+  return inclusiveDayCount(startIso, endIso);
 };
 
 export const totalProfit = (bucket) => (

--- a/src/utils/goalAnalytics.js
+++ b/src/utils/goalAnalytics.js
@@ -1,7 +1,7 @@
 // Goal-tab aggregation helpers. Operates on milestone_history rows
 // shaped like { period, period_start, achieved_at, goal_amount, actual_amount }.
 
-import { addDays, daysBetween } from './analyticsHelpers';
+import { addDays, inclusiveDayCount } from './analyticsHelpers';
 
 const HIT_RATE_WINDOW = 7;
 
@@ -25,7 +25,7 @@ export function computePeriodEnd(periodStartIso, period) {
 export function proratedRowGoal(row, firstActivityDate) {
   const periodStart = periodDate(row);
   const periodEnd = computePeriodEnd(periodStart, row.period);
-  const totalDays = daysBetween(periodStart, periodEnd) + 1;
+  const totalDays = inclusiveDayCount(periodStart, periodEnd);
   const goal = row.goal_amount || 0;
 
   if (!firstActivityDate || periodStart >= firstActivityDate) {
@@ -36,7 +36,7 @@ export function proratedRowGoal(row, firstActivityDate) {
     return { proratedGoal: goal, isPartial: true, totalDays, activeDays: 0 };
   }
 
-  const activeDays = daysBetween(firstActivityDate, periodEnd) + 1;
+  const activeDays = inclusiveDayCount(firstActivityDate, periodEnd);
   const proratedGoal = totalDays > 0 ? (goal * activeDays) / totalDays : goal;
   return { proratedGoal, isPartial: true, totalDays, activeDays };
 }


### PR DESCRIPTION
## Summary
- split analytics day math into non-inclusive difference and inclusive count helpers
- use inclusive counts for prior-period windows so comparisons use equal-length periods
- fix goal proration daily periods counting as two days

Fixes #256

## Verification
- npm run build