### PR TITLE
[codex] Add Home price movers widget

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,6 +13,11 @@
      status = 200
 
    [[redirects]]
+     from = "/api/ge-prices/1h"
+     to = "/.netlify/functions/ge-prices?endpoint=1h"
+     status = 200
+
+   [[redirects]]
      from = "/api/*"
      to = "/.netlify/functions/:splat"
      status = 200

--- a/netlify/functions/_shared/ge-cache.mjs
+++ b/netlify/functions/_shared/ge-cache.mjs
@@ -18,6 +18,18 @@ export const ENDPOINTS = {
     cdnCacheControl: 'public, max-age=3600, stale-while-revalidate=86400',
     browserCacheControl: 'public, max-age=3600, stale-while-revalidate=86400',
   },
+  '1h': {
+    path: '/1h',
+    key: '1h',
+    maxBlobAgeMs: 24 * 60 * 60 * 1000,
+    cdnCacheControl: 'public, max-age=900, stale-while-revalidate=3600',
+    browserCacheControl: 'public, max-age=900, stale-while-revalidate=3600',
+    queryParams: ['timestamp'],
+    cacheKey: (params) => {
+      const timestamp = params?.get('timestamp');
+      return timestamp ? `1h-${timestamp}` : '1h-latest';
+    },
+  },
 };
 
 function getGEStore() {
@@ -26,6 +38,12 @@ function getGEStore() {
 
 export function getEndpointConfig(endpoint) {
   return ENDPOINTS[endpoint] || null;
+}
+
+function getCacheKey(endpoint, params = new URLSearchParams()) {
+  const config = getEndpointConfig(endpoint);
+  if (!config) return null;
+  return config.cacheKey ? config.cacheKey(params) : config.key;
 }
 
 export function isCachedEndpointFresh(endpoint, cached) {
@@ -38,13 +56,19 @@ export function isCachedEndpointFresh(endpoint, cached) {
   return Date.now() - fetchedAt < config.maxBlobAgeMs;
 }
 
-export async function fetchFromOrigin(endpoint) {
+export async function fetchFromOrigin(endpoint, params = new URLSearchParams()) {
   const config = getEndpointConfig(endpoint);
   if (!config) {
     throw new Error(`Unsupported GE endpoint: ${endpoint}`);
   }
 
-  const response = await fetch(`${BASE_URL}${config.path}`, {
+  const url = new URL(`${BASE_URL}${config.path}`);
+  for (const param of config.queryParams || []) {
+    const value = params.get(param);
+    if (value != null) url.searchParams.set(param, value);
+  }
+
+  const response = await fetch(url, {
     headers: {
       'User-Agent': USER_AGENT,
       Accept: 'application/json',
@@ -58,12 +82,13 @@ export async function fetchFromOrigin(endpoint) {
   return response.json();
 }
 
-export async function readCachedEndpoint(endpoint) {
+export async function readCachedEndpoint(endpoint, params = new URLSearchParams()) {
   const config = getEndpointConfig(endpoint);
   if (!config) return null;
 
   const store = getGEStore();
-  const cached = await store.get(config.key, { type: 'json' });
+  const cacheKey = getCacheKey(endpoint, params);
+  const cached = await store.get(cacheKey, { type: 'json' });
 
   if (!cached || typeof cached !== 'object' || !('payload' in cached)) {
     return null;
@@ -72,7 +97,7 @@ export async function readCachedEndpoint(endpoint) {
   return cached;
 }
 
-export async function writeCachedEndpoint(endpoint, payload) {
+export async function writeCachedEndpoint(endpoint, payload, params = new URLSearchParams()) {
   const config = getEndpointConfig(endpoint);
   if (!config) {
     throw new Error(`Unsupported GE endpoint: ${endpoint}`);
@@ -84,11 +109,12 @@ export async function writeCachedEndpoint(endpoint, payload) {
   };
 
   const store = getGEStore();
-  await store.setJSON(config.key, cached);
+  const cacheKey = getCacheKey(endpoint, params);
+  await store.setJSON(cacheKey, cached);
   return cached;
 }
 
-export async function refreshEndpoint(endpoint) {
-  const payload = await fetchFromOrigin(endpoint);
-  return writeCachedEndpoint(endpoint, payload);
+export async function refreshEndpoint(endpoint, params = new URLSearchParams()) {
+  const payload = await fetchFromOrigin(endpoint, params);
+  return writeCachedEndpoint(endpoint, payload, params);
 }

--- a/netlify/functions/ge-prices.mjs
+++ b/netlify/functions/ge-prices.mjs
@@ -45,20 +45,42 @@ function getRequestedEndpoint(request) {
   return 'latest';
 }
 
+function getEndpointParams(request) {
+  const url = new URL(request.url);
+  return url.searchParams;
+}
+
+function validateEndpointRequest(endpoint, params) {
+  if (endpoint !== '1h') return null;
+
+  const timestamp = params.get('timestamp');
+  if (timestamp != null && !/^\d+$/.test(timestamp)) {
+    return 'timestamp must be a Unix timestamp in seconds';
+  }
+
+  return null;
+}
+
 export default async function handler(request) {
   if (request.method !== 'GET') {
     return json(405, { error: 'Method not allowed' });
   }
 
   const endpoint = getRequestedEndpoint(request);
+  const params = getEndpointParams(request);
   const config = getEndpointConfig(endpoint);
 
   if (!config) {
     return json(400, { error: `Unsupported GE endpoint: ${endpoint}` });
   }
 
+  const validationError = validateEndpointRequest(endpoint, params);
+  if (validationError) {
+    return json(400, { error: validationError });
+  }
+
   try {
-    const cached = await readCachedEndpoint(endpoint);
+    const cached = await readCachedEndpoint(endpoint, params);
 
     if (cached && isCachedEndpointFresh(endpoint, cached)) {
       return json(200, cached.payload, responseHeaders(config, cached, 'blob'));
@@ -66,7 +88,7 @@ export default async function handler(request) {
 
     if (cached) {
       try {
-        const refreshed = await refreshEndpoint(endpoint);
+        const refreshed = await refreshEndpoint(endpoint, params);
         return json(200, refreshed.payload, responseHeaders(config, refreshed, 'origin-refresh'));
       } catch (refreshError) {
         console.error(`GE ${endpoint} stale refresh error:`, refreshError.message);
@@ -78,7 +100,7 @@ export default async function handler(request) {
   }
 
   try {
-    const refreshed = await refreshEndpoint(endpoint);
+    const refreshed = await refreshEndpoint(endpoint, params);
     return json(200, refreshed.payload, responseHeaders(config, refreshed, 'origin'));
   } catch (originError) {
     console.error(`GE ${endpoint} origin fallback error:`, originError.message);

--- a/src/components/PriceMoversWidget.jsx
+++ b/src/components/PriceMoversWidget.jsx
@@ -1,0 +1,174 @@
+import React, { useMemo, useState } from 'react';
+import { Activity, TrendingDown, TrendingUp } from 'lucide-react';
+import { useGEPriceBaseline } from '../hooks/useGEPriceBaseline';
+import { formatNumber } from '../utils/formatters';
+
+const MAX_MOVERS = 6;
+
+function formatPercent(value) {
+  if (!Number.isFinite(value)) return '-';
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${value.toFixed(2)}%`;
+}
+
+function signedNumber(value, numberFormat) {
+  if (!Number.isFinite(value)) return '-';
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${formatNumber(value, numberFormat)}`;
+}
+
+function priceOf(entry) {
+  return Number(entry?.avgHighPrice ?? entry?.high ?? 0);
+}
+
+export default function PriceMoversWidget({
+  stocks = [],
+  gePrices = {},
+  numberFormat = 'compact',
+}) {
+  const [activeView, setActiveView] = useState('impact');
+  const [hideOneGpMoves, setHideOneGpMoves] = useState(true);
+  const { baselinePrices, baselineTimestamp, loading, error } = useGEPriceBaseline();
+
+  const movers = useMemo(() => {
+    if (!stocks?.length || !gePrices || !baselinePrices) return [];
+
+    return stocks
+      .filter(stock => !stock.archived && stock.shares > 0 && stock.itemId)
+      .map(stock => {
+        const itemId = String(stock.itemId);
+        const currentHigh = Number(gePrices[itemId]?.high ?? 0);
+        const baselineHigh = priceOf(baselinePrices[itemId]);
+
+        if (currentHigh <= 0 || baselineHigh <= 0) return null;
+
+        const priceDelta = currentHigh - baselineHigh;
+        const percentMove = (priceDelta / baselineHigh) * 100;
+        const impactMove = priceDelta * stock.shares;
+
+        if (!Number.isFinite(percentMove) || priceDelta === 0) return null;
+        if (hideOneGpMoves && Math.abs(priceDelta) <= 1) return null;
+
+        return {
+          id: stock.id,
+          name: stock.name,
+          shares: stock.shares,
+          currentHigh,
+          baselineHigh,
+          priceDelta,
+          percentMove,
+          impactMove,
+        };
+      })
+      .filter(Boolean);
+  }, [stocks, gePrices, baselinePrices, hideOneGpMoves]);
+
+  const sortedMovers = useMemo(() => {
+    const sortKey = activeView === 'impact' ? 'impactMove' : 'percentMove';
+    return [...movers]
+      .sort((a, b) => Math.abs(b[sortKey]) - Math.abs(a[sortKey]))
+      .slice(0, MAX_MOVERS);
+  }, [movers, activeView]);
+
+  const baselineLabel = baselineTimestamp
+    ? new Date(baselineTimestamp * 1000).toLocaleString([], {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+    : null;
+
+  const renderBody = () => {
+    if (loading) {
+      return <p className="activity-empty">Loading 24h price baseline...</p>;
+    }
+
+    if (error) {
+      return <p className="activity-empty">24h price movement is unavailable right now.</p>;
+    }
+
+    if (!stocks.some(stock => !stock.archived && stock.shares > 0 && stock.itemId)) {
+      return <p className="activity-empty">No held GE-linked items to compare.</p>;
+    }
+
+    if (sortedMovers.length === 0) {
+      return <p className="activity-empty">No held items have a usable 24h price move yet.</p>;
+    }
+
+    return (
+      <div className="price-movers-list">
+        {sortedMovers.map((mover) => {
+          const isUp = mover.priceDelta > 0;
+          const DirectionIcon = isUp ? TrendingUp : TrendingDown;
+          const valueClass = isUp ? 'price-mover-positive' : 'price-mover-negative';
+
+          return (
+            <div key={mover.id} className="price-mover-row">
+              <div className="price-mover-main">
+                <div className="price-mover-title-row">
+                  <DirectionIcon size={16} className={valueClass} />
+                  <span className="price-mover-name">{mover.name}</span>
+                </div>
+                <div className="price-mover-subtitle">
+                  {formatNumber(mover.shares, numberFormat)} held - GE High {formatNumber(mover.baselineHigh, numberFormat)} to {formatNumber(mover.currentHigh, numberFormat)}
+                </div>
+              </div>
+              <div className="price-mover-values">
+                <div className={`price-mover-primary ${valueClass}`}>
+                  {activeView === 'impact'
+                    ? signedNumber(mover.impactMove, numberFormat)
+                    : formatPercent(mover.percentMove)}
+                </div>
+                <div className="price-mover-secondary">
+                  {activeView === 'impact'
+                    ? formatPercent(mover.percentMove)
+                    : signedNumber(mover.impactMove, numberFormat)}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
+  return (
+    <div className="activity-section price-movers-section">
+      <div className="price-movers-header">
+        <h3 className="activity-section-title price-movers-title">
+          <Activity size={20} />
+          Price Movers
+        </h3>
+        <div className="price-movers-tabs" aria-label="Price mover sorting">
+          <button
+            type="button"
+            className={`price-movers-tab ${activeView === 'impact' ? 'price-movers-tab-active' : ''}`}
+            onClick={() => setActiveView('impact')}
+          >
+            Impact
+          </button>
+          <button
+            type="button"
+            className={`price-movers-tab ${activeView === 'percent' ? 'price-movers-tab-active' : ''}`}
+            onClick={() => setActiveView('percent')}
+          >
+            %
+          </button>
+        </div>
+      </div>
+      <label className="price-movers-filter">
+        <input
+          type="checkbox"
+          checked={hideOneGpMoves}
+          onChange={(event) => setHideOneGpMoves(event.target.checked)}
+        />
+        Hide 1 GP moves
+      </label>
+      <div className="price-movers-meta">
+        Held items only - compared with {baselineLabel || '24h ago'}
+      </div>
+      {renderBody()}
+    </div>
+  );
+}

--- a/src/hooks/useGEPriceBaseline.js
+++ b/src/hooks/useGEPriceBaseline.js
@@ -1,0 +1,83 @@
+import { useEffect, useMemo, useState } from 'react';
+
+const PROXY_URL = '/api/ge-prices';
+const WIKI_BASE_URL = 'https://prices.runescape.wiki/api/v1/osrs';
+const USER_AGENT = 'OSRSProfitTracker - osrsprofittracker@gmail.com';
+const DAY_MS = 86_400_000;
+const HOUR_MS = 3_600_000;
+const REFRESH_INTERVAL = 15 * 60_000;
+const USE_DIRECT_WIKI_FALLBACK = import.meta.env.DEV;
+
+function getBaselineTimestamp() {
+  return Math.floor((Date.now() - DAY_MS) / HOUR_MS) * 3600;
+}
+
+async function fetchBaseline(timestamp) {
+  const endpoint = `1h?timestamp=${timestamp}`;
+
+  try {
+    const res = await fetch(`${PROXY_URL}/${endpoint}`);
+    const contentType = res.headers.get('content-type') || '';
+    if (res.ok && contentType.includes('application/json')) return res;
+  } catch (proxyError) {
+    if (!USE_DIRECT_WIKI_FALLBACK) throw proxyError;
+  }
+
+  if (!USE_DIRECT_WIKI_FALLBACK) return null;
+  return fetch(`${WIKI_BASE_URL}/${endpoint}`, {
+    headers: { 'User-Agent': USER_AGENT },
+  });
+}
+
+export function useGEPriceBaseline() {
+  const [baselinePrices, setBaselinePrices] = useState({});
+  const [baselineTimestamp, setBaselineTimestamp] = useState(() => getBaselineTimestamp());
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let initialLoad = true;
+
+    const loadBaseline = async () => {
+      const timestamp = getBaselineTimestamp();
+      if (initialLoad) setLoading(true);
+      setError(null);
+
+      try {
+        const res = await fetchBaseline(timestamp);
+        if (!res?.ok) throw new Error(`GE 1h fetch failed${res ? `: ${res.status}` : ''}`);
+        const json = await res.json();
+
+        if (!cancelled) {
+          setBaselineTimestamp(timestamp);
+          setBaselinePrices(json.data || {});
+        }
+      } catch (fetchError) {
+        if (!cancelled) {
+          console.error('GE 24h baseline fetch failed:', fetchError);
+          setBaselinePrices({});
+          setError(fetchError.message);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+        initialLoad = false;
+      }
+    };
+
+    loadBaseline();
+    const interval = setInterval(loadBaseline, REFRESH_INTERVAL);
+
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, []);
+
+  return useMemo(() => ({
+    baselinePrices,
+    baselineTimestamp,
+    loading,
+    error,
+  }), [baselinePrices, baselineTimestamp, loading, error]);
+}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -3,6 +3,7 @@ import { formatNumber } from '../utils/formatters';
 import { calculateUnrealizedProfit } from '../utils/taxUtils';
 import { useGEData } from '../contexts/GEDataContext';
 import { useTrade } from '../contexts/TradeContext';
+import PriceMoversWidget from '../components/PriceMoversWidget';
 import '../styles/home-page.css';
 
 const SORT_OPTIONS = [
@@ -14,6 +15,9 @@ const SORT_OPTIONS = [
   { value: 'soldCost',   label: 'Total Sold Cost' },
   { value: 'unrealized', label: 'Unrealized Profit' },
 ];
+
+const TOP_ITEMS_LIMIT = 14;
+const TOP_ITEMS_COLUMN_SIZE = 7;
 
 export default function HomePage({
   transactions,
@@ -99,7 +103,7 @@ export default function HomePage({
       };
       return sortMap[topItemsSortBy] ?? 0;
     })
-    .slice(0, 10) || [];
+    .slice(0, TOP_ITEMS_LIMIT) || [];
 
   const watchlistOpportunities = useMemo(() => {
     if (!watchlistItems.length) return [];
@@ -256,9 +260,9 @@ export default function HomePage({
         </div>
       </div>
 
-      <div className="activity-grid">
+      <div className="home-dashboard-grid">
         {/* Recent Activity */}
-        <div className="activity-section">
+        <div className="activity-section home-dashboard-main">
           <h3 className="activity-section-title">
             <span>📜</span> Recent Activity
           </h3>
@@ -319,8 +323,90 @@ export default function HomePage({
           )}
         </div>
 
+        {/* Top Items */}
+        <div className="activity-section home-dashboard-top-items">
+          <h3 className="activity-section-title">
+            <span>🏆</span> Top Items
+            <select
+              className="top-items-sort-select"
+              value={topItemsSortBy}
+              onChange={e => setTopItemsSortBy(e.target.value)}
+            >
+              {SORT_OPTIONS.map(opt => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </h3>
+          <div className="top-items-grid">
+            {topItems.length === 0 ? (
+              <p className="activity-empty">No items to display</p>
+            ) : (
+              [
+                topItems.slice(0, TOP_ITEMS_COLUMN_SIZE),
+                topItems.slice(TOP_ITEMS_COLUMN_SIZE, TOP_ITEMS_LIMIT)
+              ].map((col, colIdx) => (
+                <div key={colIdx} className="top-items-column">
+                  {col.map((item, idx) => {
+                    let displayValue, displayValueClass, subtitle;
+
+                    if (topItemsSortBy === 'profit') {
+                      displayValue = formatNumber(item.profit, numberFormat);
+                      displayValueClass = item.profit >= 0 ? 'activity-item-value-positive' : 'activity-item-value-negative';
+                      subtitle = `Sold: ${item.sharesSold?.toLocaleString()} | Margin: ${item.margin.toFixed(2)}%`;
+                    } else if (topItemsSortBy === 'margin') {
+                      displayValue = `${item.margin.toFixed(2)}%`;
+                      displayValueClass = item.margin >= 0 ? 'activity-item-value-positive' : 'activity-item-value-negative';
+                      subtitle = `Profit: ${formatNumber(item.profit, numberFormat)} | Sold: ${item.sharesSold?.toLocaleString()}`;
+                    } else if (topItemsSortBy === 'stock') {
+                      displayValue = item.shares?.toLocaleString();
+                      displayValueClass = 'activity-item-value-neutral';
+                      subtitle = `Total Cost: ${formatNumber(item.totalCost, numberFormat)}`;
+                    } else if (topItemsSortBy === 'totalCost') {
+                      displayValue = formatNumber(item.totalCost, numberFormat);
+                      displayValueClass = 'activity-item-value-neutral';
+                      subtitle = `Quantity held: ${item.shares?.toLocaleString()}`;
+                    } else if (topItemsSortBy === 'soldStock') {
+                      displayValue = item.sharesSold?.toLocaleString();
+                      displayValueClass = 'activity-item-value-neutral';
+                      subtitle = `Total Sold Cost: ${formatNumber(item.totalCostSold, numberFormat)}`;
+                    } else if (topItemsSortBy === 'soldCost') {
+                      displayValue = formatNumber(item.totalCostSold, numberFormat);
+                      displayValueClass = 'activity-item-value-neutral';
+                      subtitle = `Sold: ${item.sharesSold?.toLocaleString()}`;
+                    } else if (topItemsSortBy === 'unrealized') {
+                      displayValue = formatNumber(item.unrealizedProfit, numberFormat);
+                      displayValueClass = item.unrealizedProfit >= 0 ? 'activity-item-value-positive' : 'activity-item-value-negative';
+                      subtitle = `Held: ${item.shares?.toLocaleString()} | GE High: ${item.latestHigh?.toLocaleString()}`;
+                    }
+
+                    return (
+                      <div key={idx} className="activity-item">
+                        <div className="activity-item-left">
+                          <div className="activity-item-title">{item.name}</div>
+                          <div className="activity-item-subtitle">{subtitle}</div>
+                        </div>
+                        <div className="activity-item-right">
+                          <div className={`activity-item-value ${displayValueClass}`}>
+                            {displayValue}
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        <PriceMoversWidget
+          stocks={stocksForStats}
+          gePrices={geData}
+          numberFormat={numberFormat}
+        />
+
         {/* Goals Section */}
-        <div className="activity-section">
+        <div className="activity-section home-dashboard-goals">
           <h3 className="activity-section-title">
             <span>🎯</span> Goals
           </h3>
@@ -459,78 +545,6 @@ export default function HomePage({
         )}
       </div>
 
-      {/* Top Items */}
-      <div className="activity-section">
-        <h3 className="activity-section-title">
-          <span>🏆</span> Top Items
-          <select
-            className="top-items-sort-select"
-            value={topItemsSortBy}
-            onChange={e => setTopItemsSortBy(e.target.value)}
-          >
-            {SORT_OPTIONS.map(opt => (
-              <option key={opt.value} value={opt.value}>{opt.label}</option>
-            ))}
-          </select>
-        </h3>
-        <div className="top-items-grid">
-          {topItems.length === 0 ? (
-            <p className="activity-empty">No items to display</p>
-          ) : (
-            [topItems.slice(0, 5), topItems.slice(5, 10)].map((col, colIdx) => (
-              <div key={colIdx} className="top-items-column">
-                {col.map((item, idx) => {
-                  let displayValue, displayValueClass, subtitle;
-
-                  if (topItemsSortBy === 'profit') {
-                    displayValue = formatNumber(item.profit, numberFormat);
-                    displayValueClass = item.profit >= 0 ? 'activity-item-value-positive' : 'activity-item-value-negative';
-                    subtitle = `Sold: ${item.sharesSold?.toLocaleString()} | Margin: ${item.margin.toFixed(2)}%`;
-                  } else if (topItemsSortBy === 'margin') {
-                    displayValue = `${item.margin.toFixed(2)}%`;
-                    displayValueClass = item.margin >= 0 ? 'activity-item-value-positive' : 'activity-item-value-negative';
-                    subtitle = `Profit: ${formatNumber(item.profit, numberFormat)} | Sold: ${item.sharesSold?.toLocaleString()}`;
-                  } else if (topItemsSortBy === 'stock') {
-                    displayValue = item.shares?.toLocaleString();
-                    displayValueClass = 'activity-item-value-neutral';
-                    subtitle = `Total Cost: ${formatNumber(item.totalCost, numberFormat)}`;
-                  } else if (topItemsSortBy === 'totalCost') {
-                    displayValue = formatNumber(item.totalCost, numberFormat);
-                    displayValueClass = 'activity-item-value-neutral';
-                    subtitle = `Quantity held: ${item.shares?.toLocaleString()}`;
-                  } else if (topItemsSortBy === 'soldStock') {
-                    displayValue = item.sharesSold?.toLocaleString();
-                    displayValueClass = 'activity-item-value-neutral';
-                    subtitle = `Total Sold Cost: ${formatNumber(item.totalCostSold, numberFormat)}`;
-                  } else if (topItemsSortBy === 'soldCost') {
-                    displayValue = formatNumber(item.totalCostSold, numberFormat);
-                    displayValueClass = 'activity-item-value-neutral';
-                    subtitle = `Sold: ${item.sharesSold?.toLocaleString()}`;
-                  } else if (topItemsSortBy === 'unrealized') {
-                    displayValue = formatNumber(item.unrealizedProfit, numberFormat);
-                    displayValueClass = item.unrealizedProfit >= 0 ? 'activity-item-value-positive' : 'activity-item-value-negative';
-                    subtitle = `Held: ${item.shares?.toLocaleString()} | GE High: ${item.latestHigh?.toLocaleString()}`;
-                  }
-
-                  return (
-                    <div key={idx} className="activity-item">
-                      <div className="activity-item-left">
-                        <div className="activity-item-title">{item.name}</div>
-                        <div className="activity-item-subtitle">{subtitle}</div>
-                      </div>
-                      <div className="activity-item-right">
-                        <div className={`activity-item-value ${displayValueClass}`}>
-                          {displayValue}
-                        </div>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            ))
-          )}
-        </div>
-      </div>
     </div>
   );
 }

--- a/src/styles/home-page.css
+++ b/src/styles/home-page.css
@@ -233,11 +233,28 @@
 }
 
 /* Activity/Items Grid */
-.activity-grid {
+.home-dashboard-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+  grid-template-columns: minmax(0, 1.35fr) minmax(380px, 0.75fr);
   gap: 1.5rem;
   margin-bottom: 2rem;
+}
+
+.home-dashboard-main {
+  grid-column: 1;
+  grid-row: 1;
+  min-width: 0;
+}
+
+.home-dashboard-top-items {
+  grid-column: 1;
+  grid-row: 2;
+  min-width: 0;
+}
+
+.home-dashboard-goals {
+  grid-column: 2;
+  grid-row: 1;
 }
 
 .activity-section {
@@ -338,6 +355,144 @@
   font-size: 0.875rem;
 }
 
+.price-movers-section {
+  grid-column: 2;
+  grid-row: 2;
+  min-height: 0;
+}
+
+.price-movers-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 0.35rem;
+}
+
+.price-movers-title {
+  margin-bottom: 0;
+}
+
+.price-movers-tabs {
+  display: inline-flex;
+  padding: 0.2rem;
+  background: rgb(15, 23, 42);
+  border: 1px solid rgb(51, 65, 85);
+  border-radius: 0.5rem;
+}
+
+.price-movers-tab {
+  border: 0;
+  border-radius: 0.35rem;
+  background: transparent;
+  color: rgb(148, 163, 184);
+  cursor: pointer;
+  font-size: 0.78rem;
+  font-weight: 700;
+  padding: 0.35rem 0.65rem;
+}
+
+.price-movers-tab:hover {
+  color: rgb(226, 232, 240);
+  background: rgba(51, 65, 85, 0.7);
+}
+
+.price-movers-tab-active {
+  color: white;
+  background: rgb(88, 28, 135);
+}
+
+.price-movers-tab-active:hover {
+  color: white;
+  background: rgb(107, 33, 168);
+}
+
+.price-movers-meta {
+  color: rgb(148, 163, 184);
+  font-size: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.price-movers-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: rgb(203, 213, 225);
+  cursor: pointer;
+  font-size: 0.78rem;
+  margin: 0.6rem 0 0.45rem;
+}
+
+.price-movers-filter input {
+  accent-color: rgb(88, 28, 135);
+  cursor: pointer;
+}
+
+.price-movers-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.price-mover-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.8rem;
+  background: rgb(15, 23, 42);
+  border: 1px solid rgb(51, 65, 85);
+  border-radius: 0.5rem;
+}
+
+.price-mover-main {
+  min-width: 0;
+}
+
+.price-mover-title-row {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-width: 0;
+}
+
+.price-mover-name {
+  color: rgb(226, 232, 240);
+  font-weight: 700;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.price-mover-subtitle {
+  color: rgb(148, 163, 184);
+  font-size: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+.price-mover-values {
+  flex-shrink: 0;
+  text-align: right;
+}
+
+.price-mover-primary {
+  font-size: 1rem;
+  font-weight: 800;
+}
+
+.price-mover-secondary {
+  color: rgb(148, 163, 184);
+  font-size: 0.75rem;
+  margin-top: 0.2rem;
+}
+
+.price-mover-positive {
+  color: rgb(74, 222, 128);
+}
+
+.price-mover-negative {
+  color: rgb(248, 113, 113);
+}
+
 .watchlist-summary-section {
   margin-bottom: 2rem;
 }
@@ -421,7 +576,46 @@
   border: 1px solid rgba(147, 197, 253, 0.35);
 }
 
+@media (max-width: 1100px) {
+  .home-dashboard-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .home-dashboard-main,
+  .home-dashboard-top-items,
+  .home-dashboard-goals,
+  .price-movers-section {
+    grid-column: auto;
+    grid-row: auto;
+  }
+}
+
 @media (max-width: 720px) {
+  .price-movers-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .price-movers-tabs {
+    width: 100%;
+  }
+
+  .price-movers-tab {
+    flex: 1;
+  }
+
+  .price-mover-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .price-mover-values {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+    text-align: left;
+  }
+
   .watchlist-summary-header {
     flex-direction: column;
     align-items: stretch;


### PR DESCRIPTION
## Summary
- add a Home Price Movers widget for held GE-linked items
- support Impact and % sorting, with a default-on filter for 1 GP moves
- fetch a single 24h baseline snapshot through the Netlify GE proxy/cache
- reorganize the Home dashboard so Recent Activity aligns with Goals and Top Items aligns with Price Movers

## Validation
- `npm run build`
- `node --check netlify/functions/ge-prices.mjs`
- `node --check netlify/functions/_shared/ge-cache.mjs`

## Notes
- Leaves existing local changes to `.claude/settings.local.json` and `deno.lock` out of this PR.