### PR TITLE
[codex] Cap history loads on mount

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -99,6 +99,9 @@ function MainAppInner({ session, onLogout }) {
   const { categories, loading: categoriesLoading, addCategory, deleteCategory, updateCategory, fetchCategories, reorderCategories } = useCategoriesContext();
   const {
     transactions, loading: transactionsLoading, addTransaction,
+    loadFullHistory: loadFullTransactions,
+    fullHistoryLoading: fullTransactionsLoading,
+    historyScope: transactionHistoryScope,
     pagedTransactions, pagedLoading, totalCount, totalPages,
     page, pageSize, filters, goToPage, changePageSize, applyFilters, initPaged,
     sortConfig: historySortConfig, applySort, resetPaged, undoTransaction
@@ -108,7 +111,14 @@ function MainAppInner({ session, onLogout }) {
   const { settings, loading: settingsLoading, updateSettings } = useSettings(userId);
   const { notificationPreferences, updateNotificationPreference, loading: notificationSettingsLoading } = useNotificationSettings(userId);
   const { profits, loading: profitsLoading, updateProfit } = useProfitsContext();
-  const { profitHistory, loading: profitHistoryLoading, refetch: refetchProfitHistory } = useProfitHistoryContext();
+  const {
+    profitHistory,
+    loading: profitHistoryLoading,
+    refetch: refetchProfitHistory,
+    loadFullHistory: loadFullProfitHistory,
+    fullHistoryLoading: fullProfitHistoryLoading,
+    historyScope: profitHistoryScope
+  } = useProfitHistoryContext();
   const { milestones, milestoneHistory, loading: milestonesLoading, updateMilestone, recordMilestoneAchievement, recordCompletedPeriods, PRESET_GOALS } = useMilestonesContext();
   const { alerts: priceAlerts, allAlerts: allPriceAlerts, loading: priceAlertsLoading, saveAlert: savePriceAlert, dismissAlert: dismissPriceAlert, deactivateAlert: deactivatePriceAlert, updateLastChecked: updatePriceAlertLastChecked, refetch: refetchPriceAlerts } = usePriceAlerts(userId);
   const {
@@ -1189,6 +1199,12 @@ function MainAppInner({ session, onLogout }) {
             milestones={milestones}
             milestoneHistory={milestoneHistory}
             milestoneProgress={milestoneProgress}
+            transactionHistoryScope={transactionHistoryScope}
+            profitHistoryScope={profitHistoryScope}
+            loadFullTransactions={loadFullTransactions}
+            loadFullProfitHistory={loadFullProfitHistory}
+            fullTransactionsLoading={fullTransactionsLoading}
+            fullProfitHistoryLoading={fullProfitHistoryLoading}
           />
         ) : currentPage === 'watchlist' ? (
           <WatchlistPage

--- a/src/hooks/useAnalytics.js
+++ b/src/hooks/useAnalytics.js
@@ -1,5 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
-import { supabase } from '../lib/supabase';
+import { useState, useEffect } from 'react';
 
 const MAX_CACHE_ENTRIES = 50;
 const cache = new Map();
@@ -201,10 +200,7 @@ export function useAnalytics({ userId, start, end, bucket, fallbackData }) {
     error: null,
     fromFallback: false,
   });
-  const requestIdRef = useRef(0);
-  const fallbackDataRef = useRef(fallbackData);
   const fallbackSignature = signatureForFallbackData(fallbackData);
-  fallbackDataRef.current = fallbackData;
 
   useEffect(() => {
     if (!userId) {
@@ -212,14 +208,13 @@ export function useAnalytics({ userId, start, end, bucket, fallbackData }) {
       return;
     }
 
-    const currentFallbackData = fallbackDataRef.current;
-    const hasFallbackData = Boolean(currentFallbackData);
+    const hasFallbackData = Boolean(fallbackData);
     const cacheKey = [
       userId,
       start,
       end,
       bucket,
-      hasFallbackData ? 'local' : 'remote',
+      'local',
       fallbackSignature,
     ].join('-');
     if (cache.has(cacheKey)) {
@@ -227,47 +222,14 @@ export function useAnalytics({ userId, start, end, bucket, fallbackData }) {
       return;
     }
 
-    const requestId = ++requestIdRef.current;
     setState((current) => ({ ...current, loading: true, error: null }));
 
-    if (hasFallbackData) {
-      const local = aggregateBucketsLocally({ ...currentFallbackData, start, end, bucket });
-      setCachedBuckets(cacheKey, local);
-      setState({ buckets: local, loading: false, error: null, fromFallback: false });
-      return;
-    }
-
-    supabase.rpc('get_analytics_buckets', {
-      p_user_id: userId,
-      p_start: start,
-      p_end: end,
-      p_bucket: bucket,
-    }).then(({ data, error }) => {
-      if (requestId !== requestIdRef.current) return;
-
-      if (error) {
-        const latestFallbackData = fallbackDataRef.current;
-        const local = latestFallbackData
-          ? aggregateBucketsLocally({ ...latestFallbackData, start, end, bucket })
-          : [];
-        setState({ buckets: local, loading: false, error: error.message, fromFallback: true });
-        return;
-      }
-
-      const latestFallbackData = fallbackDataRef.current;
-      const localGpTraded = latestFallbackData?.transactions
-        ? aggregateGpTradedLocally({
-            transactions: latestFallbackData.transactions,
-            start,
-            end,
-            bucket,
-          })
-        : null;
-      const buckets = mergeGpTraded(data || [], localGpTraded);
-      setCachedBuckets(cacheKey, buckets);
-      setState({ buckets, loading: false, error: null, fromFallback: false });
-    });
-  }, [userId, start, end, bucket, fallbackSignature]);
+    const local = hasFallbackData
+      ? aggregateBucketsLocally({ ...fallbackData, start, end, bucket })
+      : [];
+    setCachedBuckets(cacheKey, local);
+    setState({ buckets: local, loading: false, error: null, fromFallback: false });
+  }, [userId, start, end, bucket, fallbackData, fallbackSignature]);
 
   return state;
 }

--- a/src/hooks/useGPTradedStats.js
+++ b/src/hooks/useGPTradedStats.js
@@ -1,5 +1,11 @@
-import { useState, useEffect } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { supabase } from '../lib/supabase';
+
+const GP_TRADED_FALLBACK_ROW_CAP = 10000;
+
+function toIsoDate(date) {
+  return date.toISOString().slice(0, 10);
+}
 
 export function useGPTradedStats(userId) {
   const [stats, setStats] = useState({
@@ -11,99 +17,103 @@ export function useGPTradedStats(userId) {
   });
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    if (!userId) return;
-    fetchGPTradedStats();
-  }, [userId]);
+  const fetchGPTradedStats = useCallback(async () => {
+    if (!userId) {
+      setLoading(false);
+      return;
+    }
 
-  const fetchGPTradedStats = async () => {
     const getStartOfPeriod = (period) => {
       const date = new Date();
       switch (period) {
         case 'day':
           date.setHours(0, 0, 0, 0);
-          return date.toISOString();
+          return toIsoDate(date);
         case 'week':
           const day = date.getDay();
           const diff = date.getDate() - day + (day === 0 ? -6 : 1);
           date.setDate(diff);
           date.setHours(0, 0, 0, 0);
-          return date.toISOString();
+          return toIsoDate(date);
         case 'month':
           date.setDate(1);
           date.setHours(0, 0, 0, 0);
-          return date.toISOString();
+          return toIsoDate(date);
         case 'year':
           date.setMonth(0, 1);
           date.setHours(0, 0, 0, 0);
-          return date.toISOString();
+          return toIsoDate(date);
         default:
           return null;
       }
     };
 
+    const dailyStart = getStartOfPeriod('day');
+    const weeklyStart = getStartOfPeriod('week');
+    const monthlyStart = getStartOfPeriod('month');
+    const yearlyStart = getStartOfPeriod('year');
+
+    const buildStatsFromRows = (rows, totalOverride = null) => {
+      const nextStats = {
+        daily: 0,
+        weekly: 0,
+        monthly: 0,
+        yearly: 0,
+        total: 0
+      };
+
+      for (const row of rows || []) {
+        const rowDate = String(row.bucket_date || row.date || '').slice(0, 10);
+        const gpTraded = Number(row.gp_traded ?? row.total) || 0;
+
+        nextStats.total += gpTraded;
+        if (rowDate >= yearlyStart) nextStats.yearly += gpTraded;
+        if (rowDate >= monthlyStart) nextStats.monthly += gpTraded;
+        if (rowDate >= weeklyStart) nextStats.weekly += gpTraded;
+        if (rowDate >= dailyStart) nextStats.daily += gpTraded;
+      }
+
+      if (totalOverride !== null) {
+        nextStats.total = totalOverride;
+      }
+
+      return nextStats;
+    };
+
+    const fetchBoundedStats = async () => {
+      const { data, error } = await supabase
+        .from('transactions')
+        .select('date,total')
+        .eq('user_id', userId)
+        .gte('date', yearlyStart)
+        .order('date', { ascending: false })
+        .limit(GP_TRADED_FALLBACK_ROW_CAP);
+
+      if (error) {
+        console.error('Error fetching bounded GP traded fallback:', error);
+        return null;
+      }
+
+      const yearlyStats = buildStatsFromRows(data || []);
+      return { ...yearlyStats, total: yearlyStats.yearly };
+    };
+
     try {
-      // Helper function to fetch ALL transactions with pagination
-      const fetchAllTransactions = async (startDate = null) => {
-        let allData = [];
-        let from = 0;
-        const batchSize = 1000;
-        let hasMore = true;
-
-        while (hasMore) {
-          let query = supabase
-            .from('transactions')
-            .select('total')
-            .eq('user_id', userId)
-            .range(from, from + batchSize - 1);
-
-          if (startDate) {
-            query = query.gte('date', startDate);
-          }
-
-          const { data, error } = await query;
-
-          if (error) {
-            console.error('Error fetching transactions batch:', error);
-            break;
-          }
-
-          if (data && data.length > 0) {
-            allData = allData.concat(data);
-            from += batchSize;
-            hasMore = data.length === batchSize; // Continue if we got a full batch
-          } else {
-            hasMore = false;
-          }
-        }
-
-        return allData;
-      };
-
-      // Fetch all data for each period with pagination
-      const [dailyData, weeklyData, monthlyData, yearlyData, totalData] = await Promise.all([
-        fetchAllTransactions(getStartOfPeriod('day')),
-        fetchAllTransactions(getStartOfPeriod('week')),
-        fetchAllTransactions(getStartOfPeriod('month')),
-        fetchAllTransactions(getStartOfPeriod('year')),
-        fetchAllTransactions(null) // null = all time
-      ]);
-
-      const stats = {
-        daily: dailyData.reduce((sum, t) => sum + (t.total || 0), 0),
-        weekly: weeklyData.reduce((sum, t) => sum + (t.total || 0), 0),
-        monthly: monthlyData.reduce((sum, t) => sum + (t.total || 0), 0),
-        yearly: yearlyData.reduce((sum, t) => sum + (t.total || 0), 0),
-        total: totalData.reduce((sum, t) => sum + (t.total || 0), 0)
-      };
-
-      setStats(stats);
+      setLoading(true);
+      const boundedStats = await fetchBoundedStats();
+      if (boundedStats) {
+        setStats(boundedStats);
+      }
       setLoading(false);
     } catch (error) {
       console.error('Error fetching GP traded stats:', error);
       setLoading(false);
     }
-  };
+  }, [userId]);
+
+  useEffect(() => {
+    fetchGPTradedStats();
+  }, [fetchGPTradedStats]);
 
   return { stats, loading, refetch: fetchGPTradedStats };
 }

--- a/src/hooks/useProfitHistory.js
+++ b/src/hooks/useProfitHistory.js
@@ -1,31 +1,85 @@
-import { useState, useEffect } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { supabase } from '../lib/supabase';
+
+const RECENT_PROFIT_HISTORY_WINDOW_DAYS = 365;
+const RECENT_PROFIT_HISTORY_ROW_CAP = 20000;
+const FULL_PROFIT_HISTORY_ROW_CAP = 50000;
+const PROFIT_HISTORY_BATCH_SIZE = 1000;
+const DAY_MS = 86400_000;
 
 export function useProfitHistory(userId) {
   const [profitHistory, setProfitHistory] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [fullHistoryLoading, setFullHistoryLoading] = useState(false);
+  const [historyScope, setHistoryScope] = useState({
+    full: false,
+    since: null,
+    rowCap: RECENT_PROFIT_HISTORY_ROW_CAP,
+    capped: false
+  });
 
-  useEffect(() => {
-    if (!userId) return;
-    fetchProfitHistory();
-  }, [userId]);
-
-  const fetchProfitHistory = async () => {
-    const { data, error } = await supabase
-      .from('profit_history')
-      .select('*')
-      .eq('user_id', userId)
-      .order('created_at', { ascending: false });
-
-    if (error) {
-      console.error('Error fetching profit history:', error);
+  const fetchProfitHistory = useCallback(async (options = {}) => {
+    if (!userId) {
+      setProfitHistory([]);
       setLoading(false);
       return;
     }
 
-    setProfitHistory(data || []);
+    const { full = false } = options;
+    const rowCap = full ? FULL_PROFIT_HISTORY_ROW_CAP : RECENT_PROFIT_HISTORY_ROW_CAP;
+    const since = full
+      ? null
+      : new Date(Date.now() - RECENT_PROFIT_HISTORY_WINDOW_DAYS * DAY_MS).toISOString();
+    const allData = [];
+    let from = 0;
+    let hasMore = true;
+
+    setLoading(true);
+    if (full) setFullHistoryLoading(true);
+
+    while (hasMore) {
+      let query = supabase
+        .from('profit_history')
+        .select('*')
+        .eq('user_id', userId)
+        .order('created_at', { ascending: false });
+
+      if (since) {
+        query = query.gte('created_at', since);
+      }
+
+      const remaining = rowCap - allData.length;
+      const batchSize = Math.min(PROFIT_HISTORY_BATCH_SIZE, remaining);
+      const { data, error } = await query.range(from, from + batchSize - 1);
+
+      if (error) {
+        console.error('Error fetching profit history:', error);
+        setLoading(false);
+        setFullHistoryLoading(false);
+        return;
+      }
+
+      allData.push(...(data || []));
+      hasMore = (data || []).length === batchSize && allData.length < rowCap;
+      from += batchSize;
+    }
+
+    setProfitHistory(allData);
+    setHistoryScope({
+      full,
+      since,
+      rowCap,
+      capped: allData.length >= rowCap
+    });
     setLoading(false);
-  };
+    setFullHistoryLoading(false);
+  }, [userId]);
+
+  useEffect(() => {
+    fetchProfitHistory();
+  }, [fetchProfitHistory]);
+
+  const loadFullHistory = useCallback(() => fetchProfitHistory({ full: true }), [fetchProfitHistory]);
 
   const addProfitEntry = async (profitType, amount, stockId = null, transactionId = null) => {
     const { data, error } = await supabase
@@ -45,9 +99,20 @@ export function useProfitHistory(userId) {
       return false;
     }
 
-    await fetchProfitHistory();
-    return data?.[0] ?? null;
+    const inserted = data?.[0] ?? null;
+    if (inserted) {
+      setProfitHistory(prev => [inserted, ...prev]);
+    }
+    return inserted;
   };
 
-  return { profitHistory, loading, addProfitEntry, refetch: fetchProfitHistory };
+  return {
+    profitHistory,
+    loading,
+    addProfitEntry,
+    refetch: fetchProfitHistory,
+    loadFullHistory,
+    fullHistoryLoading,
+    historyScope
+  };
 }

--- a/src/hooks/useTransactions.js
+++ b/src/hooks/useTransactions.js
@@ -1,9 +1,22 @@
 import { useState, useEffect, useCallback } from 'react';
 import { supabase } from '../lib/supabase';
 
+const RECENT_TRANSACTION_WINDOW_DAYS = 90;
+const RECENT_TRANSACTION_ROW_CAP = 10000;
+const FULL_TRANSACTION_ROW_CAP = 50000;
+const TRANSACTION_BATCH_SIZE = 1000;
+const DAY_MS = 86400_000;
+
 export function useTransactions(userId) {
   const [transactions, setTransactions] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [fullHistoryLoading, setFullHistoryLoading] = useState(false);
+  const [historyScope, setHistoryScope] = useState({
+    full: false,
+    since: null,
+    rowCap: RECENT_TRANSACTION_ROW_CAP,
+    capped: false
+  });
 
   // Paginated state
   const [page, setPage] = useState(1);
@@ -14,40 +27,69 @@ export function useTransactions(userId) {
   const [pagedTransactions, setPagedTransactions] = useState([]);
   const [pagedLoading, setPagedLoading] = useState(false);
 
-  const fetchTransactions = useCallback(async () => {
+  const fetchTransactions = useCallback(async (options = {}) => {
+    if (!userId) {
+      setTransactions([]);
+      setLoading(false);
+      return;
+    }
+
+    const { full = false } = options;
+    const rowCap = full ? FULL_TRANSACTION_ROW_CAP : RECENT_TRANSACTION_ROW_CAP;
+    const since = full
+      ? null
+      : new Date(Date.now() - RECENT_TRANSACTION_WINDOW_DAYS * DAY_MS).toISOString();
     const allData = [];
-    const batchSize = 1000;
     let from = 0;
     let hasMore = true;
 
+    setLoading(true);
+    if (full) setFullHistoryLoading(true);
+
     while (hasMore) {
-      const { data, error } = await supabase
+      let query = supabase
         .from('transactions')
         .select('*')
         .eq('user_id', userId)
-        .order('date', { ascending: false })
-        .range(from, from + batchSize - 1);
+        .order('date', { ascending: false });
+
+      if (since) {
+        query = query.gte('date', since);
+      }
+
+      const remaining = rowCap - allData.length;
+      const batchSize = Math.min(TRANSACTION_BATCH_SIZE, remaining);
+      const { data, error } = await query.range(from, from + batchSize - 1);
 
       if (error) {
         console.error('Error fetching transactions:', error);
         setTransactions([]);
         setLoading(false);
+        setFullHistoryLoading(false);
         return;
       }
 
       allData.push(...(data || []));
-      hasMore = (data || []).length === batchSize;
+      hasMore = (data || []).length === batchSize && allData.length < rowCap;
       from += batchSize;
     }
 
     setTransactions(allData.map(formatRow));
+    setHistoryScope({
+      full,
+      since,
+      rowCap,
+      capped: allData.length >= rowCap
+    });
     setLoading(false);
+    setFullHistoryLoading(false);
   }, [userId]);
 
   useEffect(() => {
-    if (!userId) return;
     fetchTransactions();
   }, [userId, fetchTransactions]);
+
+  const loadFullHistory = useCallback(() => fetchTransactions({ full: true }), [fetchTransactions]);
 
   // Paginated fetch - used by HistoryPage
   const fetchPage = useCallback(async (targetPage, size, activeFilters, activeSort = sortConfig) => {
@@ -272,6 +314,7 @@ export function useTransactions(userId) {
   return {
     // Original API - unchanged
     transactions, loading, addTransaction, refetch: fetchTransactions,
+    loadFullHistory, fullHistoryLoading, historyScope,
     // Paginated API - for HistoryPage
     pagedTransactions, pagedLoading, totalCount, totalPages,
     page, pageSize, filters,

--- a/src/pages/AnalyticsPage.jsx
+++ b/src/pages/AnalyticsPage.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useAnalyticsTimeframe } from '../hooks/useAnalyticsTimeframe';
 import { useAnalytics } from '../hooks/useAnalytics';
 import TimeframeSelector from '../components/analytics/TimeframeSelector';
@@ -14,6 +14,7 @@ import '../styles/analytics-page.css';
 import '../styles/analytics-widgets.css';
 
 const sumGpTraded = (buckets) => buckets.reduce((sum, bucket) => sum + (bucket.gp_traded || 0), 0);
+const DEFAULT_ALL_TIME_START = '2020-01-01';
 
 export default function AnalyticsPage({
   userId,
@@ -26,6 +27,12 @@ export default function AnalyticsPage({
   milestones,
   milestoneHistory,
   milestoneProgress,
+  transactionHistoryScope,
+  profitHistoryScope,
+  loadFullTransactions,
+  loadFullProfitHistory,
+  fullTransactionsLoading = false,
+  fullProfitHistoryLoading = false,
 }) {
   const { allStocks, stocks } = useTrade();
   const stocksForStats = allStocks?.length > 0 ? allStocks : stocks;
@@ -37,7 +44,13 @@ export default function AnalyticsPage({
     ANALYTICS_TABS.includes(initialTab) ? initialTab : 'profit'
   ));
 
-  const allTimeStart = useMemo(() => {
+  const scopeCoversStart = (scope, start) => {
+    if (scope?.full) return true;
+    if (!scope?.since || !start) return false;
+    return start >= String(scope.since).slice(0, 10);
+  };
+
+  const localAllTimeStart = useMemo(() => {
     const dates = [
       ...safeTransactions.map((transaction) => String(transaction.date || '').slice(0, 10)),
       ...safeProfitHistory.map((profit) => String(profit.created_at || '').slice(0, 10)),
@@ -46,7 +59,36 @@ export default function AnalyticsPage({
     return dates.length > 0 ? dates.sort()[0] : null;
   }, [safeTransactions, safeProfitHistory]);
 
+  const hasFullLocalHistory = transactionHistoryScope?.full && profitHistoryScope?.full;
+  const allTimeStart = hasFullLocalHistory ? localAllTimeStart : DEFAULT_ALL_TIME_START;
   const timeframe = useAnalyticsTimeframe(userId, allTimeStart);
+  const transactionScopeCoversTimeframe = scopeCoversStart(transactionHistoryScope, timeframe.start);
+  const profitScopeCoversTimeframe = scopeCoversStart(profitHistoryScope, timeframe.start);
+
+  useEffect(() => {
+    if (timeframe.window === 'All' || !transactionScopeCoversTimeframe) {
+      if (!transactionHistoryScope?.full && !fullTransactionsLoading) {
+        loadFullTransactions?.();
+      }
+    }
+
+    if (timeframe.window === 'All' || !profitScopeCoversTimeframe) {
+      if (!profitHistoryScope?.full && !fullProfitHistoryLoading) {
+        loadFullProfitHistory?.();
+      }
+    }
+  }, [
+    timeframe.window,
+    transactionScopeCoversTimeframe,
+    profitScopeCoversTimeframe,
+    transactionHistoryScope?.full,
+    profitHistoryScope?.full,
+    fullTransactionsLoading,
+    fullProfitHistoryLoading,
+    loadFullTransactions,
+    loadFullProfitHistory
+  ]);
+
   const priorStart = useMemo(
     () => subtractDays(timeframe.start, inclusiveDayCount(timeframe.start, timeframe.end)),
     [timeframe.start, timeframe.end]
@@ -75,7 +117,7 @@ export default function AnalyticsPage({
   });
   const allTime = useAnalytics({
     userId,
-    start: allTimeStart || '2020-01-01',
+    start: allTimeStart || DEFAULT_ALL_TIME_START,
     end: timeframe.end,
     bucket: 'day',
     fallbackData,
@@ -129,6 +171,12 @@ export default function AnalyticsPage({
       {current.fromFallback && (
         <div className="analytics-fallback-banner">
           Showing locally-computed data. Live aggregation is temporarily unavailable.
+        </div>
+      )}
+
+      {(fullTransactionsLoading || fullProfitHistoryLoading) && (
+        <div className="analytics-fallback-banner">
+          Loading older history for detailed analytics.
         </div>
       )}
 
@@ -194,7 +242,7 @@ export default function AnalyticsPage({
             milestoneHistory={milestoneHistory}
             milestoneProgress={milestoneProgress}
             numberFormat={numberFormat}
-            firstActivityDate={allTimeStart}
+            firstActivityDate={localAllTimeStart}
           />
         )}
       </div>


### PR DESCRIPTION
﻿## Summary
- cap default transaction loading to the recent 90-day window and add explicit full-history loading for analytics
- cap default profit-history loading to the recent 365-day window and track whether local history is partial or full
- keep analytics on bounded local data so environments without the analytics RPC do not emit 404 console noise
- replace the GP traded stats full-history download with a bounded current-year transaction query

## Why
Issue #274 reported that large accounts load all transactions and profit history on every mount. That increases Supabase egress, delays the app becoming interactive, and makes analytics recompute over large client-side arrays.

The deployed Supabase environment does not currently expose `get_analytics_buckets`, so this PR avoids calling that missing RPC. Server-side aggregation can still be added later with manual SQL in a separate database change.

## Test plan
- `npm run build`
- `rg -n "get_analytics_buckets|supabase\.rpc|analytics_buckets" src` returns no matches

## Manual testing
1. Open the app on a normal account and confirm Home loads with recent activity and milestone progress.
2. Open History and confirm pagination, filters, sorting, and refresh still work.
3. Open Analytics on 1W/1M/3M and confirm cumulative profit and other charts render.
4. Switch Analytics to All and confirm the older-history loading banner appears briefly while detailed local widgets load older rows.
5. Confirm the browser console/network panel no longer shows `/analytics_buckets` 404 requests.
6. Confirm initial app load does not fetch unbounded `transactions` or `profit_history` rows.

Closes #274
