### PR TITLE
[codex] Fix analytics top gainers filtering

### DIFF
--- a/src/components/analytics/widgets/MoversList.jsx
+++ b/src/components/analytics/widgets/MoversList.jsx
@@ -17,7 +17,7 @@ export default function MoversList({
         </h3>
       </div>
       <ul className="items-movers-list">
-        {gainers.length === 0 && <li className="items-muted">No sold items to rank.</li>}
+        {gainers.length === 0 && <li className="items-muted">No items have realized a gain in this view yet.</li>}
         {gainers.map((item) => {
           const value = Number(item.totalProfit) || 0;
           const valueClassName = value < 0 ? 'items-profit-negative' : 'items-profit-positive';

--- a/src/utils/itemAnalytics.js
+++ b/src/utils/itemAnalytics.js
@@ -93,9 +93,19 @@ export function computeItemMetrics({
 }
 
 export function computeMovers(items = [], count = 5) {
+  const normalizedItems = [...items].map((item) => ({
+    ...item,
+    totalProfit: Number(item.totalProfit) || 0,
+  }));
+
   return {
-    gainers: [...items]
-      .sort((a, b) => (Number(b.totalProfit) || 0) - (Number(a.totalProfit) || 0))
+    gainers: normalizedItems
+      .filter((item) => item.totalProfit > 0)
+      .sort((a, b) => b.totalProfit - a.totalProfit)
+      .slice(0, count),
+    losers: normalizedItems
+      .filter((item) => item.totalProfit < 0)
+      .sort((a, b) => a.totalProfit - b.totalProfit)
       .slice(0, count),
   };
 }


### PR DESCRIPTION
## Summary

Fixes #265.

- Filters analytics movers so `gainers` only contains items with positive all-time realized profit.
- Normalizes `totalProfit` once before sorting movers.
- Adds a clearer empty state when no items have realized gains in the current view.
- Returns `losers` from `computeMovers` for future symmetrical reporting without changing current UI callsites.

## Root Cause

`computeMovers` sorted all filtered items by descending `totalProfit` and sliced the first N rows, so portfolios with only negative realized profit still populated the `Top gainers` widget with least-loss items.

## Validation

- `git diff --check -- src\utils\itemAnalytics.js src\components\analytics\widgets\MoversList.jsx`
- One-off `computeMovers` behavior check against the source confirms non-positive items are excluded from `gainers` and negative items are returned under `losers`.
- `npm run build`