### PR TITLE
[codex] Remove category transaction N+1

### DIFF
--- a/src/hooks/useTransactions.js
+++ b/src/hooks/useTransactions.js
@@ -85,20 +85,7 @@ export function useTransactions(userId) {
     if (activeFilters.marginMin) query = query.gte('margin', Number(activeFilters.marginMin));
     if (activeFilters.marginMax) query = query.lte('margin', Number(activeFilters.marginMax));
     if (activeFilters.category) {
-      const { data: categoryStocks } = await supabase
-        .from('stocks')
-        .select('id')
-        .eq('user_id', userId)
-        .eq('category', activeFilters.category);
-      const stockIds = (categoryStocks || []).map(s => s.id);
-      if (stockIds.length > 0) {
-        query = query.in('stock_id', stockIds);
-      } else {
-        setPagedTransactions([]);
-        setTotalCount(0);
-        setPagedLoading(false);
-        return;
-      }
+      query = query.eq('category', activeFilters.category);
     }
     if (activeFilters.mode && activeFilters.mode !== 'all') {
       const isInvestment = activeFilters.mode === 'investment';


### PR DESCRIPTION
## Summary
- Replace the HistoryPage category filter stock-id prefetch with a direct `transactions_view.category` filter.
- Keep this PR scoped to Step 1 of #276, with no schema changes and no mode/debounce/race-safety changes.

## Why
`transactions_view` already projects `category`, so fetching matching `stocks.id` values before applying `.in('stock_id', ids)` adds an unnecessary Supabase round-trip and can grow URL payloads for bulk users.

## Impact
Category filtering now stays in the main transactions query and avoids the extra `stocks` request. Empty categories naturally return an empty result set through the query instead of a client-side early return.

## Validation
- `npm run build`