### PR TITLE
[codex] Add profit heatmap and extra profit history

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -103,7 +103,9 @@ function MainAppInner({ session, onLogout }) {
     fullHistoryLoading: fullTransactionsLoading,
     historyScope: transactionHistoryScope,
     pagedTransactions, pagedLoading, totalCount, totalPages,
-    page, pageSize, filters, goToPage, changePageSize, applyFilters, initPaged,
+    page, pageSize, filters, historySource, changeHistorySource,
+    historyProfitTypes, changeHistoryProfitTypes,
+    goToPage, changePageSize, applyFilters, initPaged,
     sortConfig: historySortConfig, applySort, resetPaged, undoTransaction
   } = useTransactionsContext();
  const { stats: gpTradedStats, loading: gpStatsLoading, refetch: refetchGPStats } = useGPTradedStats(userId);
@@ -1164,6 +1166,11 @@ function MainAppInner({ session, onLogout }) {
             page={page}
             pageSize={pageSize}
             filters={filters}
+            historySource={historySource}
+            onChangeHistorySource={changeHistorySource}
+            historyProfitTypes={historyProfitTypes}
+            onChangeHistoryProfitTypes={changeHistoryProfitTypes}
+            visibleProfits={visibleProfits}
             onGoToPage={goToPage}
             onChangePageSize={changePageSize}
             onApplyFilters={applyFilters}

--- a/src/components/analytics/ProfitTab.jsx
+++ b/src/components/analytics/ProfitTab.jsx
@@ -9,6 +9,7 @@ import PeriodComparisonCards from './widgets/PeriodComparisonCards';
 import BestDaysTable from './widgets/BestDaysTable';
 import ProfitKpiStrip from './widgets/ProfitKpiStrip';
 import ProfitHeatmap from './widgets/ProfitHeatmap';
+import HourlyProfitHeatmap from './widgets/HourlyProfitHeatmap';
 import {
   addDays,
   inclusiveDayCount,
@@ -132,6 +133,17 @@ export default function ProfitTab({
         endDate={timeframe.end}
         numberFormat={numberFormat}
         onCellClick={(date) => onNavigateToHistory?.(date, date)}
+      />
+      <HourlyProfitHeatmap
+        transactions={transactions}
+        profitHistory={profitHistory}
+        timeframe={timeframe}
+        numberFormat={numberFormat}
+        onCellClick={(cell) => onNavigateToHistory?.(timeframe.start, timeframe.end, {
+          type: 'sell',
+          dayOfWeek: String(cell.dayIndex),
+          hourOfDay: String(cell.hour),
+        })}
       />
     </div>
   );

--- a/src/components/analytics/widgets/HourlyProfitHeatmap.jsx
+++ b/src/components/analytics/widgets/HourlyProfitHeatmap.jsx
@@ -1,0 +1,329 @@
+import React, { useMemo, useRef } from 'react';
+import { formatNumber } from '../../../utils/formatters';
+
+const DAY_ORDER = [1, 2, 3, 4, 5, 6, 0];
+const DAY_LABELS = {
+  0: 'Sun',
+  1: 'Mon',
+  2: 'Tue',
+  3: 'Wed',
+  4: 'Thu',
+  5: 'Fri',
+  6: 'Sat',
+};
+const CELL_WIDTH = 32;
+const CELL_HEIGHT = 22;
+const CELL_GAP = 3;
+const LABEL_WIDTH = 42;
+const TOP_LABEL_HEIGHT = 24;
+const SVG_WIDTH = LABEL_WIDTH + 24 * (CELL_WIDTH + CELL_GAP) - CELL_GAP;
+const SVG_HEIGHT = TOP_LABEL_HEIGHT + 7 * (CELL_HEIGHT + CELL_GAP) - CELL_GAP;
+const TOOLTIP_WIDTH = 176;
+const TOOLTIP_HEIGHT = 58;
+
+const getProfitType = (profit) => profit.profit_type ?? profit.profitType;
+const getProfitTxId = (profit) => profit.transaction_id ?? profit.transactionId;
+
+function toLocalDateKey(value) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function buildThresholds(values, count = 5) {
+  const sorted = [...values].filter((value) => value > 0).sort((a, b) => a - b);
+  if (!sorted.length) return [];
+
+  return Array.from({ length: count }, (_, index) => {
+    const quantileIndex = Math.ceil((sorted.length * (index + 1)) / count) - 1;
+    return sorted[Math.max(0, Math.min(sorted.length - 1, quantileIndex))];
+  });
+}
+
+function colorFor(value, positiveThresholds, negativeThresholds) {
+  if (value === 0) return 'rgb(30, 41, 59)';
+
+  if (value > 0) {
+    const index = positiveThresholds.findIndex((threshold) => value <= threshold);
+    const shade = index === -1 ? positiveThresholds.length - 1 : index;
+    return ['#1f3b2c', '#15803d', '#16a34a', '#22c55e', '#4ade80'][Math.max(0, Math.min(4, shade))];
+  }
+
+  const magnitude = Math.abs(value);
+  const index = negativeThresholds.findIndex((threshold) => magnitude <= threshold);
+  const shade = index === -1 ? negativeThresholds.length - 1 : index;
+  return ['#3b1f24', '#7f1d1d', '#b91c1c', '#dc2626', '#f87171'][Math.max(0, Math.min(4, shade))];
+}
+
+function hourLabel(hour) {
+  const next = (hour + 1) % 24;
+  return `${String(hour).padStart(2, '0')}:00-${String(next).padStart(2, '0')}:00`;
+}
+
+function tooltipPosition(x, y) {
+  const rightSide = x + CELL_WIDTH + 8;
+  const leftSide = x - TOOLTIP_WIDTH - 8;
+  const tooltipX = rightSide + TOOLTIP_WIDTH <= SVG_WIDTH ? rightSide : Math.max(LABEL_WIDTH, leftSide);
+
+  return {
+    x: tooltipX,
+    y: Math.max(0, Math.min(SVG_HEIGHT - TOOLTIP_HEIGHT, y - 16)),
+  };
+}
+
+function buildProfitByTransaction(profitHistory = []) {
+  const map = new Map();
+
+  for (const profit of profitHistory || []) {
+    if (getProfitType(profit) !== 'stock') continue;
+
+    const txId = getProfitTxId(profit);
+    if (txId == null) continue;
+
+    const key = String(txId);
+    map.set(key, (map.get(key) || 0) + (Number(profit.amount) || 0));
+  }
+
+  return map;
+}
+
+function createEmptyRows() {
+  const cells = new Map();
+
+  for (const dayIndex of DAY_ORDER) {
+    for (let hour = 0; hour < 24; hour += 1) {
+      cells.set(`${dayIndex}-${hour}`, {
+        dayIndex,
+        hour,
+        profit: 0,
+        sellCount: 0,
+      });
+    }
+  }
+
+  return cells;
+}
+
+function rowsFromCells(cells) {
+  return DAY_ORDER.map((dayIndex) => ({
+    dayIndex,
+    label: DAY_LABELS[dayIndex],
+    cells: Array.from({ length: 24 }, (_, hour) => cells.get(`${dayIndex}-${hour}`)),
+  }));
+}
+
+function addSellToCells({ cells, transaction, profit, startDate, endDate }) {
+  if (!transaction?.date) return;
+
+  const localDate = toLocalDateKey(transaction.date);
+  if (startDate && localDate < startDate) return;
+  if (endDate && localDate > endDate) return;
+
+  const date = new Date(transaction.date);
+  if (Number.isNaN(date.getTime())) return;
+
+  const dayIndex = date.getDay();
+  const hour = date.getHours();
+  const cell = cells.get(`${dayIndex}-${hour}`);
+  if (!cell) return;
+
+  cell.profit += Number(profit) || 0;
+  cell.sellCount += 1;
+}
+
+function buildCellsFromTransactions({ transactions, profitHistory, startDate, endDate }) {
+  const cells = createEmptyRows();
+  const profitByTransaction = buildProfitByTransaction(profitHistory);
+
+  for (const transaction of transactions || []) {
+    if (transaction.type !== 'sell') continue;
+
+    const txKey = String(transaction.id);
+    const profit = transaction.profit ?? profitByTransaction.get(txKey);
+    if (profit == null) continue;
+
+    addSellToCells({
+      cells,
+      transaction,
+      profit,
+      startDate,
+      endDate,
+    });
+  }
+
+  return rowsFromCells(cells);
+}
+
+function buildCells({ transactions, profitHistory, startDate, endDate }) {
+  return buildCellsFromTransactions({
+    transactions,
+    profitHistory,
+    startDate,
+    endDate,
+  });
+}
+
+export default function HourlyProfitHeatmap({
+  transactions = [],
+  profitHistory = [],
+  timeframe,
+  numberFormat,
+  onCellClick,
+}) {
+  const tooltipRef = useRef(null);
+  const tooltipTitleRef = useRef(null);
+  const tooltipProfitRef = useRef(null);
+  const tooltipStatsRef = useRef(null);
+  const activeCellLabelRef = useRef(null);
+  const rows = useMemo(
+    () => buildCells({
+      transactions,
+      profitHistory,
+      startDate: timeframe?.start,
+      endDate: timeframe?.end,
+    }),
+    [transactions, profitHistory, timeframe?.start, timeframe?.end]
+  );
+  const values = useMemo(
+    () => rows.flatMap((row) => row.cells.map((cell) => cell.profit)),
+    [rows]
+  );
+  const positiveThresholds = useMemo(
+    () => buildThresholds(values.filter((value) => value > 0)),
+    [values]
+  );
+  const negativeThresholds = useMemo(
+    () => buildThresholds(values.filter((value) => value < 0).map((value) => Math.abs(value))),
+    [values]
+  );
+
+  const showCellDetail = (cell, x, y) => {
+    const profit = Number(cell.profit) || 0;
+    const sellCount = Number(cell.sellCount) || 0;
+    const average = sellCount > 0 ? profit / sellCount : 0;
+    const title = `${DAY_LABELS[cell.dayIndex]} ${hourLabel(cell.hour)}`;
+    const stats = `${sellCount} sells - avg ${formatNumber(average, numberFormat)}`;
+    const tooltip = tooltipPosition(x, y);
+
+    if (tooltipRef.current) {
+      tooltipRef.current.setAttribute('transform', `translate(${tooltip.x} ${tooltip.y})`);
+      tooltipRef.current.classList.add('is-visible');
+    }
+    if (tooltipTitleRef.current) tooltipTitleRef.current.textContent = title;
+    if (tooltipProfitRef.current) {
+      tooltipProfitRef.current.textContent = formatNumber(profit, numberFormat);
+      tooltipProfitRef.current.setAttribute('class', profit < 0 ? 'is-negative' : 'is-positive');
+    }
+    if (tooltipStatsRef.current) tooltipStatsRef.current.textContent = stats;
+    if (activeCellLabelRef.current) {
+      activeCellLabelRef.current.textContent = `${title}: ${formatNumber(profit, numberFormat)} across ${sellCount} sells`;
+    }
+  };
+
+  const hideCellDetail = () => {
+    tooltipRef.current?.classList.remove('is-visible');
+    if (activeCellLabelRef.current) activeCellLabelRef.current.textContent = '';
+  };
+
+  return (
+    <div className="analytics-widget">
+      <div className="analytics-widget-header">
+        <div>
+          <h3
+            className="analytics-widget-title has-tooltip"
+            data-tooltip="Realized stock profit grouped by transaction timestamp in your local timezone. Rows are weekdays and columns are local hours."
+          >
+            Profit by weekday and hour
+          </h3>
+          <p className="analytics-widget-subtitle">
+            Local timezone grouping for the selected timeframe.
+          </p>
+        </div>
+        <span
+          ref={activeCellLabelRef}
+          className="analytics-widget-subtitle hourly-profit-heatmap-active"
+          aria-live="polite"
+        />
+      </div>
+      <div className="hourly-profit-heatmap-wrap">
+        <svg
+          className="hourly-profit-heatmap-svg"
+          viewBox={`0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`}
+          width={SVG_WIDTH}
+          height={SVG_HEIGHT}
+          role="img"
+          aria-label="Realized profit by weekday and local hour"
+        >
+          {Array.from({ length: 24 }, (_, hour) => (
+            <text
+              key={hour}
+              className="hourly-profit-heatmap-hour"
+              x={LABEL_WIDTH + hour * (CELL_WIDTH + CELL_GAP) + CELL_WIDTH / 2}
+              y={16}
+              textAnchor="middle"
+            >
+              {hour}
+            </text>
+          ))}
+          {rows.map((row, rowIndex) => {
+            const y = TOP_LABEL_HEIGHT + rowIndex * (CELL_HEIGHT + CELL_GAP);
+
+            return (
+              <g key={row.dayIndex}>
+                <text
+                  className="hourly-profit-heatmap-day"
+                  x={LABEL_WIDTH - 10}
+                  y={y + 15}
+                  textAnchor="end"
+                >
+                  {row.label}
+                </text>
+                {row.cells.map((cell, hour) => {
+                  const x = LABEL_WIDTH + hour * (CELL_WIDTH + CELL_GAP);
+                  const label = `${DAY_LABELS[cell.dayIndex]} ${hourLabel(cell.hour)}: ${formatNumber(cell.profit, numberFormat)}, ${cell.sellCount} sells`;
+
+                  return (
+                    <rect
+                      key={`${row.dayIndex}-${hour}`}
+                      className="hourly-profit-heatmap-cell"
+                      x={x}
+                      y={y}
+                      width={CELL_WIDTH}
+                      height={CELL_HEIGHT}
+                      rx="3"
+                      fill={colorFor(cell.profit, positiveThresholds, negativeThresholds)}
+                      tabIndex="0"
+                      role="button"
+                      aria-label={label}
+                      onMouseEnter={() => showCellDetail(cell, x, y)}
+                      onMouseLeave={hideCellDetail}
+                      onFocus={() => showCellDetail(cell, x, y)}
+                      onBlur={hideCellDetail}
+                      onClick={() => onCellClick?.(cell)}
+                      onKeyDown={(event) => {
+                        if (event.key === 'Enter' || event.key === ' ') {
+                          event.preventDefault();
+                          onCellClick?.(cell);
+                        }
+                      }}
+                    />
+                  );
+                })}
+              </g>
+            );
+          })}
+          <g ref={tooltipRef} className="hourly-profit-heatmap-tooltip">
+            <rect width={TOOLTIP_WIDTH} height={TOOLTIP_HEIGHT} rx="6" />
+            <text ref={tooltipTitleRef} x="8" y="15" />
+            <text ref={tooltipProfitRef} x="8" y="32" />
+            <text ref={tooltipStatsRef} x="8" y="49" className="is-muted" />
+          </g>
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useNavigation.js
+++ b/src/hooks/useNavigation.js
@@ -14,7 +14,8 @@ const HISTORY_EMPTY_FILTERS = {
   type: 'all', mode: 'all', stockName: '', category: '',
   dateFrom: '', dateTo: '', gpMin: '', gpMax: '',
   priceMin: '', priceMax: '', profitMin: '', profitMax: '',
-  qtyMin: '', qtyMax: '', marginMin: '', marginMax: ''
+  qtyMin: '', qtyMax: '', marginMin: '', marginMax: '',
+  dayOfWeek: '', hourOfDay: ''
 };
 
 function getPageFromURL() {
@@ -28,19 +29,22 @@ function getPageFromURL() {
 }
 
 function filtersFromHistoryParams(params) {
+  const filters = { ...HISTORY_EMPTY_FILTERS };
+
   if (params.has('search')) {
-    return { ...HISTORY_EMPTY_FILTERS, stockName: params.get('search') };
+    filters.stockName = params.get('search') || '';
   }
 
   if (params.has('dateFrom') || params.has('dateTo')) {
-    return {
-      ...HISTORY_EMPTY_FILTERS,
-      dateFrom: params.get('dateFrom') || '',
-      dateTo: params.get('dateTo') || '',
-    };
+    filters.dateFrom = params.get('dateFrom') || '';
+    filters.dateTo = params.get('dateTo') || '';
   }
 
-  return { ...HISTORY_EMPTY_FILTERS };
+  if (params.has('type')) filters.type = params.get('type') || 'all';
+  if (params.has('dayOfWeek')) filters.dayOfWeek = params.get('dayOfWeek') || '';
+  if (params.has('hourOfDay')) filters.hourOfDay = params.get('hourOfDay') || '';
+
+  return filters;
 }
 
 export function useNavigation({

--- a/src/hooks/useSettings.js
+++ b/src/hooks/useSettings.js
@@ -68,7 +68,10 @@ export function useSettings(userId) {
           investmentStartDate: data.visible_columns?.investmentStartDate ?? true,
           membershipIcon: data.visible_columns?.membershipIcon ?? true,
         },
-        visibleProfits: data.visible_profits || DEFAULT_VISIBLE_PROFITS.bondsProfit,
+        visibleProfits: {
+          ...DEFAULT_VISIBLE_PROFITS,
+          ...(data.visible_profits || {})
+        },
         altAccountTimer: data.alt_account_timer,
         showCategoryStats: data.show_category_stats || false,
         showUnrealisedProfitStats: data.show_unrealised_profit_stats ?? false,

--- a/src/hooks/useTransactions.js
+++ b/src/hooks/useTransactions.js
@@ -22,7 +22,7 @@ export function useTransactions(userId) {
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(25);
   const [totalCount, setTotalCount] = useState(0);
-  const [filters, setFilters] = useState({ type: 'all', mode: 'all', stockName: '', category: '', dateFrom: '', dateTo: '', gpMin: '', gpMax: '', priceMin: '', priceMax: '', profitMin: '', profitMax: '', qtyMin: '', qtyMax: '', marginMin: '', marginMax: '' });
+  const [filters, setFilters] = useState({ type: 'all', mode: 'all', stockName: '', category: '', dateFrom: '', dateTo: '', gpMin: '', gpMax: '', priceMin: '', priceMax: '', profitMin: '', profitMax: '', qtyMin: '', qtyMax: '', marginMin: '', marginMax: '', dayOfWeek: '', hourOfDay: '' });
   const [sortConfig, setSortConfig] = useState({ key: 'date', dir: 'desc' });
   const [pagedTransactions, setPagedTransactions] = useState([]);
   const [pagedLoading, setPagedLoading] = useState(false);
@@ -101,12 +101,12 @@ export function useTransactions(userId) {
 
     const from = (targetPage - 1) * size;
     const to = from + size - 1;
+    const hasLocalTimeFilters = (activeFilters.dayOfWeek ?? '') !== '' || (activeFilters.hourOfDay ?? '') !== '';
 
     let query = supabase
       .from('transactions_view')
       .select('*', { count: 'exact' })
-      .eq('user_id', userId)
-      .range(from, to);
+      .eq('user_id', userId);
 
     // Apply sort
     const sortKey = activeSort.key || 'date';
@@ -134,6 +134,51 @@ export function useTransactions(userId) {
     }
     if (activeFilters.mode && activeFilters.mode !== 'all') {
       query = query.eq('is_investment', activeFilters.mode === 'investment');
+    }
+
+    if (!hasLocalTimeFilters) {
+      query = query.range(from, to);
+    }
+
+    if (hasLocalTimeFilters) {
+      const matchedRows = [];
+      let matchedCount = 0;
+      let scanFrom = 0;
+      let candidateCount = null;
+      let scanComplete = false;
+      const batchSize = 1000;
+
+      while (!scanComplete) {
+        const scanTo = scanFrom + batchSize - 1;
+        const { data, error, count } = await query.range(scanFrom, scanTo);
+
+        if (requestId !== pagedRequestId.current) return;
+
+        if (error) {
+          console.error('Error fetching paged transactions:', error.message, error.details, error.hint);
+          setPagedLoading(false);
+          return;
+        }
+
+        if (candidateCount == null) candidateCount = count || 0;
+
+        for (const row of (data || []).map(formatRow)) {
+          if (!matchesLocalTimeFilters(row, activeFilters)) continue;
+
+          if (matchedCount >= from && matchedRows.length < size) {
+            matchedRows.push(row);
+          }
+          matchedCount += 1;
+        }
+
+        scanFrom += batchSize;
+        scanComplete = (data || []).length < batchSize || scanFrom >= candidateCount;
+      }
+
+      setPagedTransactions(matchedRows);
+      setTotalCount(matchedCount);
+      setPagedLoading(false);
+      return;
     }
 
     const { data, error, count } = await query;
@@ -176,7 +221,7 @@ export function useTransactions(userId) {
 
   const resetPaged = useCallback(() => {
     const defaultSort = { key: 'date', dir: 'desc' };
-    const defaultFilters = { type: 'all', mode: 'all', stockName: '', category: '', dateFrom: '', dateTo: '', gpMin: '', gpMax: '', priceMin: '', priceMax: '', profitMin: '', profitMax: '', qtyMin: '', qtyMax: '', marginMin: '', marginMax: '' };
+    const defaultFilters = { type: 'all', mode: 'all', stockName: '', category: '', dateFrom: '', dateTo: '', gpMin: '', gpMax: '', priceMin: '', priceMax: '', profitMin: '', profitMax: '', qtyMin: '', qtyMax: '', marginMin: '', marginMax: '', dayOfWeek: '', hourOfDay: '' };
     setSortConfig(defaultSort);
     setFilters(defaultFilters);
     setPage(1);
@@ -344,4 +389,24 @@ function dbColumn(key) {
     margin: 'margin'
   };
   return map[key] || 'date';
+}
+
+function matchesLocalTimeFilters(row, filters) {
+  const dayOfWeek = filters.dayOfWeek ?? '';
+  const hourOfDay = filters.hourOfDay ?? '';
+
+  if (dayOfWeek === '' && hourOfDay === '') return true;
+
+  const date = new Date(row.date);
+  if (Number.isNaN(date.getTime())) return false;
+
+  if (dayOfWeek !== '' && date.getDay() !== Number(dayOfWeek)) {
+    return false;
+  }
+
+  if (hourOfDay !== '' && date.getHours() !== Number(hourOfDay)) {
+    return false;
+  }
+
+  return true;
 }

--- a/src/hooks/useTransactions.js
+++ b/src/hooks/useTransactions.js
@@ -26,6 +26,8 @@ export function useTransactions(userId) {
   const [sortConfig, setSortConfig] = useState({ key: 'date', dir: 'desc' });
   const [pagedTransactions, setPagedTransactions] = useState([]);
   const [pagedLoading, setPagedLoading] = useState(false);
+  const [historySource, setHistorySource] = useState('transactions');
+  const [historyProfitTypes, setHistoryProfitTypes] = useState(['dump', 'referral', 'bonds']);
   const pagedRequestId = useRef(0);
 
   const fetchTransactions = useCallback(async (options = {}) => {
@@ -93,7 +95,14 @@ export function useTransactions(userId) {
   const loadFullHistory = useCallback(() => fetchTransactions({ full: true }), [fetchTransactions]);
 
   // Paginated fetch - used by HistoryPage
-  const fetchPage = useCallback(async (targetPage, size, activeFilters, activeSort = sortConfig) => {
+  const fetchPage = useCallback(async (
+    targetPage,
+    size,
+    activeFilters,
+    activeSort = sortConfig,
+    activeSource = historySource,
+    activeProfitTypes = historyProfitTypes
+  ) => {
     if (!userId) return;
     const requestId = pagedRequestId.current + 1;
     pagedRequestId.current = requestId;
@@ -102,6 +111,96 @@ export function useTransactions(userId) {
     const from = (targetPage - 1) * size;
     const to = from + size - 1;
     const hasLocalTimeFilters = (activeFilters.dayOfWeek ?? '') !== '' || (activeFilters.hourOfDay ?? '') !== '';
+
+    if (activeSource === 'profits') {
+      const visibleProfitTypes = activeProfitTypes.filter(Boolean);
+
+      if (visibleProfitTypes.length === 0) {
+        setPagedTransactions([]);
+        setTotalCount(0);
+        setPagedLoading(false);
+        return;
+      }
+
+      let query = supabase
+        .from('profit_history')
+        .select('*', { count: 'exact' })
+        .eq('user_id', userId)
+        .in('profit_type', visibleProfitTypes);
+
+      const sortKey = activeSort.key || 'date';
+      const ascending = activeSort.dir === 'asc';
+
+      query = query.order(profitHistoryColumn(sortKey), { ascending, nullsFirst: ascending });
+
+      if (visibleProfitTypes.includes(activeFilters.type)) {
+        query = query.eq('profit_type', activeFilters.type);
+      }
+      if (activeFilters.dateFrom) query = query.gte('created_at', activeFilters.dateFrom);
+      if (activeFilters.dateTo) query = query.lte('created_at', activeFilters.dateTo + 'T23:59:59');
+      if (activeFilters.gpMin) query = query.gte('amount', Number(activeFilters.gpMin));
+      if (activeFilters.gpMax) query = query.lte('amount', Number(activeFilters.gpMax));
+      if (activeFilters.profitMin) query = query.gte('amount', Number(activeFilters.profitMin));
+      if (activeFilters.profitMax) query = query.lte('amount', Number(activeFilters.profitMax));
+
+      if (!hasLocalTimeFilters) {
+        query = query.range(from, to);
+      }
+
+      if (hasLocalTimeFilters) {
+        const matchedRows = [];
+        let matchedCount = 0;
+        let scanFrom = 0;
+        let candidateCount = null;
+        let scanComplete = false;
+        const batchSize = 1000;
+
+        while (!scanComplete) {
+          const scanTo = scanFrom + batchSize - 1;
+          const { data, error, count } = await query.range(scanFrom, scanTo);
+
+          if (requestId !== pagedRequestId.current) return;
+
+          if (error) {
+            console.error('Error fetching paged profit history:', error.message, error.details, error.hint);
+            setPagedLoading(false);
+            return;
+          }
+
+          if (candidateCount == null) candidateCount = count || 0;
+
+          for (const row of (data || []).map(formatProfitRow)) {
+            if (!matchesLocalTimeFilters(row, activeFilters)) continue;
+
+            if (matchedCount >= from && matchedRows.length < size) {
+              matchedRows.push(row);
+            }
+            matchedCount += 1;
+          }
+
+          scanFrom += batchSize;
+          scanComplete = (data || []).length < batchSize || scanFrom >= candidateCount;
+        }
+
+        setPagedTransactions(matchedRows);
+        setTotalCount(matchedCount);
+        setPagedLoading(false);
+        return;
+      }
+
+      const { data, error, count } = await query;
+
+      if (requestId !== pagedRequestId.current) return;
+
+      if (error) {
+        console.error('Error fetching paged profit history:', error.message, error.details, error.hint);
+      } else {
+        setPagedTransactions((data || []).map(formatProfitRow));
+        setTotalCount(count || 0);
+      }
+      setPagedLoading(false);
+      return;
+    }
 
     let query = supabase
       .from('transactions_view')
@@ -192,32 +291,32 @@ export function useTransactions(userId) {
       setTotalCount(count || 0);
     }
     setPagedLoading(false);
-  }, [userId]);
+  }, [userId, historySource, historyProfitTypes, sortConfig]);
 
   const goToPage = useCallback((targetPage) => {
     setPage(targetPage);
-    fetchPage(targetPage, pageSize, filters);
-  }, [fetchPage, pageSize, filters]);
+    fetchPage(targetPage, pageSize, filters, sortConfig, historySource, historyProfitTypes);
+  }, [fetchPage, pageSize, filters, sortConfig, historySource, historyProfitTypes]);
 
   const changePageSize = useCallback((size) => {
     setPageSize(size);
     setPage(1);
-    fetchPage(1, size, filters);
-  }, [fetchPage, filters]);
+    fetchPage(1, size, filters, sortConfig, historySource, historyProfitTypes);
+  }, [fetchPage, filters, sortConfig, historySource, historyProfitTypes]);
 
   const applyFilters = useCallback((newFilters) => {
     setFilters(newFilters);
     setPage(1);
-    fetchPage(1, pageSize, newFilters);
-  }, [fetchPage, pageSize]);
+    fetchPage(1, pageSize, newFilters, sortConfig, historySource, historyProfitTypes);
+  }, [fetchPage, pageSize, sortConfig, historySource, historyProfitTypes]);
 
-  const initPaged = useCallback(() => fetchPage(1, pageSize, filters), [fetchPage, pageSize, filters]);
+  const initPaged = useCallback(() => fetchPage(1, pageSize, filters, sortConfig, historySource, historyProfitTypes), [fetchPage, pageSize, filters, sortConfig, historySource, historyProfitTypes]);
 
   const applySort = useCallback((newSort) => {
     setSortConfig(newSort);
     setPage(1);
-    fetchPage(1, pageSize, filters, newSort);
-  }, [fetchPage, pageSize, filters]);
+    fetchPage(1, pageSize, filters, newSort, historySource, historyProfitTypes);
+  }, [fetchPage, pageSize, filters, historySource, historyProfitTypes]);
 
   const resetPaged = useCallback(() => {
     const defaultSort = { key: 'date', dir: 'desc' };
@@ -225,8 +324,45 @@ export function useTransactions(userId) {
     setSortConfig(defaultSort);
     setFilters(defaultFilters);
     setPage(1);
-    fetchPage(1, pageSize, defaultFilters, defaultSort);
-  }, [fetchPage, pageSize]);
+    fetchPage(1, pageSize, defaultFilters, defaultSort, historySource, historyProfitTypes);
+  }, [fetchPage, pageSize, historySource, historyProfitTypes]);
+
+  const changeHistorySource = useCallback((source) => {
+    const defaultSort = { key: 'date', dir: 'desc' };
+    const sourceFilters = {
+      type: 'all',
+      mode: 'all',
+      stockName: '',
+      category: '',
+      priceMin: '',
+      priceMax: '',
+      qtyMin: '',
+      qtyMax: '',
+      marginMin: '',
+      marginMax: ''
+    };
+    const nextFilters = { ...filters, ...sourceFilters };
+    setHistorySource(source);
+    setSortConfig(defaultSort);
+    setFilters(nextFilters);
+    setPage(1);
+    fetchPage(1, pageSize, nextFilters, defaultSort, source, historyProfitTypes);
+  }, [fetchPage, pageSize, filters, historyProfitTypes]);
+
+  const changeHistoryProfitTypes = useCallback((types) => {
+    const nextTypes = types.length > 0 ? types : [];
+    const nextFilters = nextTypes.includes(filters.type)
+      ? filters
+      : { ...filters, type: 'all' };
+
+    setHistoryProfitTypes(nextTypes);
+
+    if (historySource === 'profits') {
+      if (nextFilters !== filters) setFilters(nextFilters);
+      setPage(1);
+      fetchPage(1, pageSize, nextFilters, sortConfig, historySource, nextTypes);
+    }
+  }, [fetchPage, filters, historySource, pageSize, sortConfig]);
 
   const addTransaction = useCallback(async (transaction) => {
     const dbTransaction = {
@@ -338,14 +474,14 @@ export function useTransactions(userId) {
 
       // 4. Refresh local state
       await fetchTransactions();
-      await fetchPage(1, pageSize, filters);
+      await fetchPage(1, pageSize, filters, sortConfig, historySource, historyProfitTypes);
 
       return { success: true };
     } catch (err) {
       console.error('Error undoing transaction:', err);
       return { success: false, error: err.message };
     }
-  }, [userId, fetchTransactions, fetchPage, pageSize, filters]);
+  }, [userId, fetchTransactions, fetchPage, pageSize, filters, sortConfig, historySource, historyProfitTypes]);
 
   return {
     // Original API - unchanged
@@ -353,7 +489,8 @@ export function useTransactions(userId) {
     loadFullHistory, fullHistoryLoading, historyScope,
     // Paginated API - for HistoryPage
     pagedTransactions, pagedLoading, totalCount, totalPages,
-    page, pageSize, filters,
+    page, pageSize, filters, historySource, changeHistorySource,
+    historyProfitTypes, changeHistoryProfitTypes,
     goToPage, changePageSize, applyFilters, initPaged,
     sortConfig, applySort, resetPaged, undoTransaction
   };
@@ -362,6 +499,7 @@ export function useTransactions(userId) {
 function formatRow(t) {
   return {
     id: Number(t.id),
+    activityKind: 'transaction',
     stockId: t.stock_id,
     stockName: t.stock_name,
     type: t.type,
@@ -374,6 +512,35 @@ function formatRow(t) {
     profit: t.profit ?? null,
     margin: t.margin ?? null
   };
+}
+
+function formatProfitRow(row) {
+  const amount = Number(row.amount || 0);
+
+  return {
+    id: Number(row.id),
+    activityKind: 'profit',
+    stockId: row.stock_id ?? null,
+    stockName: profitTypeLabel(row.profit_type),
+    type: row.profit_type,
+    shares: null,
+    price: null,
+    total: amount,
+    date: row.created_at,
+    category: 'Extra Profit',
+    profitHistoryId: null,
+    profit: amount,
+    margin: null
+  };
+}
+
+function profitTypeLabel(type) {
+  const labels = {
+    dump: 'Dump profit',
+    referral: 'Referral profit',
+    bonds: 'Bond profit'
+  };
+  return labels[type] || 'Extra profit';
 }
 
 function dbColumn(key) {
@@ -389,6 +556,18 @@ function dbColumn(key) {
     margin: 'margin'
   };
   return map[key] || 'date';
+}
+
+function profitHistoryColumn(key) {
+  const map = {
+    stockName: 'profit_type',
+    total: 'amount',
+    date: 'created_at',
+    type: 'profit_type',
+    category: 'profit_type',
+    profit: 'amount'
+  };
+  return map[key] || 'created_at';
 }
 
 function matchesLocalTimeFilters(row, filters) {

--- a/src/pages/AnalyticsPage.jsx
+++ b/src/pages/AnalyticsPage.jsx
@@ -204,8 +204,8 @@ export default function AnalyticsPage({
             stocks={safeStocksForStats}
             profitHistory={safeProfitHistory}
             numberFormat={numberFormat}
-            onNavigateToHistory={(dateFrom, dateTo = dateFrom) => navigateToPage?.('history', {
-              query: { dateFrom, dateTo },
+            onNavigateToHistory={(dateFrom, dateTo = dateFrom, extraFilters = {}) => navigateToPage?.('history', {
+              query: { dateFrom, dateTo, ...extraFilters },
             })}
             allTimeBuckets={allTime.buckets}
             totalProfitValue={derivedTotalProfit}

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -29,6 +29,30 @@ const EMPTY_FILTERS = {
   hourOfDay: ''
 };
 
+const TRANSACTION_TYPES = ['all', 'buy', 'sell', 'remove'];
+const PROFIT_TYPES = ['all', 'dump', 'referral', 'bonds'];
+
+function visibleProfitTypes(visibleProfits = {}) {
+  return [
+    visibleProfits.dumpProfit !== false ? 'dump' : null,
+    visibleProfits.referralProfit !== false ? 'referral' : null,
+    visibleProfits.bondsProfit !== false ? 'bonds' : null
+  ].filter(Boolean);
+}
+
+function typeLabel(type) {
+  const labels = {
+    all: 'All',
+    buy: 'Buys',
+    sell: 'Sales',
+    remove: 'Removes',
+    dump: 'Dumps',
+    referral: 'Referrals',
+    bonds: 'Bonds'
+  };
+  return labels[type] || type;
+}
+
 function hasAnyFilter(filters = EMPTY_FILTERS) {
   return Boolean(
     filters.stockName || filters.category ||
@@ -62,6 +86,9 @@ function hasVisibleFilter(filters = EMPTY_FILTERS) {
 export default function HistoryPage({
   pagedTransactions = [], pagedLoading = false, totalCount = 0, totalPages = 0,
   page = 1, pageSize = 25, filters = EMPTY_FILTERS,
+  historySource = 'transactions', onChangeHistorySource,
+  historyProfitTypes = ['dump', 'referral', 'bonds'], onChangeHistoryProfitTypes,
+  visibleProfits = {},
   onGoToPage, onChangePageSize, onApplyFilters, onInit, numberFormat,
   sortConfig = { key: 'date', dir: 'desc' },
   onApplySort, onReset, onUndo, showMembershipIcon = true
@@ -74,6 +101,10 @@ export default function HistoryPage({
     () => Object.fromEntries(stocks.map(s => [s.id, s.itemId])),
     [stocks]
   );
+  const enabledProfitTypes = useMemo(
+    () => visibleProfitTypes(visibleProfits),
+    [visibleProfits]
+  );
 
   const [localFilters, setLocalFilters] = useState({ ...EMPTY_FILTERS, ...filters });
   const [appliedFilters, setAppliedFilters] = useState({ ...EMPTY_FILTERS, ...filters });
@@ -84,6 +115,15 @@ export default function HistoryPage({
     setAppliedFilters({ ...EMPTY_FILTERS, ...filters });
     if (hasAnyFilter(filters)) setShowFilters(true);
   }, [filters]);
+
+  useEffect(() => {
+    const sameTypes = enabledProfitTypes.length === historyProfitTypes.length
+      && enabledProfitTypes.every(type => historyProfitTypes.includes(type));
+
+    if (!sameTypes) {
+      onChangeHistoryProfitTypes(enabledProfitTypes);
+    }
+  }, [enabledProfitTypes, historyProfitTypes, onChangeHistoryProfitTypes]);
 
   const [confirmUndo, setConfirmUndo] = useState(null); // holds transaction to undo
   const [undoWarning, setUndoWarning] = useState(null); // holds warning type
@@ -116,10 +156,17 @@ export default function HistoryPage({
   };
 
   const handleSort = (key) => {
+    if (historySource === 'profits' && ['shares', 'price', 'margin'].includes(key)) return;
+
     onApplySort({
       key,
       dir: sortConfig.key === key && sortConfig.dir === 'asc' ? 'desc' : 'asc'
     });
+  };
+
+  const handleSourceChange = (source) => {
+    if (source === historySource) return;
+    onChangeHistorySource(source);
   };
 
   const SortIcon = ({ col }) => {
@@ -143,6 +190,11 @@ export default function HistoryPage({
   const hasActiveFilters = hasVisibleFilter(appliedFilters);
   // Derive categories from existing transactions for the filter dropdown
   const categories = [...new Set(stocks.map(s => s.category).filter(Boolean))].sort();
+  const typeFilters = historySource === 'profits'
+    ? ['all', ...PROFIT_TYPES.filter(type => type !== 'all' && enabledProfitTypes.includes(type))]
+    : TRANSACTION_TYPES;
+  const subtitleLabel = historySource === 'profits' ? 'extra profit entries' : 'transactions';
+  const isExtraProfits = historySource === 'profits';
 
   return (
     <div className="history-page">
@@ -150,9 +202,23 @@ export default function HistoryPage({
       <div className="history-header">
         <div className="history-header-left">
           <h1 className="history-title">📜 Transaction History</h1>
-          <p className="history-subtitle">{totalCount.toLocaleString()} total transactions</p>
+          <p className="history-subtitle">{totalCount.toLocaleString()} total {subtitleLabel}</p>
         </div>
         <div className="history-controls">
+          <div className="history-source-toggle" aria-label="History source">
+            <button
+              className={`history-source-btn ${historySource === 'transactions' ? 'history-source-btn--active' : ''}`}
+              onClick={() => handleSourceChange('transactions')}
+            >
+              GE Items
+            </button>
+            <button
+              className={`history-source-btn ${historySource === 'profits' ? 'history-source-btn--active' : ''}`}
+              onClick={() => handleSourceChange('profits')}
+            >
+              Extra Profits
+            </button>
+          </div>
           <button
             className={`history-filter-toggle ${showFilters ? 'history-filter-toggle--active' : ''} ${hasActiveFilters ? 'history-filter-toggle--has-filters' : ''}`}
             onClick={() => setShowFilters(prev => !prev)}
@@ -179,32 +245,35 @@ export default function HistoryPage({
         <div className="history-filter-panel">
           <div className="history-filter-row">
 
-            <div className="history-filter-field">
-              <label className="history-filter-label">Item Name</label>
-              <input
-                className="history-search"
-                placeholder="Search item..."
-                value={localFilters.stockName}
-                onChange={e => setLocalFilters(prev => ({ ...prev, stockName: e.target.value }))}
-              />
-            </div>
+            {historySource === 'transactions' && (
+              <div className="history-filter-field">
+                <label className="history-filter-label">Item Name</label>
+                <input
+                  className="history-search"
+                  placeholder="Search item..."
+                  value={localFilters.stockName}
+                  onChange={e => setLocalFilters(prev => ({ ...prev, stockName: e.target.value }))}
+                />
+              </div>
+            )}
 
             <div className="history-filter-field">
               <label className="history-filter-label">Type</label>
               <div className="history-filter-group">
-                {['all', 'buy', 'sell', 'remove'].map(f => (
+                {typeFilters.map(f => (
                   <button
                     key={f}
                     className={`history-filter-btn history-filter-btn--${f} ${localFilters.type === f ? 'history-filter-btn--active' : ''}`}
                     onClick={() => setLocalFilters(prev => ({ ...prev, type: f }))}
                   >
-                    {f === 'all' ? 'All' : f === 'buy' ? 'Buys' : f === 'sell' ? 'Sales' : 'Removes'}
+                    {typeLabel(f)}
                   </button>
                 ))}
               </div>
             </div>
 
-            <div className="history-filter-field">
+            {historySource === 'transactions' && (
+              <div className="history-filter-field">
               <label className="history-filter-label">Mode</label>
               <div className="history-filter-group">
                 {['all', 'trade', 'investment'].map(m => (
@@ -217,9 +286,11 @@ export default function HistoryPage({
                   </button>
                 ))}
               </div>
-            </div>
+              </div>
+            )}
 
-            <div className="history-filter-field">
+            {historySource === 'transactions' && (
+              <div className="history-filter-field">
               <label className="history-filter-label">Category</label>
               <select
                 className="history-page-size"
@@ -231,7 +302,8 @@ export default function HistoryPage({
                   <option key={c} value={c}>{c}</option>
                 ))}
               </select>
-            </div>
+              </div>
+            )}
 
             <div className="history-filter-field">
               <label className="history-filter-label">Date From</label>
@@ -254,17 +326,19 @@ export default function HistoryPage({
             </div>
 
             <div className="history-filter-field">
-              <label className="history-filter-label">Total GP Min</label>
+              <label className="history-filter-label">{historySource === 'profits' ? 'Amount Min' : 'Total GP Min'}</label>
               <input type="number" className="history-search" placeholder="0"
                 value={localFilters.gpMin}
                 onChange={e => setLocalFilters(prev => ({ ...prev, gpMin: e.target.value }))} />
             </div>
             <div className="history-filter-field">
-              <label className="history-filter-label">Total GP Max</label>
+              <label className="history-filter-label">{historySource === 'profits' ? 'Amount Max' : 'Total GP Max'}</label>
               <input type="number" className="history-search" placeholder="Any"
                 value={localFilters.gpMax}
                 onChange={e => setLocalFilters(prev => ({ ...prev, gpMax: e.target.value }))} />
             </div>
+            {historySource === 'transactions' && (
+              <>
             <div className="history-filter-field">
               <label className="history-filter-label">Price Min</label>
               <input type="number" className="history-search" placeholder="0"
@@ -313,6 +387,8 @@ export default function HistoryPage({
                 value={localFilters.marginMax}
                 onChange={e => setLocalFilters(prev => ({ ...prev, marginMax: e.target.value }))} />
             </div>
+              </>
+            )}
 
           </div>
 
@@ -335,95 +411,125 @@ export default function HistoryPage({
               <th className="history-th--sortable" onClick={() => handleSort('date')} title="When this trade happened">
                 Date <SortIcon col="date" />
               </th>
-              <th className="history-th--sortable" onClick={() => handleSort('stockName')} title="Item that was traded">
-                Item <SortIcon col="stockName" />
-              </th>
+              {!isExtraProfits && (
+                <>
+                  <th className="history-th--sortable" onClick={() => handleSort('stockName')} title="Item that was traded">
+                    Item <SortIcon col="stockName" />
+                  </th>
+                </>
+              )}
               <th className="history-th--sortable" onClick={() => handleSort('type')} title="Buy, sell, or adjust">
                 Type <SortIcon col="type" />
               </th>
-              <th className="history-th--right history-th--sortable" onClick={() => handleSort('shares')} title="Number of items traded">
-                Qty <SortIcon col="shares" />
+              {!isExtraProfits && (
+                <>
+                  <th className="history-th--right history-th--sortable" onClick={() => handleSort('shares')} title="Number of items traded">
+                    Qty <SortIcon col="shares" />
+                  </th>
+                  <th className="history-th--right history-th--sortable" onClick={() => handleSort('price')} title="Price per item">
+                    Price Each <SortIcon col="price" />
+                  </th>
+                </>
+              )}
+              <th className="history-th--right history-th--sortable" onClick={() => handleSort('total')} title={isExtraProfits ? 'Extra profit amount' : 'Total GP for this trade'}>
+                {isExtraProfits ? 'Amount' : 'Total'} <SortIcon col="total" />
               </th>
-              <th className="history-th--right history-th--sortable" onClick={() => handleSort('price')} title="Price per item">
-                Price Each <SortIcon col="price" />
-              </th>
-              <th className="history-th--right history-th--sortable" onClick={() => handleSort('total')} title="Total GP for this trade">
-                Total <SortIcon col="total" />
-              </th>
-              <th className="history-th--right history-th--sortable" onClick={() => handleSort('profit')} title="Profit made on this sale">
-                Profit <SortIcon col="profit" />
-              </th>
-              <th className="history-th--right history-th--sortable" onClick={() => handleSort('margin')} title="Profit margin %">
-                Margin <SortIcon col="margin" />
-              </th>
-              <th className="history-th--sortable" onClick={() => handleSort('category')} title="Category this item is in">
-                Category <SortIcon col="category" />
-              </th>
-              <th title="Undo this trade">Undo</th>
+              {!isExtraProfits && (
+                <>
+                  <th className="history-th--right history-th--sortable" onClick={() => handleSort('profit')} title="Profit made on this sale">
+                    Profit <SortIcon col="profit" />
+                  </th>
+                  <th className="history-th--right history-th--sortable" onClick={() => handleSort('margin')} title="Profit margin %">
+                    Margin <SortIcon col="margin" />
+                  </th>
+                  <th className="history-th--sortable" onClick={() => handleSort('category')} title="Category this item is in">
+                    Category <SortIcon col="category" />
+                  </th>
+                  <th title="Undo this trade">Undo</th>
+                </>
+              )}
             </tr>
           </thead>
           <tbody>
             {pagedLoading ? (
-              <tr><td colSpan={10} className="history-empty">Loading...</td></tr>
+              <tr><td colSpan={isExtraProfits ? 3 : 10} className="history-empty">Loading...</td></tr>
             ) : displayRows.length === 0 ? (
-              <tr><td colSpan={10} className="history-empty">No transactions found</td></tr>
+              <tr><td colSpan={isExtraProfits ? 3 : 10} className="history-empty">No history found</td></tr>
             ) : displayRows.map(t => (
-              <tr key={t.id} className={`history-row history-row--${t.type}`}>
+              <tr key={`${t.activityKind || 'transaction'}-${t.id}`} className={`history-row history-row--${t.type}`}>
                 <td className="history-cell history-cell--date">
                   {new Date(t.date).toLocaleDateString()}
                   <span className="history-time"> {new Date(t.date).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
                 </td>
-                <td className="history-cell history-cell--name">
-                  <span className="history-item-name">
-                    {stockItemIdMap[t.stockId] && (
-                      <ItemIcon
-                        src={geIconMap[stockItemIdMap[t.stockId]]}
-                        alt=""
-                        className="history-item-icon"
-                        fallbackText={t.stockName}
-                      />
-                    )}
-                    {showMembershipIcon && stockItemIdMap[t.stockId] && stockItemIdMap[t.stockId] in membershipMap && (
-                      <Star
-                        className={`members-star ${membershipMap[stockItemIdMap[t.stockId]] ? 'members-star--p2p' : 'members-star--f2p'}`}
-                        size={12}
-                        fill="currentColor"
-                        title={membershipMap[stockItemIdMap[t.stockId]] ? 'Members item' : 'Free-to-play item'}
-                      />
-                    )}
-                    {t.stockName}
-                  </span>
-                </td>
+                {!isExtraProfits && (
+                  <td className="history-cell history-cell--name">
+                    <span className="history-item-name">
+                      {stockItemIdMap[t.stockId] && (
+                        <ItemIcon
+                          src={geIconMap[stockItemIdMap[t.stockId]]}
+                          alt=""
+                          className="history-item-icon"
+                          fallbackText={t.stockName}
+                        />
+                      )}
+                      {showMembershipIcon && stockItemIdMap[t.stockId] && stockItemIdMap[t.stockId] in membershipMap && (
+                        <Star
+                          className={`members-star ${membershipMap[stockItemIdMap[t.stockId]] ? 'members-star--p2p' : 'members-star--f2p'}`}
+                          size={12}
+                          fill="currentColor"
+                          title={membershipMap[stockItemIdMap[t.stockId]] ? 'Members item' : 'Free-to-play item'}
+                        />
+                      )}
+                      {t.stockName}
+                    </span>
+                  </td>
+                )}
                 <td className="history-cell">
                   <span className={`history-type-badge history-type-badge--${t.type}`}>
-                    {t.type.toUpperCase()}
+                    {typeLabel(t.type).toUpperCase()}
                   </span>
                 </td>
-                <td className="history-cell history-cell--right" title={formatNumber(t.shares, 'full')}>{t.shares.toLocaleString()}</td>
-                <td className="history-cell history-cell--right" title={formatNumber(t.price, 'full')}>{t.price.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
-                <td className="history-cell history-cell--right" title={formatNumber(t.total, 'full')}>{formatNumber(t.total, numberFormat)}</td>
-                <td className="history-cell history-cell--right" title={t.type === 'sell' && t.profit != null ? formatNumber(t.profit, 'full') : undefined}>
-                  {t.type === 'sell' && t.profit != null
-                    ? <span className={t.profit >= 0 ? 'history-total--buy' : 'history-total--sell'}>{formatNumber(t.profit, numberFormat)}</span>
-                    : <span className="history-cell--muted">—</span>
-                  }
+                {!isExtraProfits && (
+                  <>
+                    <td className="history-cell history-cell--right" title={formatNumber(t.shares, 'full')}>{t.shares.toLocaleString()}</td>
+                    <td className="history-cell history-cell--right" title={formatNumber(t.price, 'full')}>{t.price.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+                  </>
+                )}
+                <td className="history-cell history-cell--right" title={formatNumber(t.total, 'full')}>
+                  {isExtraProfits ? (
+                    <span className={t.total >= 0 ? 'history-total--buy' : 'history-total--sell'}>
+                      {formatNumber(t.total, numberFormat)}
+                    </span>
+                  ) : (
+                    formatNumber(t.total, numberFormat)
+                  )}
                 </td>
-                <td className="history-cell history-cell--right">
-                  {t.type === 'sell' && t.margin != null
-                    ? <span className={t.margin >= 0 ? 'history-total--buy' : 'history-total--sell'}>{t.margin.toFixed(1)}%</span>
-                    : <span className="history-cell--muted">—</span>
-                  }
-                </td>
-                <td className="history-cell">{t.category}</td>
-                <td className="history-cell">
-                  <button
-                    className="history-undo-btn"
-                    onClick={() => handleUndo(t)}
-                    title="Undo transaction"
-                  >
-                    ↩
-                  </button>
-                </td>
+                {!isExtraProfits && (
+                  <>
+                    <td className="history-cell history-cell--right" title={t.type === 'sell' && t.profit != null ? formatNumber(t.profit, 'full') : undefined}>
+                      {t.type === 'sell' && t.profit != null
+                        ? <span className={t.profit >= 0 ? 'history-total--buy' : 'history-total--sell'}>{formatNumber(t.profit, numberFormat)}</span>
+                        : <span className="history-cell--muted">—</span>
+                      }
+                    </td>
+                    <td className="history-cell history-cell--right">
+                      {t.type === 'sell' && t.margin != null
+                        ? <span className={t.margin >= 0 ? 'history-total--buy' : 'history-total--sell'}>{t.margin.toFixed(1)}%</span>
+                        : <span className="history-cell--muted">—</span>
+                      }
+                    </td>
+                    <td className="history-cell">{t.category}</td>
+                    <td className="history-cell">
+                      <button
+                        className="history-undo-btn"
+                        onClick={() => handleUndo(t)}
+                        title="Undo transaction"
+                      >
+                        ↩
+                      </button>
+                    </td>
+                  </>
+                )}
               </tr>
             ))}
           </tbody>

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -24,8 +24,40 @@ const EMPTY_FILTERS = {
   qtyMin: '',
   qtyMax: '',
   marginMin: '',
-  marginMax: ''
+  marginMax: '',
+  dayOfWeek: '',
+  hourOfDay: ''
 };
+
+function hasAnyFilter(filters = EMPTY_FILTERS) {
+  return Boolean(
+    filters.stockName || filters.category ||
+    filters.dateFrom || filters.dateTo ||
+    filters.gpMin || filters.gpMax ||
+    filters.priceMin || filters.priceMax ||
+    filters.profitMin || filters.profitMax ||
+    filters.qtyMin || filters.qtyMax ||
+    filters.marginMin || filters.marginMax ||
+    (filters.dayOfWeek ?? '') !== '' ||
+    (filters.hourOfDay ?? '') !== '' ||
+    (filters.type || 'all') !== 'all' ||
+    (filters.mode || 'all') !== 'all'
+  );
+}
+
+function hasVisibleFilter(filters = EMPTY_FILTERS) {
+  return Boolean(
+    filters.stockName || filters.category ||
+    filters.dateFrom || filters.dateTo ||
+    filters.gpMin || filters.gpMax ||
+    filters.priceMin || filters.priceMax ||
+    filters.profitMin || filters.profitMax ||
+    filters.qtyMin || filters.qtyMax ||
+    filters.marginMin || filters.marginMax ||
+    (filters.type || 'all') !== 'all' ||
+    (filters.mode || 'all') !== 'all'
+  );
+}
 
 export default function HistoryPage({
   pagedTransactions = [], pagedLoading = false, totalCount = 0, totalPages = 0,
@@ -50,8 +82,8 @@ export default function HistoryPage({
   useEffect(() => {
     setLocalFilters({ ...EMPTY_FILTERS, ...filters });
     setAppliedFilters({ ...EMPTY_FILTERS, ...filters });
-    if (filters.stockName) setShowFilters(true);
-  }, [filters.stockName]);
+    if (hasAnyFilter(filters)) setShowFilters(true);
+  }, [filters]);
 
   const [confirmUndo, setConfirmUndo] = useState(null); // holds transaction to undo
   const [undoWarning, setUndoWarning] = useState(null); // holds warning type
@@ -108,15 +140,7 @@ export default function HistoryPage({
     return pages;
   };
 
-  const hasActiveFilters = appliedFilters.stockName || appliedFilters.category ||
-    appliedFilters.dateFrom || appliedFilters.dateTo ||
-    appliedFilters.gpMin || appliedFilters.gpMax ||
-    appliedFilters.priceMin || appliedFilters.priceMax ||
-    appliedFilters.profitMin || appliedFilters.profitMax ||
-    appliedFilters.qtyMin || appliedFilters.qtyMax ||
-    appliedFilters.marginMin || appliedFilters.marginMax ||
-    appliedFilters.type !== 'all' ||
-    appliedFilters.mode !== 'all';
+  const hasActiveFilters = hasVisibleFilter(appliedFilters);
   // Derive categories from existing transactions for the filter dropdown
   const categories = [...new Set(stocks.map(s => s.category).filter(Boolean))].sort();
 

--- a/src/styles/analytics-widgets.css
+++ b/src/styles/analytics-widgets.css
@@ -832,6 +832,80 @@
   fill: rgb(248, 113, 113);
 }
 
+.hourly-profit-heatmap-wrap {
+  overflow-x: auto;
+  padding-bottom: 0.5rem;
+}
+
+.hourly-profit-heatmap-svg {
+  display: block;
+  width: auto;
+  max-width: none;
+  height: auto;
+}
+
+.hourly-profit-heatmap-hour,
+.hourly-profit-heatmap-day {
+  fill: rgb(148, 163, 184);
+  font-size: 0.6875rem;
+  font-weight: 700;
+}
+
+.hourly-profit-heatmap-day {
+  fill: rgb(226, 232, 240);
+}
+
+.hourly-profit-heatmap-active {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.hourly-profit-heatmap-cell {
+  cursor: pointer;
+  stroke: rgba(15, 23, 42, 0.85);
+  stroke-width: 1;
+  outline: none;
+}
+
+.hourly-profit-heatmap-cell:focus {
+  stroke: white;
+  stroke-width: 2;
+}
+
+.hourly-profit-heatmap-tooltip {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.hourly-profit-heatmap-tooltip.is-visible {
+  opacity: 1;
+}
+
+.hourly-profit-heatmap-tooltip rect {
+  fill: rgb(15, 23, 42);
+  stroke: rgba(148, 163, 184, 0.65);
+  stroke-width: 1;
+}
+
+.hourly-profit-heatmap-tooltip text {
+  fill: rgb(226, 232, 240);
+  font-size: 0.625rem;
+  font-weight: 700;
+}
+
+.hourly-profit-heatmap-tooltip text.is-positive {
+  fill: rgb(74, 222, 128);
+}
+
+.hourly-profit-heatmap-tooltip text.is-negative {
+  fill: rgb(248, 113, 113);
+}
+
+.hourly-profit-heatmap-tooltip text.is-muted {
+  fill: rgb(148, 163, 184);
+  font-weight: 600;
+}
+
 .goal-streak-strip,
 .goal-avg-strip {
   grid-template-columns: repeat(4, minmax(0, 1fr));

--- a/src/styles/history-page.css
+++ b/src/styles/history-page.css
@@ -38,6 +38,36 @@
   flex-wrap: wrap;
 }
 
+.history-source-toggle {
+  display: flex;
+  background: rgb(15, 23, 42);
+  border: 1px solid rgb(51, 65, 85);
+  border-radius: 0.375rem;
+  overflow: hidden;
+}
+
+.history-source-btn {
+  padding: 0.5rem 0.875rem;
+  border: none;
+  background: transparent;
+  color: rgb(148, 163, 184);
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-weight: 600;
+  transition: background 0.15s, color 0.15s;
+}
+
+.history-source-btn:hover {
+  color: white;
+  background: rgb(30, 41, 59);
+}
+
+.history-source-btn--active {
+  background: rgb(37, 99, 235);
+  color: white;
+  box-shadow: inset 0 -2px 0 rgb(147, 197, 253);
+}
+
 .history-search {
   background: rgb(30, 41, 59);
   border: 1px solid rgb(71, 85, 105);
@@ -97,6 +127,26 @@
   color: white;
 }
 
+.history-filter-btn--remove.history-filter-btn--active {
+  background: rgb(109, 40, 217);
+  color: white;
+}
+
+.history-filter-btn--dump.history-filter-btn--active {
+  background: rgb(3, 105, 161);
+  color: white;
+}
+
+.history-filter-btn--referral.history-filter-btn--active {
+  background: rgb(13, 148, 136);
+  color: white;
+}
+
+.history-filter-btn--bonds.history-filter-btn--active {
+  background: rgb(180, 83, 9);
+  color: white;
+}
+
 .history-page-size {
   background: rgb(30, 41, 59);
   border: 1px solid rgb(71, 85, 105);
@@ -151,6 +201,18 @@
 
 .history-row--remove {
   border-left: 3px solid rgb(168, 85, 247);
+}
+
+.history-row--dump {
+  border-left: 3px solid rgb(14, 165, 233);
+}
+
+.history-row--referral {
+  border-left: 3px solid rgb(20, 184, 166);
+}
+
+.history-row--bonds {
+  border-left: 3px solid rgb(245, 158, 11);
 }
 
 .history-row:hover {
@@ -241,6 +303,24 @@
   background: rgba(124, 58, 237, 0.25);
   color: rgb(196, 181, 253);
   border: 1px solid rgba(168, 85, 247, 0.3);
+}
+
+.history-type-badge--dump {
+  background: rgba(14, 165, 233, 0.2);
+  color: rgb(125, 211, 252);
+  border: 1px solid rgba(14, 165, 233, 0.3);
+}
+
+.history-type-badge--referral {
+  background: rgba(20, 184, 166, 0.2);
+  color: rgb(94, 234, 212);
+  border: 1px solid rgba(20, 184, 166, 0.3);
+}
+
+.history-type-badge--bonds {
+  background: rgba(245, 158, 11, 0.2);
+  color: rgb(253, 186, 116);
+  border: 1px solid rgba(245, 158, 11, 0.3);
 }
 
 .history-total--buy {

--- a/src/utils/categoryAnalytics.js
+++ b/src/utils/categoryAnalytics.js
@@ -537,48 +537,22 @@ export function buildCategoryDrilldownData({
     profit: toNumber(bucket.by_category?.[category]),
   }));
   const profitByTransaction = buildProfitByTransaction(profitHistory);
-  const positions = new Map();
   const windowProfitByStock = new Map();
   const categoryTransactions = (transactions || [])
     .filter((transaction) => stockIds.has(String(stockIdOf(transaction))));
 
-  for (const transaction of [...categoryTransactions].sort((a, b) => String(a.date || '').localeCompare(String(b.date || '')))) {
+  for (const transaction of categoryTransactions) {
     const stockId = String(stockIdOf(transaction));
-    const position = positions.get(stockId) || { shares: 0, cost: 0 };
-    const shares = toNumber(transaction.shares);
-    const total = toNumber(transaction.total);
+    if (transaction.type !== 'sell') continue;
 
-    if (transaction.type === 'buy') {
-      position.shares += shares;
-      position.cost += total;
-      positions.set(stockId, position);
-      continue;
-    }
-
-    if (transaction.type !== 'sell') {
-      if (transaction.type === 'remove') {
-        const nextPosition = applyAverageCostExit(position, shares);
-        position.shares = nextPosition.shares;
-        position.cost = nextPosition.cost;
-      }
-      positions.set(stockId, position);
-      continue;
-    }
-
-    const nextPosition = applyAverageCostExit(position, shares);
-    const estimatedBasis = nextPosition.estimatedBasis;
     const iso = isoOf(transaction.date);
+    if (start && end && (iso < start || iso > end)) continue;
 
-    if (!start || !end || (iso >= start && iso <= end)) {
-      const transactionProfit = profitByTransaction.has(String(transaction.id))
-        ? profitByTransaction.get(String(transaction.id))
-        : total - estimatedBasis;
-      windowProfitByStock.set(stockId, (windowProfitByStock.get(stockId) || 0) + transactionProfit);
-    }
+    const txKey = String(transaction.id);
+    if (!profitByTransaction.has(txKey)) continue;
 
-    position.shares = nextPosition.shares;
-    position.cost = nextPosition.cost;
-    positions.set(stockId, position);
+    const transactionProfit = profitByTransaction.get(txKey);
+    windowProfitByStock.set(stockId, (windowProfitByStock.get(stockId) || 0) + transactionProfit);
   }
 
   const recentTransactions = (transactions || [])

--- a/src/utils/itemAnalytics.js
+++ b/src/utils/itemAnalytics.js
@@ -1,5 +1,4 @@
 import { calculateUnrealizedProfit } from './taxUtils';
-import { applyAverageCostExit } from './positionAnalytics';
 
 export const isoOf = (value) => String(value || '').slice(0, 10);
 export const stockIdOf = (row) => row?.stockId ?? row?.stock_id;
@@ -132,44 +131,22 @@ export function buildDailyItemProfit({ itemId, transactions = [], profitHistory 
   const profitByTx = buildStockProfitByTransaction(profitHistory);
   const byDay = new Map();
   const dates = [];
-  const position = { shares: 0, cost: 0 };
 
   const itemTransactions = (transactions || [])
     .filter((tx) => String(stockIdOf(tx)) === String(itemId))
     .sort((a, b) => String(a.date || '').localeCompare(String(b.date || '')));
 
   for (const tx of itemTransactions) {
-    const shares = Number(tx.shares) || 0;
-    const total = Number(tx.total) || 0;
-
-    if (tx.type === 'buy') {
-      position.shares += shares;
-      position.cost += total;
-      continue;
-    }
-
     const iso = isoOf(tx.date);
-    if (tx.type === 'remove') {
-      const nextPosition = applyAverageCostExit(position, shares);
-      position.shares = nextPosition.shares;
-      position.cost = nextPosition.cost;
-      continue;
-    }
-
     if (tx.type !== 'sell') continue;
 
-    const nextPosition = applyAverageCostExit(position, shares);
-    position.shares = nextPosition.shares;
-    position.cost = nextPosition.cost;
-
     if (start && end && !inWindow(iso, start, end)) continue;
-    dates.push(iso);
 
     const txKey = String(tx.id);
-    const profit = profitByTx.has(txKey)
-      ? profitByTx.get(txKey)
-      : total - nextPosition.estimatedBasis;
+    if (!profitByTx.has(txKey)) continue;
 
+    dates.push(iso);
+    const profit = profitByTx.get(txKey);
     byDay.set(iso, (byDay.get(iso) || 0) + profit);
   }
 


### PR DESCRIPTION
## Summary
- Adds the hourly profit heatmap history navigation from this branch.
- Adds a History source toggle for GE item transactions vs extra profits.
- Shows dump, referral, and bond profit history using enabled profit visibility settings.
- Simplifies the Extra Profits table to Date, Type, and Amount, with profit-style green/red amount coloring.
- Preserves shared History filters, including day-of-week and hour-of-day filters, when switching sources.

## Validation
- npm run build

## Notes
- This PR targets Develop and contains the existing heatmap commit plus the new extra profit history commit.
