### PR TITLE
Fix negative zero display

### DIFF
--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -24,11 +24,15 @@ export const handleMKInput = (value, setter) => {
   return value;
 };
 
+export const normalizeDisplayNumber = (value) => {
+  return Object.is(value, -0) ? 0 : value;
+};
+
 export const formatNumber = (num, numberFormat = 'compact') => {
   if (num == null || isNaN(num)) return '-';
 
   // Round to nearest integer first
-  const rounded = Math.round(num);
+  const rounded = normalizeDisplayNumber(Math.round(num));
   const sign = rounded < 0 ? '-' : '';
   const absolute = Math.abs(rounded);
 
@@ -53,12 +57,14 @@ export const formatNumber = (num, numberFormat = 'compact') => {
 };
 
 export function formatAvgPrice(value, numberFormat) {
-  if (value < 100000) {
+  const displayValue = normalizeDisplayNumber(value);
+
+  if (displayValue < 100000) {
     // Below 100K: show with 2 decimals
-    return `$${value.toFixed(2)}`;
+    return `$${displayValue.toFixed(2)}`;
   } else {
     // Above 100K: use formatNumber
-    return `$${formatNumber(value, numberFormat)}`;
+    return `$${formatNumber(displayValue, numberFormat)}`;
   }
 }
 

--- a/src/utils/taxUtils.js
+++ b/src/utils/taxUtils.js
@@ -71,5 +71,6 @@ export function calculateUnrealizedProfit(stock, latestHigh, itemId) {
   const netSellPerItem = latestHigh - taxPerItem;
   const profit = (netSellPerItem - avgBuyPrice) * stock.shares;
 
-  return Math.round(profit);
+  const roundedProfit = Math.round(profit);
+  return Object.is(roundedProfit, -0) ? 0 : roundedProfit;
 }


### PR DESCRIPTION
## Summary
- Normalize JavaScript negative zero in shared number formatting so `-0` no longer leaks into displayed GP values.
- Normalize rounded unrealized profit before returning it, covering fractional losses that round to zero.

## Verification
- node snippet verified `formatNumber(-0)`, `formatNumber(-0.4)`, `formatNumber(-0.4, 'full')`, `formatAvgPrice(-0)`, and `calculateUnrealizedProfit(...)` return/display plain zero instead of negative zero.
- `npm run build`

Fixes #307
