### PR TITLE
Release GE cache and Blob fixes

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -18,10 +18,10 @@
      status = 200
 
    [functions."osrs-news-cache"]
-   schedule = "*/1 * * * *"
+   schedule = "*/10 * * * *"
 
    [functions."jmod-comments-cache"]
-   schedule = "*/1 * * * *"
+   schedule = "*/10 * * * *"
 
    [functions."ge-prices-cache"]
    schedule = "*/1 * * * *"

--- a/netlify/functions/_shared/ge-cache.mjs
+++ b/netlify/functions/_shared/ge-cache.mjs
@@ -7,12 +7,14 @@ export const ENDPOINTS = {
   latest: {
     path: '/latest',
     key: 'latest',
-    cdnCacheControl: 'public, max-age=60, stale-while-revalidate=120',
-    browserCacheControl: 'public, max-age=30, stale-while-revalidate=60',
+    maxBlobAgeMs: 55_000,
+    cdnCacheControl: 'public, max-age=15, stale-while-revalidate=45',
+    browserCacheControl: 'public, max-age=15, stale-while-revalidate=45',
   },
   mapping: {
     path: '/mapping',
     key: 'mapping',
+    maxBlobAgeMs: 24 * 60 * 60 * 1000,
     cdnCacheControl: 'public, max-age=3600, stale-while-revalidate=86400',
     browserCacheControl: 'public, max-age=3600, stale-while-revalidate=86400',
   },
@@ -24,6 +26,16 @@ function getGEStore() {
 
 export function getEndpointConfig(endpoint) {
   return ENDPOINTS[endpoint] || null;
+}
+
+export function isCachedEndpointFresh(endpoint, cached) {
+  const config = getEndpointConfig(endpoint);
+  if (!config || !cached?.fetchedAt) return false;
+
+  const fetchedAt = new Date(cached.fetchedAt).getTime();
+  if (!Number.isFinite(fetchedAt)) return false;
+
+  return Date.now() - fetchedAt < config.maxBlobAgeMs;
 }
 
 export async function fetchFromOrigin(endpoint) {

--- a/netlify/functions/ge-prices.mjs
+++ b/netlify/functions/ge-prices.mjs
@@ -1,5 +1,6 @@
 import {
   getEndpointConfig,
+  isCachedEndpointFresh,
   readCachedEndpoint,
   refreshEndpoint,
 } from './_shared/ge-cache.mjs';
@@ -23,6 +24,14 @@ function responseHeaders(config, cached, source) {
   };
 }
 
+function staleResponseHeaders(config, cached) {
+  return {
+    ...responseHeaders(config, cached, 'stale-blob'),
+    'Cache-Control': 'no-store',
+    'Netlify-CDN-Cache-Control': 'no-store',
+  };
+}
+
 export default async function handler(request) {
   if (request.method !== 'GET') {
     return json(405, { error: 'Method not allowed' });
@@ -39,8 +48,18 @@ export default async function handler(request) {
   try {
     const cached = await readCachedEndpoint(endpoint);
 
-    if (cached) {
+    if (cached && isCachedEndpointFresh(endpoint, cached)) {
       return json(200, cached.payload, responseHeaders(config, cached, 'blob'));
+    }
+
+    if (cached) {
+      try {
+        const refreshed = await refreshEndpoint(endpoint);
+        return json(200, refreshed.payload, responseHeaders(config, refreshed, 'origin-refresh'));
+      } catch (refreshError) {
+        console.error(`GE ${endpoint} stale refresh error:`, refreshError.message);
+        return json(200, cached.payload, staleResponseHeaders(config, cached));
+      }
     }
   } catch (cacheReadError) {
     console.error(`GE ${endpoint} cache read error:`, cacheReadError.message);

--- a/netlify/functions/jmod-comments-cache.js
+++ b/netlify/functions/jmod-comments-cache.js
@@ -12,7 +12,7 @@ const HEADERS = {
 };
 
 function getJmodStore() {
-  return getStore('jmod-comments');
+  return getStore({ name: 'jmod-comments', consistency: 'strong' });
 }
 
 function parseRssEntries(xml, username) {
@@ -116,5 +116,5 @@ exports.handler = async () => {
 };
 
 exports.config = {
-  schedule: '*/1 * * * *',
+  schedule: '*/10 * * * *',
 };

--- a/netlify/functions/jmod-comments.js
+++ b/netlify/functions/jmod-comments.js
@@ -1,7 +1,7 @@
 const { getStore } = require('@netlify/blobs');
 
 function getJmodStore() {
-  return getStore('jmod-comments');
+  return getStore({ name: 'jmod-comments', consistency: 'strong' });
 }
 
 const JSON_HEADERS = {

--- a/netlify/functions/osrs-news-cache.js
+++ b/netlify/functions/osrs-news-cache.js
@@ -1,7 +1,7 @@
 const { getStore } = require('@netlify/blobs');
 
 function getNewsStore() {
-  return getStore('osrs-news');
+  return getStore({ name: 'osrs-news', consistency: 'strong' });
 }
 
 function parseArticles(html) {
@@ -73,5 +73,5 @@ exports.handler = async () => {
 };
 
 exports.config = {
-  schedule: '*/1 * * * *',
+  schedule: '*/10 * * * *',
 };

--- a/netlify/functions/osrs-news.js
+++ b/netlify/functions/osrs-news.js
@@ -1,7 +1,7 @@
 const { getStore } = require('@netlify/blobs');
 
 function getNewsStore() {
-  return getStore('osrs-news');
+  return getStore({ name: 'osrs-news', consistency: 'strong' });
 }
 
 const JSON_HEADERS = {

--- a/src/hooks/useGEPrices.js
+++ b/src/hooks/useGEPrices.js
@@ -75,11 +75,40 @@ export function useGEPrices() {
   };
 
   useEffect(() => {
-    fetchMapping();
-    fetchPrices();
+    const clearPriceInterval = () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
 
-    intervalRef.current = setInterval(fetchPrices, REFRESH_INTERVAL);
-    return () => clearInterval(intervalRef.current);
+    const startPriceInterval = () => {
+      clearPriceInterval();
+      if (document.visibilityState === 'visible') {
+        intervalRef.current = setInterval(fetchPrices, REFRESH_INTERVAL);
+      }
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        fetchPrices();
+        startPriceInterval();
+      } else {
+        clearPriceInterval();
+      }
+    };
+
+    fetchMapping();
+    if (document.visibilityState === 'visible') {
+      fetchPrices();
+    }
+    startPriceInterval();
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      clearPriceInterval();
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
   }, []);
 
   return { prices, mapping, mappingLoading, iconMap };


### PR DESCRIPTION
## Summary
- pause GE latest polling while browser tabs are hidden and refresh immediately when visible again
- keep GE latest fresh by refreshing stale Blob data on read instead of relying only on exact scheduled function timing
- reduce OSRS news and JMOD scheduled cache refreshes from every minute to every 10 minutes
- fix Netlify Blob store initialization for news and JMOD functions

## Why
This lowers Netlify credit usage from background tabs and overly frequent scheduled functions while keeping GE prices fresh for active users. It also fixes the `MissingBlobsEnvironmentError` seen in Netlify logs for OSRS news and JMOD comment functions.

## Validation
- `node --check` for news, JMOD, and GE Netlify functions
- ESM import check for GE Netlify function modules
- `npm run build`

Note: build still reports the existing large JS bundle warning.

## Manual checks after deploy
- `/api/ge-prices?endpoint=latest` returns JSON and includes `X-GE-Cache-Source`
- `/api/osrs-news` returns JSON without `MissingBlobsEnvironmentError`
- `/api/jmod-comments` returns JSON without `MissingBlobsEnvironmentError`
- in browser DevTools, hidden tabs should stop recurring `/api/ge-prices?endpoint=latest` polling until visible again
