### PR TITLE
[codex] Fix remove transaction analytics basis

### DIFF
--- a/src/utils/categoryAnalytics.js
+++ b/src/utils/categoryAnalytics.js
@@ -1,4 +1,5 @@
 import { calculateUnrealizedProfit } from './taxUtils';
+import { applyAverageCostExit } from './positionAnalytics';
 
 const DEFAULT_CATEGORY = 'Uncategorized';
 
@@ -229,13 +230,21 @@ const addTransactionWindowMetrics = ({
       continue;
     }
 
+    if (transaction.type === 'remove') {
+      const nextPosition = applyAverageCostExit(position, shares);
+      position.shares = nextPosition.shares;
+      position.cost = nextPosition.cost;
+      positions.set(positionKey, position);
+      continue;
+    }
+
     if (transaction.type !== 'sell') {
       positions.set(positionKey, position);
       continue;
     }
 
-    const avgCost = position.shares > 0 ? position.cost / position.shares : 0;
-    const estimatedBasis = avgCost * shares;
+    const nextPosition = applyAverageCostExit(position, shares);
+    const estimatedBasis = nextPosition.estimatedBasis;
     const transactionProfit = profitByTransaction.has(String(transaction.id))
       ? profitByTransaction.get(String(transaction.id))
       : total - estimatedBasis;
@@ -243,8 +252,8 @@ const addTransactionWindowMetrics = ({
 
     if (inWindow) row.windowBasis += basis;
 
-    position.shares = Math.max(0, position.shares - shares);
-    position.cost = Math.max(0, position.cost - estimatedBasis);
+    position.shares = nextPosition.shares;
+    position.cost = nextPosition.cost;
     positions.set(positionKey, position);
   }
 };
@@ -305,10 +314,9 @@ export function computeCategoryAverageInventory({
       }
 
       if (transaction.type === 'sell' || transaction.type === 'remove') {
-        const avgCost = position.shares > 0 ? position.cost / position.shares : 0;
-        const estimatedBasis = avgCost * shares;
-        position.shares = Math.max(0, position.shares - shares);
-        position.cost = Math.max(0, position.cost - estimatedBasis);
+        const nextPosition = applyAverageCostExit(position, shares);
+        position.shares = nextPosition.shares;
+        position.cost = nextPosition.cost;
       }
 
       positions.set(key, position);
@@ -556,17 +564,16 @@ export function buildCategoryDrilldownData({
 
     if (transaction.type !== 'sell') {
       if (transaction.type === 'remove') {
-        const removeAvgCost = position.shares > 0 ? position.cost / position.shares : 0;
-        const removeBasis = removeAvgCost * shares;
-        position.shares = Math.max(0, position.shares - shares);
-        position.cost = Math.max(0, position.cost - removeBasis);
+        const nextPosition = applyAverageCostExit(position, shares);
+        position.shares = nextPosition.shares;
+        position.cost = nextPosition.cost;
       }
       positions.set(stockId, position);
       continue;
     }
 
-    const avgCost = position.shares > 0 ? position.cost / position.shares : 0;
-    const estimatedBasis = avgCost * shares;
+    const nextPosition = applyAverageCostExit(position, shares);
+    const estimatedBasis = nextPosition.estimatedBasis;
     const iso = isoOf(transaction.date);
 
     if (!start || !end || (iso >= start && iso <= end)) {
@@ -576,8 +583,8 @@ export function buildCategoryDrilldownData({
       windowProfitByStock.set(stockId, (windowProfitByStock.get(stockId) || 0) + transactionProfit);
     }
 
-    position.shares = Math.max(0, position.shares - shares);
-    position.cost = Math.max(0, position.cost - estimatedBasis);
+    position.shares = nextPosition.shares;
+    position.cost = nextPosition.cost;
     positions.set(stockId, position);
   }
 

--- a/src/utils/itemAnalytics.js
+++ b/src/utils/itemAnalytics.js
@@ -1,4 +1,5 @@
 import { calculateUnrealizedProfit } from './taxUtils';
+import { applyAverageCostExit } from './positionAnalytics';
 
 export const isoOf = (value) => String(value || '').slice(0, 10);
 export const stockIdOf = (row) => row?.stockId ?? row?.stock_id;
@@ -121,8 +122,7 @@ export function buildDailyItemProfit({ itemId, transactions = [], profitHistory 
   const profitByTx = buildStockProfitByTransaction(profitHistory);
   const byDay = new Map();
   const dates = [];
-  let heldShares = 0;
-  let heldCost = 0;
+  const position = { shares: 0, cost: 0 };
 
   const itemTransactions = (transactions || [])
     .filter((tx) => String(stockIdOf(tx)) === String(itemId))
@@ -133,18 +133,24 @@ export function buildDailyItemProfit({ itemId, transactions = [], profitHistory 
     const total = Number(tx.total) || 0;
 
     if (tx.type === 'buy') {
-      heldShares += shares;
-      heldCost += total;
+      position.shares += shares;
+      position.cost += total;
       continue;
     }
 
     const iso = isoOf(tx.date);
+    if (tx.type === 'remove') {
+      const nextPosition = applyAverageCostExit(position, shares);
+      position.shares = nextPosition.shares;
+      position.cost = nextPosition.cost;
+      continue;
+    }
+
     if (tx.type !== 'sell') continue;
 
-    const averageCost = heldShares > 0 ? heldCost / heldShares : 0;
-    const estimatedBasis = averageCost * shares;
-    heldShares = Math.max(0, heldShares - shares);
-    heldCost = Math.max(0, heldCost - estimatedBasis);
+    const nextPosition = applyAverageCostExit(position, shares);
+    position.shares = nextPosition.shares;
+    position.cost = nextPosition.cost;
 
     if (start && end && !inWindow(iso, start, end)) continue;
     dates.push(iso);
@@ -152,7 +158,7 @@ export function buildDailyItemProfit({ itemId, transactions = [], profitHistory 
     const txKey = String(tx.id);
     const profit = profitByTx.has(txKey)
       ? profitByTx.get(txKey)
-      : total - estimatedBasis;
+      : total - nextPosition.estimatedBasis;
 
     byDay.set(iso, (byDay.get(iso) || 0) + profit);
   }

--- a/src/utils/positionAnalytics.js
+++ b/src/utils/positionAnalytics.js
@@ -1,0 +1,15 @@
+const toNumber = (value) => Number(value) || 0;
+
+export function applyAverageCostExit(position, shares) {
+  const currentShares = toNumber(position?.shares);
+  const currentCost = toNumber(position?.cost);
+  const exitShares = toNumber(shares);
+  const averageCost = currentShares > 0 ? currentCost / currentShares : 0;
+  const estimatedBasis = averageCost * exitShares;
+
+  return {
+    shares: Math.max(0, currentShares - exitShares),
+    cost: Math.max(0, currentCost - estimatedBasis),
+    estimatedBasis,
+  };
+}


### PR DESCRIPTION
## Summary

Fixes item and category analytics position math for `remove` transactions.

## What changed

- Added a shared average-cost exit helper for analytics position walkers.
- Updated item drilldown daily profit fallback math so `remove` reduces held shares and held cost without adding profit.
- Updated category analytics walkers to use the same average-cost exit logic, including category drilldown fallback calculations.

## Root cause

`buildDailyItemProfit` ignored `remove` transactions while replaying item history. That left the local held share and cost basis state inflated, so later fallback sell-profit calculations could use stale basis and show incorrect realized profit.

## Validation

- `npm run build`