### PR TITLE
[codex] Memoize stock table sorting

### DIFF
--- a/src/components/StockTable.jsx
+++ b/src/components/StockTable.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Edit3, Trash2, GripVertical, Star, Bell, BellRing } from 'lucide-react';
 import { formatNumber, formatTimer, formatAvgPrice } from '../utils/formatters';
 import { calculateAvgBuyPrice, calculateAvgSellPrice, calculateProfit } from '../utils/calculations';
@@ -56,7 +56,10 @@ export default function StockTable({
   onViewGraph,
 }) {
   const { gePrices: geData, geIconMap, membershipMap } = useGEData();
-  const sortedStocks = sortStocks(stocks, sortConfig);
+  const sortedStocks = useMemo(
+    () => sortStocks(stocks, sortConfig),
+    [stocks, sortConfig]
+  );
 
   return (
     <div className="table-container">


### PR DESCRIPTION
## Summary
- Memoize StockTable sorting with React useMemo
- Avoid rerunning sortStocks on renders where stocks and sortConfig are unchanged

## Impact
- Reduces repeated stock sorting during timer and GE data refresh renders
- Preserves existing sort behavior when stocks or sortConfig change

## Validation
- npm run build

Closes #277