### PR TITLE
[codex] fix analytics UTC timeframe windows

### DIFF
--- a/src/contexts/UIStateContext.jsx
+++ b/src/contexts/UIStateContext.jsx
@@ -31,16 +31,16 @@ export function UIStateProvider({ userId, children }) {
     if (!profitHistory) return { day: 0, week: 0, month: 0, year: 0 };
 
     const getStartOfPeriod = (period) => {
-      const date = new Date();
-      if (period === 'day') { date.setHours(0, 0, 0, 0); return date; }
+      const now = new Date();
+      const date = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+      if (period === 'day') return date;
       if (period === 'week') {
-        const diff = date.getDate() - date.getDay() + (date.getDay() === 0 ? -6 : 1);
-        date.setDate(diff);
-        date.setHours(0, 0, 0, 0);
+        const dayOfWeek = (date.getUTCDay() + 6) % 7;
+        date.setUTCDate(date.getUTCDate() - dayOfWeek);
         return date;
       }
-      if (period === 'month') { date.setDate(1); date.setHours(0, 0, 0, 0); return date; }
-      if (period === 'year') { date.setMonth(0, 1); date.setHours(0, 0, 0, 0); return date; }
+      if (period === 'month') return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+      if (period === 'year') return new Date(Date.UTC(now.getUTCFullYear(), 0, 1));
       return date;
     };
 

--- a/src/hooks/useAnalyticsTimeframe.js
+++ b/src/hooks/useAnalyticsTimeframe.js
@@ -1,4 +1,5 @@
 import { useState, useMemo, useCallback } from 'react';
+import { subtractDays, toIsoDate } from '../utils/analyticsHelpers';
 
 const WINDOW_OPTIONS = ['1W', '1M', '3M', '6M', '1Y', 'All'];
 
@@ -27,8 +28,6 @@ const daysForWindow = (window) => {
   }
 };
 
-const toIsoDate = (date) => date.toISOString().slice(0, 10);
-
 export function useAnalyticsTimeframe(userId, allTimeStart = null) {
   const storageKey = `analyticsTimeframe_${userId}`;
 
@@ -44,8 +43,7 @@ export function useAnalyticsTimeframe(userId, allTimeStart = null) {
   }, [storageKey]);
 
   const { start, end, bucket } = useMemo(() => {
-    const today = new Date();
-    const endIso = toIsoDate(today);
+    const endIso = toIsoDate(new Date());
     const days = daysForWindow(window);
 
     if (days == null) {
@@ -56,11 +54,8 @@ export function useAnalyticsTimeframe(userId, allTimeStart = null) {
       };
     }
 
-    const startDate = new Date(today);
-    startDate.setDate(startDate.getDate() - days);
-
     return {
-      start: toIsoDate(startDate),
+      start: subtractDays(endIso, days - 1),
       end: endIso,
       bucket: bucketForWindow(window),
     };

--- a/src/hooks/useMilestones.js
+++ b/src/hooks/useMilestones.js
@@ -9,23 +9,18 @@ const getPeriodStart = (date, period) => {
   const d = new Date(date);
   switch (period) {
     case 'day':
-      d.setHours(0, 0, 0, 0);
-      return d;
+      return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
     case 'week': {
-      const day = d.getDay();
+      const day = d.getUTCDay();
       const diff = day === 0 ? -6 : 1 - day; // Monday = start
-      d.setDate(d.getDate() + diff);
-      d.setHours(0, 0, 0, 0);
-      return d;
+      const start = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+      start.setUTCDate(start.getUTCDate() + diff);
+      return start;
     }
     case 'month':
-      d.setDate(1);
-      d.setHours(0, 0, 0, 0);
-      return d;
+      return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1));
     case 'year':
-      d.setMonth(0, 1);
-      d.setHours(0, 0, 0, 0);
-      return d;
+      return new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
     default:
       return d;
   }
@@ -35,16 +30,16 @@ const getPeriodEnd = (periodStart, period) => {
   const d = new Date(periodStart);
   switch (period) {
     case 'day':
-      d.setDate(d.getDate() + 1);
+      d.setUTCDate(d.getUTCDate() + 1);
       return d;
     case 'week':
-      d.setDate(d.getDate() + 7);
+      d.setUTCDate(d.getUTCDate() + 7);
       return d;
     case 'month':
-      d.setMonth(d.getMonth() + 1);
+      d.setUTCMonth(d.getUTCMonth() + 1);
       return d;
     case 'year':
-      d.setFullYear(d.getFullYear() + 1);
+      d.setUTCFullYear(d.getUTCFullYear() + 1);
       return d;
     default:
       return d;
@@ -66,13 +61,7 @@ const generatePastPeriods = (period, minDate) => {
   return periods;
 };
 
-// Convert a Date to a YYYY-MM-DD string (local time)
-const toDateString = (date) => {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, '0');
-  const d = String(date.getDate()).padStart(2, '0');
-  return `${y}-${m}-${d}`;
-};
+const toDateString = (date) => date.toISOString().slice(0, 10);
 
 // ---
 
@@ -196,7 +185,7 @@ export function useMilestones(userId) {
     const entryDates = profitHistory.map(e => new Date(e.created_at).getTime());
     const minDate = new Date(Math.min(...entryDates));
     const oneYearAgo = new Date();
-    oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+    oneYearAgo.setUTCFullYear(oneYearAgo.getUTCFullYear() - 1);
     const effectiveMinDate = minDate < oneYearAgo ? oneYearAgo : minDate;
 
     const periodTypes = ['day', 'week', 'month', 'year'];

--- a/src/utils/goalAnalytics.js
+++ b/src/utils/goalAnalytics.js
@@ -146,16 +146,35 @@ export function estimateTimeToGoal({ currentProgress, goal, elapsedDays, totalDa
   return { daysRemaining, onTrack, pacePerDay, projected };
 }
 
-// Calendar helpers used by the estimator widget. All times in local zone.
+const utcPeriodStart = (now, period) => {
+  if (period === 'day') {
+    return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  }
+  if (period === 'week') {
+    const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+    const dayOfWeek = (start.getUTCDay() + 6) % 7; // Monday = 0
+    start.setUTCDate(start.getUTCDate() - dayOfWeek);
+    return start;
+  }
+  if (period === 'month') {
+    return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+  }
+  if (period === 'year') {
+    return new Date(Date.UTC(now.getUTCFullYear(), 0, 1));
+  }
+  return now;
+};
+
+// Calendar helpers used by the estimator widget. All period boundaries are UTC.
 export const periodTotalDays = (period) => {
   if (period === 'day') return 1;
   if (period === 'week') return 7;
   if (period === 'month') {
     const now = new Date();
-    return new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+    return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 0)).getUTCDate();
   }
   if (period === 'year') {
-    const year = new Date().getFullYear();
+    const year = new Date().getUTCFullYear();
     const isLeap = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
     return isLeap ? 366 : 365;
   }
@@ -164,22 +183,8 @@ export const periodTotalDays = (period) => {
 
 export const periodElapsedDays = (period) => {
   const now = new Date();
-  if (period === 'day') {
-    const startOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-    return Math.max(1 / 1440, (now - startOfDay) / 86400000);
-  }
-  if (period === 'week') {
-    const dayOfWeek = (now.getDay() + 6) % 7; // Monday = 0
-    const startOfWeek = new Date(now.getFullYear(), now.getMonth(), now.getDate() - dayOfWeek);
-    return Math.max(1 / 1440, (now - startOfWeek) / 86400000);
-  }
-  if (period === 'month') {
-    const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
-    return Math.max(1 / 1440, (now - startOfMonth) / 86400000);
-  }
-  if (period === 'year') {
-    const startOfYear = new Date(now.getFullYear(), 0, 1);
-    return Math.max(1 / 1440, (now - startOfYear) / 86400000);
+  if (period === 'day' || period === 'week' || period === 'month' || period === 'year') {
+    return Math.max(1 / 1440, (now - utcPeriodStart(now, period)) / 86400000);
   }
   return 1;
 };


### PR DESCRIPTION
## Summary
- Keep analytics timeframe windows on UTC date arithmetic end to end
- Make fixed windows inclusive so 1W returns 7 calendar dates instead of 8
- Align goal progress, elapsed-day estimates, and milestone period backfill with UTC period boundaries

## Root Cause
`useAnalyticsTimeframe` created `end` with `toISOString()` but walked `start` back with local `setDate()`. That mixed UTC dates with local calendar arithmetic and let windows drift around midnight for non-UTC users. It also subtracted the full advertised day count while downstream code treats start and end as inclusive.

## Validation
- `npm run build`
- One-off Node check for UTC, Asia/Singapore, and America/New_York confirmed a 1W window produces 7 inclusive days
- `git diff --check -- src/contexts/UIStateContext.jsx src/hooks/useAnalyticsTimeframe.js src/hooks/useMilestones.js src/utils/goalAnalytics.js`

Closes #260