### PR TITLE
[codex] Add Cloudflare cache setup

### DIFF
--- a/docs/cloudflare-cache-setup.md
+++ b/docs/cloudflare-cache-setup.md
@@ -1,0 +1,80 @@
+# Cloudflare Cache Setup
+
+Use this when the Netlify site is proxied through Cloudflare. The goal is to let Cloudflare serve shared public OSRS data from edge cache so Netlify Functions are only hit on cache misses.
+
+## DNS
+
+1. Add the production domain to Cloudflare.
+2. Point the domain at Netlify using the current Netlify DNS target.
+3. Keep the DNS record proxied in Cloudflare. The cloud icon must be orange.
+4. Keep Netlify as the origin and deploy host.
+
+## Cache Rules
+
+Create one Cloudflare Cache Rule for GE prices:
+
+```txt
+Name: Cache GE price API
+When: URI Path starts with /api/ge-prices/
+Cache eligibility: Eligible for cache
+Edge TTL: Respect origin headers
+Browser TTL: Respect origin headers
+Cache key: Include query string, or use default full URL cache key
+```
+
+The app now calls:
+
+```txt
+/api/ge-prices/latest
+/api/ge-prices/mapping
+```
+
+Those paths are deliberately separate so Cloudflare does not need to rely on `endpoint=latest` and `endpoint=mapping` query-string handling for the main app flow.
+
+Optional extra rules:
+
+```txt
+/api/osrs-news
+Edge TTL: 10 minutes
+
+/api/jmod-comments
+Edge TTL: 10 minutes
+```
+
+Both functions already return public cache headers, so a Cloudflare rule is only needed if Cloudflare does not cache them from origin headers.
+
+## Expected Headers
+
+For `/api/ge-prices/latest`, the origin returns:
+
+```txt
+Cache-Control: public, max-age=30, stale-while-revalidate=30
+CDN-Cache-Control: public, max-age=60, stale-while-revalidate=30
+Netlify-CDN-Cache-Control: public, max-age=60, stale-while-revalidate=30
+```
+
+For `/api/ge-prices/mapping`, the origin returns longer-lived cache headers.
+
+## Verification
+
+After deploying and enabling Cloudflare, check:
+
+```powershell
+curl.exe -I https://YOUR_DOMAIN/api/ge-prices/latest
+curl.exe -I https://YOUR_DOMAIN/api/ge-prices/mapping
+```
+
+Look for:
+
+```txt
+cf-cache-status: HIT
+cache-control: public, max-age=30, stale-while-revalidate=30
+cdn-cache-control: public, max-age=60, stale-while-revalidate=30
+```
+
+The first request can be `MISS`; repeat the request after a few seconds. The second request should usually be `HIT`.
+
+## What Still Hits Netlify
+
+Cloudflare cache misses still hit Netlify. The scheduled `ge-prices-cache` function also keeps running every minute on Netlify so fresh GE data is ready before users ask for it.
+

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,16 @@
      publish = "dist"
 
    [[redirects]]
+     from = "/api/ge-prices/latest"
+     to = "/.netlify/functions/ge-prices?endpoint=latest"
+     status = 200
+
+   [[redirects]]
+     from = "/api/ge-prices/mapping"
+     to = "/.netlify/functions/ge-prices?endpoint=mapping"
+     status = 200
+
+   [[redirects]]
      from = "/api/*"
      to = "/.netlify/functions/:splat"
      status = 200

--- a/netlify/functions/_shared/ge-cache.mjs
+++ b/netlify/functions/_shared/ge-cache.mjs
@@ -7,9 +7,9 @@ export const ENDPOINTS = {
   latest: {
     path: '/latest',
     key: 'latest',
-    maxBlobAgeMs: 55_000,
-    cdnCacheControl: 'public, max-age=15, stale-while-revalidate=45',
-    browserCacheControl: 'public, max-age=15, stale-while-revalidate=45',
+    maxBlobAgeMs: 70_000,
+    cdnCacheControl: 'public, max-age=60, stale-while-revalidate=30',
+    browserCacheControl: 'public, max-age=30, stale-while-revalidate=30',
   },
   mapping: {
     path: '/mapping',

--- a/netlify/functions/ge-prices.mjs
+++ b/netlify/functions/ge-prices.mjs
@@ -18,6 +18,7 @@ function json(statusCode, body, headers = {}) {
 function responseHeaders(config, cached, source) {
   return {
     'Cache-Control': config.browserCacheControl,
+    'CDN-Cache-Control': config.cdnCacheControl,
     'Netlify-CDN-Cache-Control': config.cdnCacheControl,
     'X-GE-Cache-Source': source,
     'X-GE-Cache-Fetched-At': cached.fetchedAt || '',
@@ -28,8 +29,20 @@ function staleResponseHeaders(config, cached) {
   return {
     ...responseHeaders(config, cached, 'stale-blob'),
     'Cache-Control': 'no-store',
+    'CDN-Cache-Control': 'no-store',
     'Netlify-CDN-Cache-Control': 'no-store',
   };
+}
+
+function getRequestedEndpoint(request) {
+  const url = new URL(request.url);
+  const endpoint = url.searchParams.get('endpoint');
+  if (endpoint) return endpoint;
+
+  const pathEndpoint = url.pathname.split('/').filter(Boolean).pop();
+  if (pathEndpoint && pathEndpoint !== 'ge-prices') return pathEndpoint;
+
+  return 'latest';
 }
 
 export default async function handler(request) {
@@ -37,8 +50,7 @@ export default async function handler(request) {
     return json(405, { error: 'Method not allowed' });
   }
 
-  const url = new URL(request.url);
-  const endpoint = url.searchParams.get('endpoint') || 'latest';
+  const endpoint = getRequestedEndpoint(request);
   const config = getEndpointConfig(endpoint);
 
   if (!config) {

--- a/src/hooks/useGEPrices.js
+++ b/src/hooks/useGEPrices.js
@@ -19,7 +19,7 @@ export function useGEPrices() {
 
   const fetchGEEndpoint = async (endpoint) => {
     try {
-      const res = await fetch(`${PROXY_URL}?endpoint=${endpoint}`);
+      const res = await fetch(`${PROXY_URL}/${endpoint}`);
       const contentType = res.headers.get('content-type') || '';
       if (res.ok && contentType.includes('application/json')) return res;
     } catch (proxyError) {


### PR DESCRIPTION
## Summary

Adds Cloudflare-friendly cache routing for the GE price API while keeping Netlify as the origin.

## Changes

- Adds clean /api/ge-prices/latest and /api/ge-prices/mapping routes for easier CDN cache rules.
- Adds CDN-Cache-Control headers alongside existing Netlify cache headers.
- Tunes GE latest caching to a 60-second CDN TTL and 30-second browser TTL.
- Documents the Cloudflare DNS, cache rule, and verification steps.

## Validation

- npm run build