### PR TITLE
[codex] Persist analytics view state in URL

### DIFF
--- a/src/components/analytics/CategoriesTab.jsx
+++ b/src/components/analytics/CategoriesTab.jsx
@@ -13,11 +13,21 @@ import {
   filterBucketsByCategories,
 } from '../../utils/categoryAnalytics';
 import { useGEData } from '../../contexts/GEDataContext';
+import { useUrlState } from '../../hooks/useUrlState';
 
 const categoryOf = (stock) => stock?.category || 'Uncategorized';
 
 const bucketCategories = (buckets = []) => (
   buckets.flatMap((bucket) => Object.keys(bucket.by_category || {}))
+);
+
+const parseCategoriesParam = (value) => {
+  if (!value) return [];
+  return value.split(',').map((category) => category.trim()).filter(Boolean).sort();
+};
+
+const serializeCategoriesParam = (value) => (
+  value?.length ? value.join(',') : null
 );
 
 export default function CategoriesTab({
@@ -32,7 +42,13 @@ export default function CategoriesTab({
   onTimeframeChange,
 }) {
   const { gePrices } = useGEData();
-  const [selectedCategories, setSelectedCategories] = useState([]);
+  const [selectedCategories, setSelectedCategories] = useUrlState(
+    'categories',
+    [],
+    parseCategoriesParam,
+    serializeCategoriesParam,
+    { history: 'push' }
+  );
   const [drillCategory, setDrillCategory] = useState(null);
   const timeframeLabel = timeframe?.window || 'selected';
 
@@ -85,12 +101,21 @@ export default function CategoriesTab({
     }
   }, [drillCategory, selectedCategories]);
 
+  useEffect(() => {
+    if (categories.length === 0 || selectedCategories.length === 0) return;
+    const validCategories = new Set(categories);
+    const nextCategories = selectedCategories.filter((category) => validCategories.has(category));
+    if (nextCategories.length !== selectedCategories.length) {
+      setSelectedCategories(nextCategories, { history: 'replace' });
+    }
+  }, [categories, selectedCategories, setSelectedCategories]);
+
   const toggleCategory = (category) => {
     setSelectedCategories((current) => (
       current.includes(category)
         ? current.filter((value) => value !== category)
         : [...current, category].sort()
-    ));
+    ), { history: 'push' });
   };
 
   return (
@@ -107,7 +132,7 @@ export default function CategoriesTab({
             type="button"
             className={`category-filter-pill has-tooltip${selectedCategories.length === 0 ? ' is-on' : ''}`}
             data-tooltip="Show every category."
-            onClick={() => setSelectedCategories([])}
+            onClick={() => setSelectedCategories([], { history: 'push' })}
           >
             All
           </button>

--- a/src/components/analytics/ItemsTab.jsx
+++ b/src/components/analytics/ItemsTab.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   computeBuyingVsSelling,
   computeItemMetrics,
@@ -10,7 +10,27 @@ import ItemsTable from './widgets/ItemsTable';
 import ItemDrilldownDrawer from './widgets/ItemDrilldownDrawer';
 import MoversList from './widgets/MoversList';
 import BuyingVsSellingChart from './widgets/BuyingVsSellingChart';
+import { useUrlState } from '../../hooks/useUrlState';
 import '../../styles/analytics-items.css';
+
+const parseCategoryParam = (value) => value || 'all';
+const serializeCategoryParam = (value) => (value && value !== 'all' ? value : null);
+
+const parseBooleanParam = (value) => (
+  value === '1' || value === 'true' || value === 'yes'
+);
+const serializeBooleanParam = (value) => (value ? '1' : null);
+
+const parseMinimumSellsParam = (value) => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) return 0;
+  return Math.floor(parsed);
+};
+const serializeMinimumSellsParam = (value) => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return String(Math.floor(parsed));
+};
 
 export default function ItemsTab({
   stocks = [],
@@ -22,11 +42,41 @@ export default function ItemsTab({
   onTimeframeChange,
 }) {
   const { gePrices } = useGEData();
-  const [selectedCategory, setSelectedCategory] = useState('all');
-  const [hasStockOnly, setHasStockOnly] = useState(false);
-  const [soldInWindowOnly, setSoldInWindowOnly] = useState(false);
-  const [showArchived, setShowArchived] = useState(false);
-  const [minimumSells, setMinimumSells] = useState(0);
+  const [selectedCategory, setSelectedCategory] = useUrlState(
+    'category',
+    'all',
+    parseCategoryParam,
+    serializeCategoryParam,
+    { history: 'push' }
+  );
+  const [hasStockOnly, setHasStockOnly] = useUrlState(
+    'hasStock',
+    false,
+    parseBooleanParam,
+    serializeBooleanParam,
+    { history: 'push' }
+  );
+  const [soldInWindowOnly, setSoldInWindowOnly] = useUrlState(
+    'soldInWindow',
+    false,
+    parseBooleanParam,
+    serializeBooleanParam,
+    { history: 'push' }
+  );
+  const [showArchived, setShowArchived] = useUrlState(
+    'archived',
+    false,
+    parseBooleanParam,
+    serializeBooleanParam,
+    { history: 'push' }
+  );
+  const [minimumSells, setMinimumSells] = useUrlState(
+    'minSells',
+    0,
+    parseMinimumSellsParam,
+    serializeMinimumSellsParam,
+    { history: 'replace' }
+  );
   const [drillItem, setDrillItem] = useState(null);
 
   const items = useMemo(() => (
@@ -42,6 +92,13 @@ export default function ItemsTab({
   const categories = useMemo(() => (
     [...new Set(items.map((item) => item.category).filter(Boolean))].sort()
   ), [items]);
+
+  useEffect(() => {
+    if (selectedCategory === 'all' || categories.length === 0) return;
+    if (!categories.includes(selectedCategory)) {
+      setSelectedCategory('all', { history: 'replace' });
+    }
+  }, [categories, selectedCategory, setSelectedCategory]);
 
   const filteredItems = useMemo(() => (
     items.filter((item) => {
@@ -66,15 +123,15 @@ export default function ItemsTab({
       <ItemsFilterBar
         categories={categories}
         selectedCategory={selectedCategory}
-        onCategoryChange={setSelectedCategory}
+        onCategoryChange={(value) => setSelectedCategory(value, { history: 'push' })}
         hasStockOnly={hasStockOnly}
-        onToggleHasStock={() => setHasStockOnly((value) => !value)}
+        onToggleHasStock={() => setHasStockOnly((value) => !value, { history: 'push' })}
         soldInWindowOnly={soldInWindowOnly}
-        onToggleSoldInWindow={() => setSoldInWindowOnly((value) => !value)}
+        onToggleSoldInWindow={() => setSoldInWindowOnly((value) => !value, { history: 'push' })}
         showArchived={showArchived}
-        onToggleArchived={() => setShowArchived((value) => !value)}
+        onToggleArchived={() => setShowArchived((value) => !value, { history: 'push' })}
         minimumSells={minimumSells}
-        onMinimumSellsChange={setMinimumSells}
+        onMinimumSellsChange={(value) => setMinimumSells(value, { history: 'replace' })}
       />
 
       <ItemsTable

--- a/src/components/analytics/widgets/MilestoneHistoryTable.jsx
+++ b/src/components/analytics/widgets/MilestoneHistoryTable.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { formatNumber } from '../../../utils/formatters';
 import { periodDate } from '../../../utils/goalAnalytics';
+import { useUrlState } from '../../../hooks/useUrlState';
 
 const PERIODS = [
   { key: 'all', label: 'All' },
@@ -11,9 +12,24 @@ const PERIODS = [
 ];
 
 const DEFAULT_VISIBLE = 25;
+const PERIOD_KEYS = new Set(PERIODS.map((period) => period.key));
+
+const parseHistoryPeriodParam = (value) => (
+  PERIOD_KEYS.has(value) ? value : null
+);
+
+const serializeHistoryPeriodParam = (value) => (
+  PERIOD_KEYS.has(value) && value !== 'all' ? value : null
+);
 
 export default function MilestoneHistoryTable({ milestoneHistory = [], numberFormat }) {
-  const [period, setPeriod] = useState('all');
+  const [period, setPeriod] = useUrlState(
+    'historyPeriod',
+    'all',
+    parseHistoryPeriodParam,
+    serializeHistoryPeriodParam,
+    { history: 'push' }
+  );
   const [expanded, setExpanded] = useState(false);
 
   const sortedAll = useMemo(() => (
@@ -53,7 +69,7 @@ export default function MilestoneHistoryTable({ milestoneHistory = [], numberFor
                     ? 'Show every recorded period.'
                     : `Filter to completed ${option.label.toLowerCase()} periods.`
                 }
-                onClick={() => setPeriod(option.key)}
+                onClick={() => setPeriod(option.key, { history: 'push' })}
               >
                 {option.label}
               </button>

--- a/src/hooks/useAnalyticsTimeframe.js
+++ b/src/hooks/useAnalyticsTimeframe.js
@@ -1,5 +1,6 @@
-import { useState, useMemo, useCallback } from 'react';
+import { useEffect, useMemo, useCallback } from 'react';
 import { subtractDays, toIsoDate } from '../utils/analyticsHelpers';
+import { useUrlState } from './useUrlState';
 
 const WINDOW_OPTIONS = ['1W', '1M', '3M', '6M', '1Y', 'All'];
 
@@ -28,19 +29,43 @@ const daysForWindow = (window) => {
   }
 };
 
+const parseWindowParam = (value) => (
+  WINDOW_OPTIONS.includes(value) ? value : null
+);
+
+const serializeWindowParam = (value) => (
+  WINDOW_OPTIONS.includes(value) ? value : null
+);
+
 export function useAnalyticsTimeframe(userId, allTimeStart = null) {
   const storageKey = `analyticsTimeframe_${userId}`;
 
-  const [window, setWindowState] = useState(() => {
+  const initialWindow = useCallback(() => {
     const stored = localStorage.getItem(storageKey);
     return WINDOW_OPTIONS.includes(stored) ? stored : '1M';
-  });
+  }, [storageKey]);
+
+  const [window, setWindowState] = useUrlState(
+    'window',
+    initialWindow,
+    parseWindowParam,
+    serializeWindowParam,
+    { history: 'push' }
+  );
+
+  useEffect(() => {
+    const url = new URL(globalThis.location.href);
+    if (url.searchParams.get('window') === window) return;
+
+    url.searchParams.set('window', window);
+    globalThis.history.replaceState(globalThis.history.state || {}, '', url);
+  }, [window]);
 
   const setWindow = useCallback((next) => {
     if (!WINDOW_OPTIONS.includes(next)) return;
-    setWindowState(next);
+    setWindowState(next, { history: 'push' });
     localStorage.setItem(storageKey, next);
-  }, [storageKey]);
+  }, [setWindowState, storageKey]);
 
   const { start, end, bucket } = useMemo(() => {
     const endIso = toIsoDate(new Date());

--- a/src/hooks/useUrlState.js
+++ b/src/hooks/useUrlState.js
@@ -1,0 +1,62 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+const resolveInitial = (initial) => (
+  typeof initial === 'function' ? initial() : initial
+);
+
+const defaultParse = (value) => value;
+const defaultSerialize = (value) => (
+  value === undefined || value === null || value === '' ? null : String(value)
+);
+
+export function useUrlState(
+  key,
+  initial,
+  parse = defaultParse,
+  serialize = defaultSerialize,
+  options = {}
+) {
+  const defaultHistory = options.history || 'replace';
+
+  const readValue = useCallback(() => {
+    const fallback = resolveInitial(initial);
+    const params = new URLSearchParams(window.location.search);
+    const rawValue = params.get(key);
+    const parsed = parse(rawValue, params);
+    return parsed == null ? fallback : parsed;
+  }, [initial, key, parse]);
+
+  const [value, setValueState] = useState(readValue);
+
+  useEffect(() => {
+    const handlePopState = () => {
+      setValueState(readValue());
+    };
+
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, [readValue]);
+
+  const setValue = useCallback((next, updateOptions = {}) => {
+    setValueState((current) => {
+      const resolved = typeof next === 'function' ? next(current) : next;
+      const serialized = serialize(resolved);
+      const url = new URL(window.location.href);
+
+      if (serialized == null || serialized === '') {
+        url.searchParams.delete(key);
+      } else {
+        url.searchParams.set(key, serialized);
+      }
+
+      const historyMode = updateOptions.history || defaultHistory;
+      const state = window.history.state || {};
+      const historyMethod = historyMode === 'push' ? 'pushState' : 'replaceState';
+      window.history[historyMethod](state, '', url);
+
+      return resolved;
+    });
+  }, [defaultHistory, key, serialize]);
+
+  return useMemo(() => [value, setValue], [value, setValue]);
+}

--- a/src/pages/AnalyticsPage.jsx
+++ b/src/pages/AnalyticsPage.jsx
@@ -1,6 +1,8 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Check, Copy } from 'lucide-react';
 import { useAnalyticsTimeframe } from '../hooks/useAnalyticsTimeframe';
 import { useAnalytics } from '../hooks/useAnalytics';
+import { useUrlState } from '../hooks/useUrlState';
 import TimeframeSelector from '../components/analytics/TimeframeSelector';
 import TabNav, { ANALYTICS_TABS } from '../components/analytics/TabNav';
 import KpiBand from '../components/analytics/KpiBand';
@@ -15,6 +17,31 @@ import '../styles/analytics-widgets.css';
 
 const sumGpTraded = (buckets) => buckets.reduce((sum, bucket) => sum + (bucket.gp_traded || 0), 0);
 const DEFAULT_ALL_TIME_START = '2020-01-01';
+
+const parseTabParam = (value) => (
+  ANALYTICS_TABS.includes(value) ? value : null
+);
+
+const serializeTabParam = (value) => (
+  ANALYTICS_TABS.includes(value) ? value : null
+);
+
+const copyText = async (text) => {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return true;
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.className = 'analytics-copy-fallback';
+  document.body.appendChild(textarea);
+  textarea.select();
+  const copied = document.execCommand('copy');
+  document.body.removeChild(textarea);
+  return copied;
+};
 
 export default function AnalyticsPage({
   userId,
@@ -40,9 +67,14 @@ export default function AnalyticsPage({
   const safeProfitHistory = profitHistory || [];
   const safeStocksForStats = stocksForStats || [];
 
-  const [activeTab, setActiveTab] = useState(() => (
-    ANALYTICS_TABS.includes(initialTab) ? initialTab : 'profit'
-  ));
+  const [activeTab, setActiveTab] = useUrlState(
+    'tab',
+    ANALYTICS_TABS.includes(initialTab) ? initialTab : 'profit',
+    parseTabParam,
+    serializeTabParam,
+    { history: 'push' }
+  );
+  const [linkCopied, setLinkCopied] = useState(false);
 
   const scopeCoversStart = (scope, start) => {
     if (scope?.full) return true;
@@ -144,13 +176,15 @@ export default function AnalyticsPage({
     [safeStocksForStats]
   );
 
-  const handleTabChange = (next) => {
-    setActiveTab(next);
+  const handleTabChange = useCallback((next) => {
+    setActiveTab(next, { history: 'push' });
+  }, [setActiveTab]);
 
-    const url = new URL(window.location.href);
-    url.searchParams.set('tab', next);
-    window.history.replaceState({}, '', url);
-  };
+  const handleCopyLink = useCallback(async () => {
+    const copied = await copyText(window.location.href).catch(() => false);
+    setLinkCopied(copied);
+    window.setTimeout(() => setLinkCopied(false), 1600);
+  }, []);
 
   return (
     <div className="analytics-page">
@@ -161,11 +195,23 @@ export default function AnalyticsPage({
             Deep portfolio insights across profit, items, categories, and goals.
           </p>
         </div>
-        <TimeframeSelector
-          window={timeframe.window}
-          options={timeframe.options}
-          onChange={timeframe.setWindow}
-        />
+        <div className="analytics-header-actions">
+          <TimeframeSelector
+            window={timeframe.window}
+            options={timeframe.options}
+            onChange={timeframe.setWindow}
+          />
+          <button
+            type="button"
+            className={`analytics-copy-link-btn has-tooltip${linkCopied ? ' is-copied' : ''}`}
+            data-tooltip={linkCopied ? 'Link copied.' : 'Copy link to this analytics view.'}
+            aria-label="Copy link to this analytics view"
+            onClick={handleCopyLink}
+          >
+            {linkCopied ? <Check size={16} /> : <Copy size={16} />}
+          </button>
+          {linkCopied && <span className="analytics-copy-toast">Copied</span>}
+        </div>
       </div>
 
       {current.fromFallback && (

--- a/src/styles/analytics-page.css
+++ b/src/styles/analytics-page.css
@@ -25,6 +25,15 @@
   margin: 0.25rem 0 0;
 }
 
+.analytics-header-actions {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
 .analytics-timeframe {
   display: flex;
   gap: 0.25rem;
@@ -54,6 +63,54 @@
 .analytics-timeframe-btn.is-active {
   background: rgb(21, 128, 61);
   color: white;
+}
+
+.analytics-copy-link-btn {
+  width: 2.25rem;
+  height: 2.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgb(30, 41, 59);
+  border: 1px solid rgb(51, 65, 85);
+  border-radius: 0.5rem;
+  color: rgb(203, 213, 225);
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.analytics-copy-link-btn:hover,
+.analytics-copy-link-btn:focus-visible {
+  background: rgba(34, 197, 94, 0.14);
+  border-color: rgba(34, 197, 94, 0.45);
+  color: white;
+}
+
+.analytics-copy-link-btn.is-copied {
+  background: rgb(21, 128, 61);
+  border-color: rgb(21, 128, 61);
+  color: white;
+}
+
+.analytics-copy-toast {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  z-index: 20;
+  background: rgb(15, 23, 42);
+  border: 1px solid rgb(51, 65, 85);
+  border-radius: 0.5rem;
+  color: white;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.375rem 0.625rem;
+  box-shadow: 0 0.75rem 1.5rem rgba(0, 0, 0, 0.25);
+}
+
+.analytics-copy-fallback {
+  position: fixed;
+  left: -9999px;
+  top: 0;
 }
 
 .analytics-tab-nav {
@@ -152,5 +209,9 @@
 
   .analytics-timeframe {
     flex-wrap: wrap;
+  }
+
+  .analytics-header-actions {
+    justify-content: flex-start;
   }
 }


### PR DESCRIPTION
## Summary
- Add a reusable `useUrlState` hook for query-param backed state with browser back/forward restoration.
- Encode analytics tab, timeframe window, category filters, item filters, and milestone history period in the URL.
- Add a copy-link icon beside the analytics timeframe selector with transient copied feedback.

## Impact
Analytics views can now be bookmarked and shared with their active tab, timeframe, and supported filters intact. Missing or invalid params fall back to existing defaults, with timeframe still preserving the existing localStorage fallback when no URL param is present.

Refs #252

## Validation
- `npm run build`
- `git diff --check -- src\hooks\useUrlState.js src\hooks\useAnalyticsTimeframe.js src\pages\AnalyticsPage.jsx src\components\analytics\CategoriesTab.jsx src\components\analytics\ItemsTab.jsx src\components\analytics\widgets\MilestoneHistoryTable.jsx src\styles\analytics-page.css`
- Opened `http://127.0.0.1:5174/analytics?tab=items&window=1W&hasStock=1&soldInWindow=1&archived=1&minSells=2` in the in-app browser; route served and redirected to auth as expected for an unauthenticated session.