### PR TITLE
[codex] Add Supabase hot-path index script

### DIFF
--- a/docs/supabase-hot-path-indexes-issue-275.sql
+++ b/docs/supabase-hot-path-indexes-issue-275.sql
@@ -1,0 +1,72 @@
+-- Issue #275: composite indexes for hot-path Supabase queries.
+--
+-- Apply manually in the Supabase SQL Editor.
+-- CREATE INDEX CONCURRENTLY cannot run inside a transaction block; if the
+-- editor reports that error, run each statement below one at a time.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transactions_user_date
+  ON transactions(user_id, date DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_profit_history_user_created
+  ON profit_history(user_id, created_at DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_stocks_user_position
+  ON stocks(user_id, position ASC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_stocks_user_archived_name
+  ON stocks(user_id, archived, name ASC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_categories_user_position
+  ON categories(user_id, position ASC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_stock_notes_user_stock
+  ON stock_notes(user_id, stock_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_milestones_user
+  ON milestones(user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_milestone_history_user_period_start
+  ON milestone_history(user_id, period_start DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_price_alerts_user_created_active
+  ON price_alerts(user_id, created_at DESC)
+  WHERE dismissed = false;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_watchlist_items_user_created
+  ON watchlist_items(user_id, created_at DESC);
+
+-- Verification examples after applying the indexes.
+-- Replace '<user-id>' with a real auth.users.id value from the target project.
+--
+-- EXPLAIN ANALYZE
+-- SELECT *
+-- FROM transactions
+-- WHERE user_id = '<user-id>'
+-- ORDER BY date DESC
+-- LIMIT 25;
+--
+-- EXPLAIN ANALYZE
+-- SELECT *
+-- FROM profit_history
+-- WHERE user_id = '<user-id>'
+-- ORDER BY created_at DESC
+-- LIMIT 25;
+--
+-- EXPLAIN ANALYZE
+-- SELECT *
+-- FROM categories
+-- WHERE user_id = '<user-id>'
+-- ORDER BY position ASC;
+--
+-- EXPLAIN ANALYZE
+-- SELECT *
+-- FROM price_alerts
+-- WHERE user_id = '<user-id>'
+--   AND dismissed = false
+-- ORDER BY created_at DESC;
+--
+-- EXPLAIN ANALYZE
+-- SELECT *
+-- FROM watchlist_items
+-- WHERE user_id = '<user-id>'
+-- ORDER BY created_at DESC;


### PR DESCRIPTION
## Summary

Adds a manual Supabase SQL script for issue #275 covering hot-path composite indexes used by the app's per-user queries.

The script intentionally lives under `docs/` instead of a migration folder because this repository does not currently contain Supabase migration infrastructure and the repo instructions require database changes to be applied through the Supabase SQL Editor unless migrations are explicitly requested.

## What changed

- Adds composite indexes for `transactions`, `profit_history`, `stocks`, `categories`, `stock_notes`, `milestones`, `milestone_history`, `price_alerts`, and `watchlist_items`.
- Uses the current table names from the codebase, including `watchlist_items` rather than `watchlist`.
- Uses a partial index for non-dismissed price alerts, matching the active fetch query.
- Includes commented `EXPLAIN ANALYZE` examples for post-apply verification.

## Supabase apply status

Applied directly to Supabase project `wwidaaaktxwgeeqrhghp` with `supabase db query --linked`, one `CREATE INDEX CONCURRENTLY` statement at a time.

Verified all 10 indexes exist and are marked `indisvalid = true` and `indisready = true` in `pg_index`.

## Validation

- `git diff --check -- docs/supabase-hot-path-indexes-issue-275.sql`
- `npm run build`
- Supabase catalog verification for all added indexes

Refs #275