### PR TITLE
[codex] Fix item profit drawer empty state

### DIFF
--- a/src/components/analytics/widgets/ItemDrilldownDrawer.jsx
+++ b/src/components/analytics/widgets/ItemDrilldownDrawer.jsx
@@ -179,7 +179,7 @@ export default function ItemDrilldownDrawer({
             Realized profit per day
           </h3>
           {profitSeries.length === 0 ? (
-            <div className="analytics-widget-empty">No linked profit rows for this item.</div>
+            <div className="analytics-widget-empty">No linked profit rows for this item in the selected timeframe.</div>
           ) : (
             <div className="items-chart is-drawer">
               <ResponsiveContainer width="100%" height="100%">

--- a/src/utils/itemAnalytics.js
+++ b/src/utils/itemAnalytics.js
@@ -163,7 +163,7 @@ export function buildDailyItemProfit({ itemId, transactions = [], profitHistory 
     byDay.set(iso, (byDay.get(iso) || 0) + profit);
   }
 
-  if (!dates.length && (!start || !end)) return [];
+  if (!dates.length) return [];
 
   const startDateIso = start || dates.sort()[0];
   const endDateIso = end || dates[dates.length - 1];


### PR DESCRIPTION
## Summary
- Return an empty item profit series when no linked sell/profit rows exist in the selected window
- Update the drawer empty-state copy to mention the selected timeframe

## Root cause
`buildDailyItemProfit` only returned `[]` when no sell dates existed and no complete timeframe was passed. Analytics always passes `start` and `end`, so the drawer received a zero-padded series and rendered a flat chart instead of the empty state.

## Validation
- `npm run build`

Fixes #258