### PR TITLE
Add global bulk trade actions

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -1387,6 +1387,26 @@ function MainAppInner({ session, onLogout }) {
 
           {/* Right - Search + Notifications + User dropdown */}
           <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <div className="topbar-bulk-actions" aria-label="GE bulk trade actions">
+            <button
+              type="button"
+              className="topbar-bulk-action-btn is-success"
+              onClick={() => openModal('bulkBuy')}
+              title="Bulk Buy GE items"
+            >
+              <ShoppingCart size={14} />
+              Bulk Buy
+            </button>
+            <button
+              type="button"
+              className="topbar-bulk-action-btn is-danger"
+              onClick={() => openModal('bulkSell')}
+              title="Bulk Sell GE items"
+            >
+              <TrendingDown size={14} />
+              Bulk Sell
+            </button>
+          </div>
           <GlobalSearch
             transactions={transactions}
             navigateToPage={navigateToPage}

--- a/src/components/modals/BulkTradeModal.jsx
+++ b/src/components/modals/BulkTradeModal.jsx
@@ -11,6 +11,7 @@ export default function BulkTradeModal({ mode, tradeMode = 'trade', onConfirm, o
   const isBuy = mode === 'buy';
   const { gePrices, geIconMap } = useGEData();
   const { stocks, categories } = useTrade();
+  const [activeTradeMode, setActiveTradeMode] = useState(tradeMode);
   const [buyMode, setBuyMode] = useState('perItem');
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedItems, setSelectedItems] = useState({});
@@ -19,9 +20,17 @@ export default function BulkTradeModal({ mode, tradeMode = 'trade', onConfirm, o
   const groupedStocks = useGroupedStocks(
     stocks,
     categories,
-    tradeMode,
+    activeTradeMode,
     isBuy ? undefined : { requireShares: true }
   );
+
+  const handleTradeModeChange = (nextMode) => {
+    if (nextMode === activeTradeMode) return;
+
+    setActiveTradeMode(nextMode);
+    setSearchQuery('');
+    setSelectedItems({});
+  };
 
   const filteredGroups = useMemo(() => {
     if (!searchQuery.trim()) return groupedStocks;
@@ -226,26 +235,46 @@ export default function BulkTradeModal({ mode, tradeMode = 'trade', onConfirm, o
       {/* Header */}
       <div className="bulk-trade-header">
         <h2>{isBuy ? 'Bulk Buy' : 'Bulk Sell'}</h2>
-        {isBuy ? (
-          <div className="bulk-trade-mode-toggle">
+        <div className="bulk-trade-header-actions">
+          <div className="bulk-trade-mode-toggle" aria-label="GE tracker section">
             <button
-              className={`bulk-trade-mode-btn ${buyMode === 'perItem' ? 'active' : ''}`}
-              onClick={() => setBuyMode('perItem')}
+              type="button"
+              className={`bulk-trade-mode-btn ${activeTradeMode === 'trade' ? 'active' : ''}`}
+              onClick={() => handleTradeModeChange('trade')}
             >
-              Per-Item
+              Trading
             </button>
             <button
-              className={`bulk-trade-mode-btn ${buyMode === 'budgetSplit' ? 'active' : ''}`}
-              onClick={() => setBuyMode('budgetSplit')}
+              type="button"
+              className={`bulk-trade-mode-btn ${activeTradeMode === 'investment' ? 'active' : ''}`}
+              onClick={() => handleTradeModeChange('investment')}
             >
-              Budget Split
+              Investments
             </button>
           </div>
-        ) : (
-          selectedCount > 0 && (
-            <span className="bulk-trade-count-badge">{selectedCount}</span>
-          )
-        )}
+          {isBuy ? (
+            <div className="bulk-trade-mode-toggle">
+              <button
+                type="button"
+                className={`bulk-trade-mode-btn ${buyMode === 'perItem' ? 'active' : ''}`}
+                onClick={() => setBuyMode('perItem')}
+              >
+                Per-Item
+              </button>
+              <button
+                type="button"
+                className={`bulk-trade-mode-btn ${buyMode === 'budgetSplit' ? 'active' : ''}`}
+                onClick={() => setBuyMode('budgetSplit')}
+              >
+                Budget Split
+              </button>
+            </div>
+          ) : (
+            selectedCount > 0 && (
+              <span className="bulk-trade-count-badge">{selectedCount}</span>
+            )
+          )}
+        </div>
       </div>
 
       {/* Body */}

--- a/src/styles/bulk-trade-modal.css
+++ b/src/styles/bulk-trade-modal.css
@@ -45,6 +45,14 @@
   letter-spacing: -0.01em;
 }
 
+.bulk-trade-header-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
 .bulk-trade-mode-toggle {
   display: flex;
   gap: 2px;
@@ -773,6 +781,17 @@
   .bulk-trade-modal {
     width: 100%;
     height: 95vh;
+  }
+
+  .bulk-trade-header {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .bulk-trade-header-actions {
+    justify-content: flex-start;
+    width: 100%;
   }
 
   .bulk-trade-body {

--- a/src/styles/header.css
+++ b/src/styles/header.css
@@ -62,6 +62,64 @@
   margin-bottom: 1.5rem;
 }
 
+.topbar-bulk-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.topbar-bulk-action-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  min-height: 2.1rem;
+  padding: 0.4rem 0.65rem;
+  border: 1px solid transparent;
+  border-radius: 0.45rem;
+  color: white;
+  cursor: pointer;
+  font-size: 0.78rem;
+  font-weight: 700;
+  white-space: nowrap;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.topbar-bulk-action-btn.is-success {
+  background: rgb(21, 128, 61);
+  border-color: rgba(34, 197, 94, 0.42);
+}
+
+.topbar-bulk-action-btn.is-success:hover {
+  background: rgb(22, 101, 52);
+  border-color: rgba(134, 239, 172, 0.55);
+}
+
+.topbar-bulk-action-btn.is-danger {
+  background: rgb(153, 27, 27);
+  border-color: rgba(248, 113, 113, 0.38);
+}
+
+.topbar-bulk-action-btn.is-danger:hover {
+  background: rgb(127, 29, 29);
+  border-color: rgba(252, 165, 165, 0.5);
+}
+
+@media (max-width: 1280px) {
+  .topbar-bulk-action-btn {
+    width: 2.1rem;
+    padding: 0.4rem;
+  }
+
+  .topbar-bulk-action-btn svg {
+    flex-shrink: 0;
+  }
+
+  .topbar-bulk-action-btn {
+    font-size: 0;
+  }
+}
+
 
 /* User Dropdown */
 .user-dropdown-wrapper {


### PR DESCRIPTION
## Summary
- Adds GE Bulk Buy and Bulk Sell actions to the persistent top bar so they are available from every authenticated app page.
- Adds a Trading/Investments switch inside the GE bulk trade modal so bulk operations can target either section without navigating tabs.
- Clears modal selections when switching sections to avoid submitting hidden selections from the previous section.

## Verification
- npm run build
- Local browser check at http://127.0.0.1:5173: opened Bulk Buy from the top bar, switched to Investments in the modal, and checked browser console errors.

Closes #301