### PR TITLE
[codex] Keep category drilldown open during refetch

### DIFF
--- a/src/components/analytics/CategoriesTab.jsx
+++ b/src/components/analytics/CategoriesTab.jsx
@@ -80,10 +80,10 @@ export default function CategoriesTab({
 
   useEffect(() => {
     if (!drillCategory) return;
-    if (!visibleCategories.includes(drillCategory.category)) {
+    if (selectedCategories.length > 0 && !selectedCategories.includes(drillCategory.category)) {
       setDrillCategory(null);
     }
-  }, [drillCategory, visibleCategories]);
+  }, [drillCategory, selectedCategories]);
 
   const toggleCategory = (category) => {
     setSelectedCategories((current) => (


### PR DESCRIPTION
## Summary
- keep the category drilldown drawer open during analytics bucket refetches and other transient category-list changes
- close the drawer only when an active user category filter explicitly excludes the open category

## Root cause
`CategoriesTab` closed the drawer whenever `visibleCategories` no longer contained the open drawer category. That list is derived from analytics bucket arrays, so refetches, timeframe changes, or upstream re-aggregation could temporarily change the list and dismiss the drawer even when the user did not remove the category from filters.

## Validation
- One-off regression check confirms unfiltered transient category-list changes keep the drawer open, while explicit filters still close or keep it as expected.
- `npm run build` exits 0. Vite still reports the existing large chunk size warning.

Fixes #264