### PR TITLE
Fix bulk trade selection across trading and investments

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -1013,8 +1013,9 @@ function MainAppInner({ session, onLogout }) {
 
     try {
       // Get the target position
+      const isInvestmentMode = tradeMode === 'investment';
       const filteredForMode = categories.filter(c =>
-        c.name === 'Uncategorized' || (tradeMode === 'investment' ? c.isInvestment : !c.isInvestment)
+        Boolean(c.isInvestment) === isInvestmentMode
       );
       const targetIndex = filteredForMode.findIndex(c => c.name === targetCategory);
 
@@ -1052,6 +1053,7 @@ function MainAppInner({ session, onLogout }) {
     e.preventDefault();
     const draggedStockId = parseInt(e.dataTransfer.getData('stockId'));
     const sourceCategory = e.dataTransfer.getData('sourceCategory');
+    const isInvestmentMode = tradeMode === 'investment';
 
     // If targetStockId is null/undefined, we're dropping on category header
     if (!targetStockId || draggedStockId === targetStockId) {
@@ -1060,7 +1062,9 @@ function MainAppInner({ session, onLogout }) {
         try {
           const draggedStock = stocks.find(s => s.id === draggedStockId);
           if (draggedStock) {
-            const targetCategoryStocks = stocks.filter(s => s.category === targetCategory);
+            const targetCategoryStocks = stocks.filter(s =>
+              s.category === targetCategory && Boolean(s.isInvestment) === isInvestmentMode
+            );
             const newPosition = targetCategoryStocks.length;
 
             await updateStock(draggedStockId, {
@@ -1083,7 +1087,9 @@ function MainAppInner({ session, onLogout }) {
       if (sourceCategory !== targetCategory) {
         // Move to different category - need to set proper position
         const draggedStock = stocks.find(s => s.id === draggedStockId);
-        const targetCategoryStocks = stocks.filter(s => s.category === targetCategory);
+        const targetCategoryStocks = stocks.filter(s =>
+          s.category === targetCategory && Boolean(s.isInvestment) === isInvestmentMode
+        );
         const targetStockIndex = targetCategoryStocks.findIndex(s => s.id === targetStockId);
 
         if (draggedStock) {
@@ -1117,7 +1123,8 @@ function MainAppInner({ session, onLogout }) {
             limit4h: stock.id === draggedStockId ? draggedStock.limit4h : stock.limit4h,
             needed: stock.id === draggedStockId ? draggedStock.needed : stock.needed,
             timer_end_time: stock.id === draggedStockId ? draggedStock.timerEndTime : stock.timerEndTime,
-            category: targetCategory
+            category: targetCategory,
+            is_investment: isInvestmentMode
           }));
 
           await supabase
@@ -1129,7 +1136,7 @@ function MainAppInner({ session, onLogout }) {
         }
       } else {
         // Reorder within same category
-        await reorderStocks(draggedStockId, targetStockId, targetCategory);
+        await reorderStocks(draggedStockId, targetStockId, targetCategory, isInvestmentMode);
         await refetch();
         highlightRow(draggedStockId);
       }

--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react';
-import { Archive, BarChart3, Eye, FolderPlus, LogOut, Package, PackagePlus } from 'lucide-react';
+import { Archive, BarChart3, Eye, FolderPlus, LogOut, Package, PackagePlus, ShoppingCart, TrendingDown } from 'lucide-react';
 import HomePage from './pages/HomePage';
 import HistoryPage from './pages/HistoryPage';
 import GraphsPage from './pages/GraphsPage';
@@ -1646,6 +1646,24 @@ function MainAppInner({ session, onLogout }) {
                     >
                       <PackagePlus size={14} />
                       Add Item
+                    </button>
+                  </div>
+                  <div className="trade-quick-action-group">
+                    <button
+                      type="button"
+                      onClick={() => openModal('bulkBuy')}
+                      className="trade-quick-action-btn is-success"
+                    >
+                      <ShoppingCart size={14} />
+                      Bulk Buy
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => openModal('bulkSell')}
+                      className="trade-quick-action-btn is-danger"
+                    >
+                      <TrendingDown size={14} />
+                      Bulk Sell
                     </button>
                   </div>
                   <div className="trade-quick-action-group trade-quick-action-group-archive">

--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react';
-import { Archive, BarChart3, Eye, FolderPlus, LogOut, Package, PackagePlus, ShoppingCart, TrendingDown } from 'lucide-react';
+import { Archive, BarChart3, Eye, FolderPlus, LogOut, Package, PackagePlus } from 'lucide-react';
 import HomePage from './pages/HomePage';
 import HistoryPage from './pages/HistoryPage';
 import GraphsPage from './pages/GraphsPage';
@@ -1646,24 +1646,6 @@ function MainAppInner({ session, onLogout }) {
                     >
                       <PackagePlus size={14} />
                       Add Item
-                    </button>
-                  </div>
-                  <div className="trade-quick-action-group">
-                    <button
-                      type="button"
-                      onClick={() => openModal('bulkBuy')}
-                      className="trade-quick-action-btn is-success"
-                    >
-                      <ShoppingCart size={14} />
-                      Bulk Buy
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => openModal('bulkSell')}
-                      className="trade-quick-action-btn is-danger"
-                    >
-                      <TrendingDown size={14} />
-                      Bulk Sell
                     </button>
                   </div>
                   <div className="trade-quick-action-group trade-quick-action-group-archive">

--- a/src/components/ModalManager.jsx
+++ b/src/components/ModalManager.jsx
@@ -147,7 +147,7 @@ export default function ModalManager({
       <ModalContainer isOpen={modals.bulkBuy}>
         <BulkTradeModal
           mode="buy"
-          tradeMode={tradeMode}
+          tradeMode="all"
           onConfirm={handleBulkBuy}
           onCancel={() => closeModal('bulkBuy')}
           isSubmitting={isSubmitting}
@@ -157,7 +157,7 @@ export default function ModalManager({
       <ModalContainer isOpen={modals.bulkSell}>
         <BulkTradeModal
           mode="sell"
-          tradeMode={tradeMode}
+          tradeMode="all"
           onConfirm={handleBulkSell}
           onCancel={() => closeModal('bulkSell')}
           isSubmitting={isSubmitting}

--- a/src/components/ModalManager.jsx
+++ b/src/components/ModalManager.jsx
@@ -147,7 +147,7 @@ export default function ModalManager({
       <ModalContainer isOpen={modals.bulkBuy}>
         <BulkTradeModal
           mode="buy"
-          tradeMode="all"
+          tradeMode={tradeMode}
           onConfirm={handleBulkBuy}
           onCancel={() => closeModal('bulkBuy')}
           isSubmitting={isSubmitting}
@@ -157,7 +157,7 @@ export default function ModalManager({
       <ModalContainer isOpen={modals.bulkSell}>
         <BulkTradeModal
           mode="sell"
-          tradeMode="all"
+          tradeMode={tradeMode}
           onConfirm={handleBulkSell}
           onCancel={() => closeModal('bulkSell')}
           isSubmitting={isSubmitting}

--- a/src/components/modals/BulkTradeModal.jsx
+++ b/src/components/modals/BulkTradeModal.jsx
@@ -19,8 +19,10 @@ export default function BulkTradeModal({ mode, tradeMode = 'trade', onConfirm, o
   const groupedStocks = useGroupedStocks(
     stocks,
     categories,
-    tradeMode === 'all' ? 'all' : tradeMode,
-    isBuy ? undefined : { requireShares: true }
+    'all',
+    isBuy
+      ? { preferredTradeMode: tradeMode }
+      : { requireShares: true, preferredTradeMode: tradeMode }
   );
 
   const filteredGroups = useMemo(() => {

--- a/src/components/modals/BulkTradeModal.jsx
+++ b/src/components/modals/BulkTradeModal.jsx
@@ -19,7 +19,7 @@ export default function BulkTradeModal({ mode, tradeMode = 'trade', onConfirm, o
   const groupedStocks = useGroupedStocks(
     stocks,
     categories,
-    tradeMode,
+    tradeMode === 'all' ? 'all' : tradeMode,
     isBuy ? undefined : { requireShares: true }
   );
 
@@ -263,7 +263,7 @@ export default function BulkTradeModal({ mode, tradeMode = 'trade', onConfirm, o
           <div className="bulk-trade-item-list">
             {filteredGroups.map(group => (
               <React.Fragment key={group.name}>
-                <div className="bulk-trade-category-label">{group.name}</div>
+                <div className="bulk-trade-category-label">{group.label || group.name}</div>
                 {group.stocks.map(stock => {
                   const isSelected = !!selectedItems[stock.id];
                   const iconUrl = stock.itemId ? geIconMap[stock.itemId] : null;

--- a/src/hooks/useGPTradedStats.js
+++ b/src/hooks/useGPTradedStats.js
@@ -73,25 +73,6 @@ export function useGPTradedStats(userId) {
       return nextStats;
     };
 
-    const fetchAggregateTotal = async (startDate = null) => {
-      let query = supabase
-        .from('transactions')
-        .select('gp_traded:total.sum()')
-        .eq('user_id', userId);
-
-      if (startDate) {
-        query = query.gte('date', startDate);
-      }
-
-      const { data, error } = await query;
-
-      if (error) {
-        return null;
-      }
-
-      return Number(data?.[0]?.gp_traded) || 0;
-    };
-
     const fetchRowsSince = async (startDate = null) => {
       const rows = [];
       let from = 0;
@@ -131,26 +112,9 @@ export function useGPTradedStats(userId) {
       return buildStatsFromRows(allRows);
     };
 
-    const fetchStatsFromAggregates = async () => {
-      const [daily, weekly, monthly, yearly, total] = await Promise.all([
-        fetchAggregateTotal(dailyStart),
-        fetchAggregateTotal(weeklyStart),
-        fetchAggregateTotal(monthlyStart),
-        fetchAggregateTotal(yearlyStart),
-        fetchAggregateTotal()
-      ]);
-
-      if ([daily, weekly, monthly, yearly, total].some(value => value === null)) {
-        return null;
-      }
-
-      return { daily, weekly, monthly, yearly, total };
-    };
-
     try {
       setLoading(true);
-      const aggregateStats = await fetchStatsFromAggregates();
-      const nextStats = aggregateStats || await fetchStatsFromRows();
+      const nextStats = await fetchStatsFromRows();
       if (nextStats) {
         setStats(nextStats);
       }

--- a/src/hooks/useGroupedStocks.js
+++ b/src/hooks/useGroupedStocks.js
@@ -6,18 +6,68 @@ import { useMemo } from 'react';
  *
  * @param {Stock[]} stocks
  * @param {Category[]} categories
- * @param {'trade'|'investment'} tradeMode
+ * @param {'trade'|'investment'|'all'} tradeMode
  * @param {{ requireShares?: boolean }} options
  */
 export function useGroupedStocks(stocks, categories = [], tradeMode = 'trade', { requireShares = false } = {}) {
   return useMemo(() => {
+    const matchesMode = (item) => {
+      if (tradeMode === 'all') return true;
+      return tradeMode === 'investment' ? item.isInvestment : !item.isInvestment;
+    };
+
+    if (tradeMode === 'all') {
+      const filteredCats = categories.filter(matchesMode);
+      const filtered = stocks.filter(s => matchesMode(s) && (!requireShares || s.shares > 0));
+      const groups = [];
+
+      for (const cat of filteredCats) {
+        if (cat.name === 'Uncategorized') continue;
+
+        const catStocks = filtered.filter(s =>
+          s.category === cat.name && Boolean(s.isInvestment) === Boolean(cat.isInvestment)
+        );
+
+        if (catStocks.length > 0) {
+          const modeLabel = cat.isInvestment ? 'Investments' : 'Trading';
+          groups.push({
+            name: `${modeLabel}:${cat.name}`,
+            label: `${modeLabel} / ${cat.name}`,
+            stocks: catStocks,
+          });
+        }
+      }
+
+      for (const isInvestment of [false, true]) {
+        const modeLabel = isInvestment ? 'Investments' : 'Trading';
+        const catNames = filteredCats
+          .filter(c => Boolean(c.isInvestment) === isInvestment)
+          .map(c => c.name);
+
+        const uncategorized = filtered.filter(s =>
+          Boolean(s.isInvestment) === isInvestment &&
+          (s.category === 'Uncategorized' || !s.category || !catNames.includes(s.category))
+        );
+
+        if (uncategorized.length > 0) {
+          groups.push({
+            name: `${modeLabel}:Uncategorized`,
+            label: `${modeLabel} / Uncategorized`,
+            stocks: uncategorized,
+          });
+        }
+      }
+
+      return groups;
+    }
+
     const filteredCats = categories.filter(c =>
-      tradeMode === 'investment' ? c.isInvestment : !c.isInvestment
+      matchesMode(c)
     );
     const catNames = filteredCats.map(c => c.name);
 
     const filtered = stocks.filter(s => {
-      const modeMatch = tradeMode === 'investment' ? s.isInvestment : !s.isInvestment;
+      const modeMatch = matchesMode(s);
       return modeMatch && (!requireShares || s.shares > 0);
     });
 

--- a/src/hooks/useGroupedStocks.js
+++ b/src/hooks/useGroupedStocks.js
@@ -7,9 +7,14 @@ import { useMemo } from 'react';
  * @param {Stock[]} stocks
  * @param {Category[]} categories
  * @param {'trade'|'investment'|'all'} tradeMode
- * @param {{ requireShares?: boolean }} options
+ * @param {{ requireShares?: boolean, preferredTradeMode?: 'trade'|'investment' }} options
  */
-export function useGroupedStocks(stocks, categories = [], tradeMode = 'trade', { requireShares = false } = {}) {
+export function useGroupedStocks(
+  stocks,
+  categories = [],
+  tradeMode = 'trade',
+  { requireShares = false, preferredTradeMode = 'trade' } = {}
+) {
   return useMemo(() => {
     const matchesMode = (item) => {
       if (tradeMode === 'all') return true;
@@ -20,26 +25,30 @@ export function useGroupedStocks(stocks, categories = [], tradeMode = 'trade', {
       const filteredCats = categories.filter(matchesMode);
       const filtered = stocks.filter(s => matchesMode(s) && (!requireShares || s.shares > 0));
       const groups = [];
+      const modeOrder = preferredTradeMode === 'investment'
+        ? [true, false]
+        : [false, true];
 
-      for (const cat of filteredCats) {
-        if (cat.name === 'Uncategorized') continue;
-
-        const catStocks = filtered.filter(s =>
-          s.category === cat.name && Boolean(s.isInvestment) === Boolean(cat.isInvestment)
+      for (const isInvestment of modeOrder) {
+        const modeLabel = isInvestment ? 'Investments' : 'Trading';
+        const modeCategories = filteredCats.filter(c =>
+          Boolean(c.isInvestment) === isInvestment && c.name !== 'Uncategorized'
         );
 
-        if (catStocks.length > 0) {
-          const modeLabel = cat.isInvestment ? 'Investments' : 'Trading';
-          groups.push({
-            name: `${modeLabel}:${cat.name}`,
-            label: `${modeLabel} / ${cat.name}`,
-            stocks: catStocks,
-          });
-        }
-      }
+        for (const cat of modeCategories) {
+          const catStocks = filtered.filter(s =>
+            s.category === cat.name && Boolean(s.isInvestment) === isInvestment
+          );
 
-      for (const isInvestment of [false, true]) {
-        const modeLabel = isInvestment ? 'Investments' : 'Trading';
+          if (catStocks.length > 0) {
+            groups.push({
+              name: `${modeLabel}:${cat.name}`,
+              label: `${modeLabel} / ${cat.name}`,
+              stocks: catStocks,
+            });
+          }
+        }
+
         const catNames = filteredCats
           .filter(c => Boolean(c.isInvestment) === isInvestment)
           .map(c => c.name);
@@ -87,5 +96,5 @@ export function useGroupedStocks(stocks, categories = [], tradeMode = 'trade', {
     }
 
     return groups;
-  }, [stocks, categories, tradeMode, requireShares]);
+  }, [stocks, categories, tradeMode, requireShares, preferredTradeMode]);
 }

--- a/src/hooks/useStocks.js
+++ b/src/hooks/useStocks.js
@@ -53,10 +53,12 @@ export function useStocks(userId) {
     fetchStocks();
   }, [userId, fetchStocks]);
 
-  const reorderStocks = useCallback(async (stockId, targetStockId, category) => {
+  const reorderStocks = useCallback(async (stockId, targetStockId, category, isInvestment = false) => {
     try {
       // Optimistically update UI first
-      const categoryStocks = stocks.filter(s => s.category === category);
+      const categoryStocks = stocks.filter(s =>
+        s.category === category && Boolean(s.isInvestment) === Boolean(isInvestment)
+      );
       const movingStockIndex = categoryStocks.findIndex(s => s.id === stockId);
       const targetStockIndex = categoryStocks.findIndex(s => s.id === targetStockId);
 
@@ -147,6 +149,7 @@ export function useStocks(userId) {
     if (updates.limit4h !== undefined) dbUpdates.limit4h = updates.limit4h;
     if (updates.onHold !== undefined) dbUpdates.on_hold = updates.onHold;
     if (updates.isInvestment !== undefined) dbUpdates.is_investment = updates.isInvestment;
+    if (updates.position !== undefined) dbUpdates.position = updates.position;
     if (updates.itemId !== undefined) dbUpdates.item_id = updates.itemId;
     if (updates.investmentStartDate !== undefined) dbUpdates.investment_start_date = updates.investmentStartDate || null;
 

--- a/src/pages/NonGEPage.jsx
+++ b/src/pages/NonGEPage.jsx
@@ -28,12 +28,36 @@ function NonGECategorySnapshot({ categories }) {
       </div>
       {categories.length > 0 ? (
         <div className="non-ge-category-snapshot-list">
-          <div className="non-ge-category-snapshot-heading" aria-hidden="true">
-            <span>Category</span>
+          <div className="non-ge-category-snapshot-heading">
+            <span
+              className="non-ge-category-snapshot-tooltip"
+              data-tooltip="Category name and item, held, and sold counts."
+              tabIndex={0}
+            >
+              Category
+            </span>
             <div className="non-ge-category-snapshot-heading-values">
-              <span>Cost</span>
-              <span>Profit</span>
-              <span>Share</span>
+              <span
+                className="non-ge-category-snapshot-tooltip"
+                data-tooltip="Current total cost basis for held items in this category."
+                tabIndex={0}
+              >
+                Cost
+              </span>
+              <span
+                className="non-ge-category-snapshot-tooltip"
+                data-tooltip="All-time realized profit from sold items in this category."
+                tabIndex={0}
+              >
+                Profit
+              </span>
+              <span
+                className="non-ge-category-snapshot-tooltip"
+                data-tooltip="This category's percentage of total Non-GE cost."
+                tabIndex={0}
+              >
+                Share
+              </span>
             </div>
           </div>
           {categories.map(category => (

--- a/src/pages/NonGEPage.jsx
+++ b/src/pages/NonGEPage.jsx
@@ -33,10 +33,16 @@ function NonGECategorySnapshot({ categories }) {
               <div className="non-ge-category-snapshot-main">
                 <span className="non-ge-category-snapshot-name">{category.name}</span>
                 <span className="non-ge-category-snapshot-meta">
-                  {category.itemCount} item{category.itemCount === 1 ? '' : 's'} / {category.heldQtyLabel} held
+                  {category.itemCount} item{category.itemCount === 1 ? '' : 's'} / {category.heldQtyLabel} held / {category.soldQtyLabel} sold
                 </span>
               </div>
-              <span className="non-ge-category-snapshot-value">{category.totalCostLabel}</span>
+              <div className="non-ge-category-snapshot-values">
+                <span className="non-ge-category-snapshot-value">{category.totalCostLabel}</span>
+                <span className={`non-ge-category-snapshot-profit ${category.realizedProfit >= 0 ? 'positive' : 'negative'}`}>
+                  {category.realizedProfitLabel}
+                </span>
+                <span className="non-ge-category-snapshot-share">{category.costShareLabel}</span>
+              </div>
             </div>
           ))}
         </div>
@@ -106,20 +112,27 @@ export default function NonGEPage({
         const categoryStocks = groupedStocks.get(category.id) || [];
         const totalCost = categoryStocks.reduce((sum, stock) => sum + (stock.totalCost || 0), 0);
         const heldQty = categoryStocks.reduce((sum, stock) => sum + (stock.shares || 0), 0);
+        const soldQty = categoryStocks.reduce((sum, stock) => sum + (stock.sharesSold || 0), 0);
+        const realizedProfit = categoryStocks.reduce((sum, stock) => sum + calculateProfit(stock), 0);
+        const costShare = summary.totalCost > 0 ? (totalCost / summary.totalCost) * 100 : 0;
 
         return {
           id: category.id,
           name: category.name,
           itemCount: categoryStocks.length,
           totalCost,
+          realizedProfit,
           totalCostLabel: formatNumber(totalCost, numberFormat),
           heldQtyLabel: formatNumber(heldQty, numberFormat),
+          soldQtyLabel: formatNumber(soldQty, numberFormat),
+          realizedProfitLabel: `${realizedProfit >= 0 ? '+' : ''}${formatNumber(realizedProfit, numberFormat)}`,
+          costShareLabel: `${costShare.toFixed(1)}% of cost`,
         };
       })
       .filter(category => category.itemCount > 0)
       .sort((a, b) => b.totalCost - a.totalCost)
       .slice(0, 3);
-  }, [categories, groupedStocks, numberFormat]);
+  }, [categories, groupedStocks, numberFormat, summary.totalCost]);
 
   const toggleCategory = (categoryId) => {
     setCollapsedCategories(prev => ({ ...prev, [categoryId]: !prev[categoryId] }));

--- a/src/pages/NonGEPage.jsx
+++ b/src/pages/NonGEPage.jsx
@@ -20,6 +20,33 @@ function NonGEStatusItem({ icon: Icon, label, value, valueClass = '' }) {
   );
 }
 
+function NonGECategorySnapshot({ categories }) {
+  return (
+    <div className="trade-quick-actions non-ge-category-snapshot" aria-label="Non-GE category snapshot">
+      <div className="trade-quick-actions-header">
+        <span className="trade-quick-actions-title">Category Snapshot</span>
+      </div>
+      {categories.length > 0 ? (
+        <div className="non-ge-category-snapshot-list">
+          {categories.map(category => (
+            <div key={category.id} className="non-ge-category-snapshot-row">
+              <div className="non-ge-category-snapshot-main">
+                <span className="non-ge-category-snapshot-name">{category.name}</span>
+                <span className="non-ge-category-snapshot-meta">
+                  {category.itemCount} item{category.itemCount === 1 ? '' : 's'} / {category.heldQtyLabel} held
+                </span>
+              </div>
+              <span className="non-ge-category-snapshot-value">{category.totalCostLabel}</span>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="non-ge-category-snapshot-empty">No category data yet</div>
+      )}
+    </div>
+  );
+}
+
 export default function NonGEPage({
   stocks,
   categories,
@@ -72,6 +99,27 @@ export default function NonGEPage({
 
     return groups;
   }, [stocks, categories]);
+
+  const categorySnapshot = useMemo(() => {
+    return categories
+      .map(category => {
+        const categoryStocks = groupedStocks.get(category.id) || [];
+        const totalCost = categoryStocks.reduce((sum, stock) => sum + (stock.totalCost || 0), 0);
+        const heldQty = categoryStocks.reduce((sum, stock) => sum + (stock.shares || 0), 0);
+
+        return {
+          id: category.id,
+          name: category.name,
+          itemCount: categoryStocks.length,
+          totalCost,
+          totalCostLabel: formatNumber(totalCost, numberFormat),
+          heldQtyLabel: formatNumber(heldQty, numberFormat),
+        };
+      })
+      .filter(category => category.itemCount > 0)
+      .sort((a, b) => b.totalCost - a.totalCost)
+      .slice(0, 3);
+  }, [categories, groupedStocks, numberFormat]);
 
   const toggleCategory = (categoryId) => {
     setCollapsedCategories(prev => ({ ...prev, [categoryId]: !prev[categoryId] }));
@@ -212,6 +260,7 @@ export default function NonGEPage({
               </div>
             </div>
           </div>
+          <NonGECategorySnapshot categories={categorySnapshot} />
         </div>
       </section>
 

--- a/src/pages/NonGEPage.jsx
+++ b/src/pages/NonGEPage.jsx
@@ -28,6 +28,14 @@ function NonGECategorySnapshot({ categories }) {
       </div>
       {categories.length > 0 ? (
         <div className="non-ge-category-snapshot-list">
+          <div className="non-ge-category-snapshot-heading" aria-hidden="true">
+            <span>Category</span>
+            <div className="non-ge-category-snapshot-heading-values">
+              <span>Cost</span>
+              <span>Profit</span>
+              <span>Share</span>
+            </div>
+          </div>
           {categories.map(category => (
             <div key={category.id} className="non-ge-category-snapshot-row">
               <div className="non-ge-category-snapshot-main">

--- a/src/pages/NonGEPage.jsx
+++ b/src/pages/NonGEPage.jsx
@@ -20,7 +20,7 @@ function NonGEStatusItem({ icon: Icon, label, value, valueClass = '' }) {
   );
 }
 
-function NonGECategorySnapshot({ categories, segments }) {
+function NonGECategorySnapshot({ categories }) {
   return (
     <div className="trade-quick-actions non-ge-category-snapshot" aria-label="Non-GE category snapshot">
       <div className="trade-quick-actions-header">
@@ -61,12 +61,9 @@ function NonGECategorySnapshot({ categories, segments }) {
             </div>
           </div>
           {categories.map(category => (
-            <div key={category.id} className={`non-ge-category-snapshot-row ${category.colorClass}`}>
+            <div key={category.id} className="non-ge-category-snapshot-row">
               <div className="non-ge-category-snapshot-main">
-                <span className="non-ge-category-snapshot-name">
-                  <span className={`non-ge-category-snapshot-swatch ${category.colorClass}`} aria-hidden="true" />
-                  {category.name}
-                </span>
+                <span className="non-ge-category-snapshot-name">{category.name}</span>
                 <span className="non-ge-category-snapshot-meta">
                   {category.itemCount} item{category.itemCount === 1 ? '' : 's'} / {category.heldQtyLabel} held / {category.soldQtyLabel} sold
                 </span>
@@ -80,39 +77,46 @@ function NonGECategorySnapshot({ categories, segments }) {
               </div>
             </div>
           ))}
-          {segments.length > 0 && (
-            <div className="non-ge-category-allocation">
-              <div className="non-ge-category-allocation-header">
-                <span>Cost allocation</span>
-                <span>Top 3 + other</span>
-              </div>
-              <svg
-                className="non-ge-category-allocation-bar"
-                viewBox="0 0 100 8"
-                preserveAspectRatio="none"
-                role="img"
-                aria-label="Non-GE cost allocation by category"
-              >
-                <rect className="non-ge-category-allocation-bg" x="0" y="0" width="100" height="8" rx="4" />
-                {segments.map(segment => (
-                  <rect
-                    key={segment.id}
-                    className={`non-ge-category-allocation-segment ${segment.colorClass}`}
-                    x={segment.offset}
-                    y="0"
-                    width={segment.width}
-                    height="8"
-                  >
-                    <title>{segment.label}</title>
-                  </rect>
-                ))}
-              </svg>
-            </div>
-          )}
         </div>
       ) : (
         <div className="non-ge-category-snapshot-empty">No category data yet</div>
       )}
+    </div>
+  );
+}
+
+function NonGEQuantityFlow({ flow }) {
+  if (flow.totalQty <= 0) return null;
+
+  return (
+    <div className="non-ge-quick-flow" aria-label="Non-GE quantity flow">
+      <div className="non-ge-quick-flow-header">
+        <span>Quantity flow</span>
+        <span>{flow.heldPercentLabel} held</span>
+      </div>
+      <svg
+        className="non-ge-quick-flow-bar"
+        viewBox="0 0 100 8"
+        preserveAspectRatio="none"
+        role="img"
+        aria-label={`Held quantity ${flow.heldQtyLabel}, sold quantity ${flow.soldQtyLabel}`}
+      >
+        <rect className="non-ge-quick-flow-bg" x="0" y="0" width="100" height="8" rx="4" />
+        {flow.heldPercent > 0 && (
+          <rect className="non-ge-quick-flow-segment is-held" x="0" y="0" width={flow.heldPercent} height="8">
+            <title>Held quantity: {flow.heldQtyLabel}</title>
+          </rect>
+        )}
+        {flow.soldPercent > 0 && (
+          <rect className="non-ge-quick-flow-segment is-sold" x={flow.heldPercent} y="0" width={flow.soldPercent} height="8">
+            <title>Sold quantity: {flow.soldQtyLabel}</title>
+          </rect>
+        )}
+      </svg>
+      <div className="non-ge-quick-flow-legend">
+        <span><i className="is-held" aria-hidden="true" />Held {flow.heldQtyLabel}</span>
+        <span><i className="is-sold" aria-hidden="true" />Sold {flow.soldQtyLabel}</span>
+      </div>
     </div>
   );
 }
@@ -150,12 +154,28 @@ export default function NonGEPage({
       (acc, stock) => ({
         activeItems: acc.activeItems + 1,
         heldQty: acc.heldQty + (stock.shares || 0),
+        soldQty: acc.soldQty + (stock.sharesSold || 0),
         totalCost: acc.totalCost + (stock.totalCost || 0),
         realizedProfit: acc.realizedProfit + calculateProfit(stock),
       }),
-      { activeItems: 0, heldQty: 0, totalCost: 0, realizedProfit: 0 }
+      { activeItems: 0, heldQty: 0, soldQty: 0, totalCost: 0, realizedProfit: 0 }
     );
   }, [stocks]);
+
+  const quantityFlow = useMemo(() => {
+    const totalQty = summary.heldQty + summary.soldQty;
+    const heldPercent = totalQty > 0 ? (summary.heldQty / totalQty) * 100 : 0;
+    const soldPercent = totalQty > 0 ? Math.max(0, 100 - heldPercent) : 0;
+
+    return {
+      totalQty,
+      heldPercent: Number(heldPercent.toFixed(2)),
+      soldPercent: Number(soldPercent.toFixed(2)),
+      heldPercentLabel: `${heldPercent.toFixed(1)}%`,
+      heldQtyLabel: formatNumber(summary.heldQty, numberFormat),
+      soldQtyLabel: formatNumber(summary.soldQty, numberFormat),
+    };
+  }, [numberFormat, summary.heldQty, summary.soldQty]);
 
   const groupedStocks = useMemo(() => {
     const groups = new Map(categories.map(category => [category.id, []]));
@@ -171,7 +191,7 @@ export default function NonGEPage({
   }, [stocks, categories]);
 
   const categorySnapshot = useMemo(() => {
-    const rankedCategories = categories
+    return categories
       .map(category => {
         const categoryStocks = groupedStocks.get(category.id) || [];
         const totalCost = categoryStocks.reduce((sum, stock) => sum + (stock.totalCost || 0), 0);
@@ -186,7 +206,6 @@ export default function NonGEPage({
           itemCount: categoryStocks.length,
           totalCost,
           realizedProfit,
-          costShare,
           totalCostLabel: formatNumber(totalCost, numberFormat),
           heldQtyLabel: formatNumber(heldQty, numberFormat),
           soldQtyLabel: formatNumber(soldQty, numberFormat),
@@ -195,45 +214,8 @@ export default function NonGEPage({
         };
       })
       .filter(category => category.itemCount > 0)
-      .sort((a, b) => b.totalCost - a.totalCost);
-
-    const visibleCategories = rankedCategories.slice(0, 3).map((category, index) => ({
-      ...category,
-      colorClass: `is-snapshot-${index + 1}`,
-    }));
-
-    let offset = 0;
-    const visibleSegments = summary.totalCost > 0
-      ? visibleCategories
-          .filter(category => category.costShare > 0)
-          .map(category => {
-            const segment = {
-              id: category.id,
-              width: Number(category.costShare.toFixed(2)),
-              offset: Number(offset.toFixed(2)),
-              colorClass: category.colorClass,
-              label: `${category.name}: ${category.costShare.toFixed(1)}% of Non-GE cost`,
-            };
-            offset += category.costShare;
-            return segment;
-          })
-      : [];
-
-    const otherShare = summary.totalCost > 0 ? Math.max(0, 100 - offset) : 0;
-    const otherSegment = otherShare > 0.05
-      ? [{
-        id: 'other',
-        width: Number(otherShare.toFixed(2)),
-        offset: Number(offset.toFixed(2)),
-        colorClass: 'is-snapshot-other',
-        label: `Other categories: ${otherShare.toFixed(1)}% of Non-GE cost`,
-      }]
-      : [];
-
-    return {
-      categories: visibleCategories,
-      segments: [...visibleSegments, ...otherSegment],
-    };
+      .sort((a, b) => b.totalCost - a.totalCost)
+      .slice(0, 3);
   }, [categories, groupedStocks, numberFormat, summary.totalCost]);
 
   const toggleCategory = (categoryId) => {
@@ -374,8 +356,9 @@ export default function NonGEPage({
                 </button>
               </div>
             </div>
+            <NonGEQuantityFlow flow={quantityFlow} />
           </div>
-          <NonGECategorySnapshot categories={categorySnapshot.categories} segments={categorySnapshot.segments} />
+          <NonGECategorySnapshot categories={categorySnapshot} />
         </div>
       </section>
 

--- a/src/pages/NonGEPage.jsx
+++ b/src/pages/NonGEPage.jsx
@@ -20,7 +20,7 @@ function NonGEStatusItem({ icon: Icon, label, value, valueClass = '' }) {
   );
 }
 
-function NonGECategorySnapshot({ categories }) {
+function NonGECategorySnapshot({ categories, segments }) {
   return (
     <div className="trade-quick-actions non-ge-category-snapshot" aria-label="Non-GE category snapshot">
       <div className="trade-quick-actions-header">
@@ -61,9 +61,12 @@ function NonGECategorySnapshot({ categories }) {
             </div>
           </div>
           {categories.map(category => (
-            <div key={category.id} className="non-ge-category-snapshot-row">
+            <div key={category.id} className={`non-ge-category-snapshot-row ${category.colorClass}`}>
               <div className="non-ge-category-snapshot-main">
-                <span className="non-ge-category-snapshot-name">{category.name}</span>
+                <span className="non-ge-category-snapshot-name">
+                  <span className={`non-ge-category-snapshot-swatch ${category.colorClass}`} aria-hidden="true" />
+                  {category.name}
+                </span>
                 <span className="non-ge-category-snapshot-meta">
                   {category.itemCount} item{category.itemCount === 1 ? '' : 's'} / {category.heldQtyLabel} held / {category.soldQtyLabel} sold
                 </span>
@@ -77,6 +80,35 @@ function NonGECategorySnapshot({ categories }) {
               </div>
             </div>
           ))}
+          {segments.length > 0 && (
+            <div className="non-ge-category-allocation">
+              <div className="non-ge-category-allocation-header">
+                <span>Cost allocation</span>
+                <span>Top 3 + other</span>
+              </div>
+              <svg
+                className="non-ge-category-allocation-bar"
+                viewBox="0 0 100 8"
+                preserveAspectRatio="none"
+                role="img"
+                aria-label="Non-GE cost allocation by category"
+              >
+                <rect className="non-ge-category-allocation-bg" x="0" y="0" width="100" height="8" rx="4" />
+                {segments.map(segment => (
+                  <rect
+                    key={segment.id}
+                    className={`non-ge-category-allocation-segment ${segment.colorClass}`}
+                    x={segment.offset}
+                    y="0"
+                    width={segment.width}
+                    height="8"
+                  >
+                    <title>{segment.label}</title>
+                  </rect>
+                ))}
+              </svg>
+            </div>
+          )}
         </div>
       ) : (
         <div className="non-ge-category-snapshot-empty">No category data yet</div>
@@ -139,7 +171,7 @@ export default function NonGEPage({
   }, [stocks, categories]);
 
   const categorySnapshot = useMemo(() => {
-    return categories
+    const rankedCategories = categories
       .map(category => {
         const categoryStocks = groupedStocks.get(category.id) || [];
         const totalCost = categoryStocks.reduce((sum, stock) => sum + (stock.totalCost || 0), 0);
@@ -154,6 +186,7 @@ export default function NonGEPage({
           itemCount: categoryStocks.length,
           totalCost,
           realizedProfit,
+          costShare,
           totalCostLabel: formatNumber(totalCost, numberFormat),
           heldQtyLabel: formatNumber(heldQty, numberFormat),
           soldQtyLabel: formatNumber(soldQty, numberFormat),
@@ -162,8 +195,45 @@ export default function NonGEPage({
         };
       })
       .filter(category => category.itemCount > 0)
-      .sort((a, b) => b.totalCost - a.totalCost)
-      .slice(0, 3);
+      .sort((a, b) => b.totalCost - a.totalCost);
+
+    const visibleCategories = rankedCategories.slice(0, 3).map((category, index) => ({
+      ...category,
+      colorClass: `is-snapshot-${index + 1}`,
+    }));
+
+    let offset = 0;
+    const visibleSegments = summary.totalCost > 0
+      ? visibleCategories
+          .filter(category => category.costShare > 0)
+          .map(category => {
+            const segment = {
+              id: category.id,
+              width: Number(category.costShare.toFixed(2)),
+              offset: Number(offset.toFixed(2)),
+              colorClass: category.colorClass,
+              label: `${category.name}: ${category.costShare.toFixed(1)}% of Non-GE cost`,
+            };
+            offset += category.costShare;
+            return segment;
+          })
+      : [];
+
+    const otherShare = summary.totalCost > 0 ? Math.max(0, 100 - offset) : 0;
+    const otherSegment = otherShare > 0.05
+      ? [{
+        id: 'other',
+        width: Number(otherShare.toFixed(2)),
+        offset: Number(offset.toFixed(2)),
+        colorClass: 'is-snapshot-other',
+        label: `Other categories: ${otherShare.toFixed(1)}% of Non-GE cost`,
+      }]
+      : [];
+
+    return {
+      categories: visibleCategories,
+      segments: [...visibleSegments, ...otherSegment],
+    };
   }, [categories, groupedStocks, numberFormat, summary.totalCost]);
 
   const toggleCategory = (categoryId) => {
@@ -305,7 +375,7 @@ export default function NonGEPage({
               </div>
             </div>
           </div>
-          <NonGECategorySnapshot categories={categorySnapshot} />
+          <NonGECategorySnapshot categories={categorySnapshot.categories} segments={categorySnapshot.segments} />
         </div>
       </section>
 

--- a/src/pages/NonGEPage.jsx
+++ b/src/pages/NonGEPage.jsx
@@ -1,15 +1,21 @@
 import React, { useMemo, useState } from 'react';
-import { Archive, Boxes, FolderPlus, PackagePlus, Plus, ShoppingCart, TrendingDown } from 'lucide-react';
+import { Archive, Boxes, FolderPlus, Package, PackagePlus, Plus, ShoppingCart, TrendingDown, TrendingUp, Wallet } from 'lucide-react';
 import NonGECategorySection from '../components/non-ge/NonGECategorySection';
 import { calculateProfit } from '../utils/calculations';
 import { formatNumber } from '../utils/formatters';
+import '../styles/trade-status-strip.css';
 import '../styles/non-ge-page.css';
 
-function SummaryCard({ label, value }) {
+function NonGEStatusItem({ icon: Icon, label, value, valueClass = '' }) {
   return (
-    <div className="non-ge-summary-card">
-      <div className="non-ge-summary-label">{label}</div>
-      <div className="non-ge-summary-value">{value}</div>
+    <div className="trade-status-item">
+      <div className="trade-status-icon">
+        <Icon size={16} />
+      </div>
+      <div className="trade-status-copy">
+        <span className="trade-status-label">{label}</span>
+        <span className={`trade-status-value ${valueClass}`}>{value}</span>
+      </div>
     </div>
   );
 }
@@ -119,48 +125,95 @@ export default function NonGEPage({
 
   return (
     <div className="non-ge-page">
-      <div className="non-ge-page-header">
-        <div>
-          <h1 className="non-ge-page-title">Non-GE Tracker</h1>
-          <p className="non-ge-page-subtitle">Track fixed catalog and private collector items outside Grand Exchange pricing.</p>
+      <section className="trade-status-overview" aria-label="Non-GE overview">
+        <div className="trade-status-strip">
+          <NonGEStatusItem
+            icon={Package}
+            label="Active Items"
+            value={formatNumber(summary.activeItems, 'full')}
+          />
+          <NonGEStatusItem
+            icon={Boxes}
+            label="Held Qty"
+            value={formatNumber(summary.heldQty, numberFormat)}
+          />
+          <NonGEStatusItem
+            icon={Wallet}
+            label="Total Cost"
+            value={formatNumber(summary.totalCost, numberFormat)}
+          />
+          <NonGEStatusItem
+            icon={TrendingUp}
+            label="Realized Profit"
+            value={`${summary.realizedProfit >= 0 ? '+' : ''}${formatNumber(summary.realizedProfit, numberFormat)}`}
+            valueClass={summary.realizedProfit >= 0 ? 'positive' : 'negative'}
+          />
         </div>
-        <div className="non-ge-page-actions">
-          <button type="button" className="btn btn-primary" onClick={onAddCategory}>
-            <FolderPlus size={16} />
-            Add Category
-          </button>
-          <button type="button" className="btn btn-success" onClick={() => onAddItem()}>
-            <Plus size={16} />
-            Add Item
-          </button>
-          <button type="button" className="btn btn-primary" onClick={onBulkAdd}>
-            <PackagePlus size={16} />
-            Bulk Add
-          </button>
-          <button type="button" className="btn btn-success" onClick={onBulkBuy}>
-            <ShoppingCart size={16} />
-            Bulk Buy
-          </button>
-          <button type="button" className="btn btn-sell" onClick={onBulkSell}>
-            <TrendingDown size={16} />
-            Bulk Sell
-          </button>
-          <button type="button" className="btn btn-secondary" onClick={onArchiveOpen}>
-            <Archive size={16} />
-            Archive
-          </button>
-        </div>
-      </div>
 
-      <div className="non-ge-summary-grid">
-        <SummaryCard label="Active Items" value={formatNumber(summary.activeItems, 'full')} />
-        <SummaryCard label="Held Qty" value={formatNumber(summary.heldQty, numberFormat)} />
-        <SummaryCard label="Total Cost" value={formatNumber(summary.totalCost, numberFormat)} />
-        <SummaryCard
-          label="Realized Profit"
-          value={`${summary.realizedProfit >= 0 ? '+' : ''}${formatNumber(summary.realizedProfit, numberFormat)}`}
-        />
-      </div>
+        <div className="trade-status-companion-row non-ge-status-companion-row">
+          <div className="trade-quick-actions" aria-label="Non-GE quick actions">
+            <div className="trade-quick-actions-header">
+              <span className="trade-quick-actions-title">Quick Actions</span>
+            </div>
+            <div className="trade-quick-actions-grid">
+              <div className="trade-quick-action-group">
+                <button
+                  type="button"
+                  className="trade-quick-action-btn is-category"
+                  onClick={onAddCategory}
+                >
+                  <FolderPlus size={14} />
+                  Add Category
+                </button>
+                <button
+                  type="button"
+                  className="trade-quick-action-btn is-item"
+                  onClick={() => onAddItem()}
+                >
+                  <Plus size={14} />
+                  Add Item
+                </button>
+              </div>
+              <div className="trade-quick-action-group">
+                <button
+                  type="button"
+                  className="trade-quick-action-btn is-item"
+                  onClick={onBulkAdd}
+                >
+                  <PackagePlus size={14} />
+                  Bulk Add
+                </button>
+                <button
+                  type="button"
+                  className="trade-quick-action-btn is-success"
+                  onClick={onBulkBuy}
+                >
+                  <ShoppingCart size={14} />
+                  Bulk Buy
+                </button>
+                <button
+                  type="button"
+                  className="trade-quick-action-btn is-danger"
+                  onClick={onBulkSell}
+                >
+                  <TrendingDown size={14} />
+                  Bulk Sell
+                </button>
+              </div>
+              <div className="trade-quick-action-group trade-quick-action-group-archive">
+                <button
+                  type="button"
+                  className="trade-quick-action-btn"
+                  onClick={onArchiveOpen}
+                >
+                  <Archive size={14} />
+                  Archive
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
 
       {loading ? (
         <div className="non-ge-page-empty">Loading Non-GE items...</div>

--- a/src/styles/non-ge-page.css
+++ b/src/styles/non-ge-page.css
@@ -3,7 +3,7 @@
 }
 
 .non-ge-status-companion-row {
-  grid-template-columns: minmax(28rem, 1.4fr) minmax(20rem, 0.9fr);
+  grid-template-columns: minmax(27rem, 0.9fr) minmax(34rem, 1.65fr);
 }
 
 .non-ge-category-snapshot {
@@ -50,11 +50,40 @@
   white-space: nowrap;
 }
 
-.non-ge-category-snapshot-value {
+.non-ge-category-snapshot-values {
   flex: 0 0 auto;
+  display: grid;
+  grid-template-columns: minmax(5.5rem, auto) minmax(5.5rem, auto) minmax(5.5rem, auto);
+  gap: 0.65rem;
+  align-items: center;
+  text-align: right;
+}
+
+.non-ge-category-snapshot-value {
   color: rgb(147, 197, 253);
   font-size: 0.82rem;
   font-weight: 800;
+  white-space: nowrap;
+}
+
+.non-ge-category-snapshot-profit {
+  font-size: 0.82rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.non-ge-category-snapshot-profit.positive {
+  color: rgb(52, 211, 153);
+}
+
+.non-ge-category-snapshot-profit.negative {
+  color: rgb(248, 113, 113);
+}
+
+.non-ge-category-snapshot-share {
+  color: rgb(148, 163, 184);
+  font-size: 0.74rem;
+  font-weight: 700;
   white-space: nowrap;
 }
 

--- a/src/styles/non-ge-page.css
+++ b/src/styles/non-ge-page.css
@@ -24,6 +24,27 @@
   gap: 0.45rem;
 }
 
+.non-ge-category-snapshot-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0 0.6rem;
+  color: rgb(148, 163, 184);
+  font-size: 0.68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.non-ge-category-snapshot-heading-values {
+  flex: 0 0 auto;
+  display: grid;
+  grid-template-columns: minmax(5.5rem, auto) minmax(5.5rem, auto) minmax(5.5rem, auto);
+  gap: 0.65rem;
+  text-align: right;
+}
+
 .non-ge-category-snapshot-row {
   min-width: 0;
   display: flex;

--- a/src/styles/non-ge-page.css
+++ b/src/styles/non-ge-page.css
@@ -45,6 +45,43 @@
   text-align: right;
 }
 
+.non-ge-category-snapshot-tooltip {
+  position: relative;
+  cursor: help;
+  outline: none;
+}
+
+.non-ge-category-snapshot-tooltip:hover::after,
+.non-ge-category-snapshot-tooltip:focus-visible::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 0;
+  bottom: calc(100% + 0.45rem);
+  z-index: 20;
+  width: max-content;
+  max-width: 15rem;
+  padding: 0.45rem 0.55rem;
+  color: rgb(226, 232, 240);
+  background: rgb(15, 23, 42);
+  border: 1px solid rgb(51, 65, 85);
+  border-radius: 0.375rem;
+  box-shadow: 0 10px 24px rgba(2, 6, 23, 0.35);
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1.3;
+  letter-spacing: 0;
+  text-align: left;
+  text-transform: none;
+  white-space: normal;
+  pointer-events: none;
+}
+
+.non-ge-category-snapshot-heading-values .non-ge-category-snapshot-tooltip:hover::after,
+.non-ge-category-snapshot-heading-values .non-ge-category-snapshot-tooltip:focus-visible::after {
+  right: 0;
+  left: auto;
+}
+
 .non-ge-category-snapshot-row {
   min-width: 0;
   display: flex;

--- a/src/styles/non-ge-page.css
+++ b/src/styles/non-ge-page.css
@@ -3,7 +3,67 @@
 }
 
 .non-ge-status-companion-row {
-  grid-template-columns: 1fr;
+  grid-template-columns: minmax(28rem, 1.4fr) minmax(20rem, 0.9fr);
+}
+
+.non-ge-category-snapshot {
+  justify-content: flex-start;
+}
+
+.non-ge-category-snapshot-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.non-ge-category-snapshot-row {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.5rem 0.6rem;
+  background: rgba(15, 23, 42, 0.46);
+  border: 1px solid rgba(51, 65, 85, 0.9);
+  border-radius: 0.375rem;
+}
+
+.non-ge-category-snapshot-main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.12rem;
+}
+
+.non-ge-category-snapshot-name {
+  color: rgb(226, 232, 240);
+  font-size: 0.82rem;
+  font-weight: 800;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.non-ge-category-snapshot-meta {
+  color: rgb(148, 163, 184);
+  font-size: 0.74rem;
+  white-space: nowrap;
+}
+
+.non-ge-category-snapshot-value {
+  flex: 0 0 auto;
+  color: rgb(147, 197, 253);
+  font-size: 0.82rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.non-ge-category-snapshot-empty {
+  display: flex;
+  align-items: center;
+  min-height: 2.5rem;
+  color: rgb(148, 163, 184);
+  font-size: 0.82rem;
 }
 
 .non-ge-page .btn:hover,

--- a/src/styles/non-ge-page.css
+++ b/src/styles/non-ge-page.css
@@ -102,31 +102,12 @@
 }
 
 .non-ge-category-snapshot-name {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
   color: rgb(226, 232, 240);
   font-size: 0.82rem;
   font-weight: 800;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.non-ge-category-snapshot-swatch {
-  width: 0.45rem;
-  height: 0.45rem;
-  flex: 0 0 auto;
-  border-radius: 999px;
-  background: rgb(96, 165, 250);
-}
-
-.non-ge-category-snapshot-swatch.is-snapshot-2 {
-  background: rgb(52, 211, 153);
-}
-
-.non-ge-category-snapshot-swatch.is-snapshot-3 {
-  background: rgb(168, 85, 247);
 }
 
 .non-ge-category-snapshot-meta {
@@ -180,15 +161,15 @@
   font-size: 0.82rem;
 }
 
-.non-ge-category-allocation {
+.non-ge-quick-flow {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  margin-top: 0.2rem;
-  padding: 0 0.6rem 0.2rem;
+  margin-top: auto;
+  padding-top: 0.8rem;
 }
 
-.non-ge-category-allocation-header {
+.non-ge-quick-flow-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -200,32 +181,57 @@
   letter-spacing: 0.04em;
 }
 
-.non-ge-category-allocation-bar {
+.non-ge-quick-flow-bar {
   display: block;
   width: 100%;
-  height: 0.55rem;
+  height: 0.6rem;
   overflow: hidden;
   border-radius: 999px;
 }
 
-.non-ge-category-allocation-bg {
-  fill: rgba(15, 23, 42, 0.7);
+.non-ge-quick-flow-bg {
+  fill: rgba(15, 23, 42, 0.72);
 }
 
-.non-ge-category-allocation-segment {
-  fill: rgb(96, 165, 250);
+.non-ge-quick-flow-segment.is-held {
+  fill: rgb(34, 197, 94);
 }
 
-.non-ge-category-allocation-segment.is-snapshot-2 {
-  fill: rgb(52, 211, 153);
+.non-ge-quick-flow-segment.is-sold {
+  fill: rgb(239, 68, 68);
 }
 
-.non-ge-category-allocation-segment.is-snapshot-3 {
-  fill: rgb(168, 85, 247);
+.non-ge-quick-flow-legend {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  color: rgb(148, 163, 184);
+  font-size: 0.72rem;
+  font-weight: 700;
 }
 
-.non-ge-category-allocation-segment.is-snapshot-other {
-  fill: rgb(71, 85, 105);
+.non-ge-quick-flow-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  min-width: 0;
+  white-space: nowrap;
+}
+
+.non-ge-quick-flow-legend i {
+  width: 0.42rem;
+  height: 0.42rem;
+  flex: 0 0 auto;
+  border-radius: 999px;
+}
+
+.non-ge-quick-flow-legend i.is-held {
+  background: rgb(34, 197, 94);
+}
+
+.non-ge-quick-flow-legend i.is-sold {
+  background: rgb(239, 68, 68);
 }
 
 .non-ge-page .btn:hover,

--- a/src/styles/non-ge-page.css
+++ b/src/styles/non-ge-page.css
@@ -2,6 +2,10 @@
   padding-bottom: 2rem;
 }
 
+.non-ge-status-companion-row {
+  grid-template-columns: 1fr;
+}
+
 .non-ge-page .btn:hover,
 .non-ge-modal .btn:hover {
   transform: none;

--- a/src/styles/non-ge-page.css
+++ b/src/styles/non-ge-page.css
@@ -102,12 +102,31 @@
 }
 
 .non-ge-category-snapshot-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
   color: rgb(226, 232, 240);
   font-size: 0.82rem;
   font-weight: 800;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.non-ge-category-snapshot-swatch {
+  width: 0.45rem;
+  height: 0.45rem;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: rgb(96, 165, 250);
+}
+
+.non-ge-category-snapshot-swatch.is-snapshot-2 {
+  background: rgb(52, 211, 153);
+}
+
+.non-ge-category-snapshot-swatch.is-snapshot-3 {
+  background: rgb(168, 85, 247);
 }
 
 .non-ge-category-snapshot-meta {
@@ -159,6 +178,54 @@
   min-height: 2.5rem;
   color: rgb(148, 163, 184);
   font-size: 0.82rem;
+}
+
+.non-ge-category-allocation {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-top: 0.2rem;
+  padding: 0 0.6rem 0.2rem;
+}
+
+.non-ge-category-allocation-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  color: rgb(148, 163, 184);
+  font-size: 0.68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.non-ge-category-allocation-bar {
+  display: block;
+  width: 100%;
+  height: 0.55rem;
+  overflow: hidden;
+  border-radius: 999px;
+}
+
+.non-ge-category-allocation-bg {
+  fill: rgba(15, 23, 42, 0.7);
+}
+
+.non-ge-category-allocation-segment {
+  fill: rgb(96, 165, 250);
+}
+
+.non-ge-category-allocation-segment.is-snapshot-2 {
+  fill: rgb(52, 211, 153);
+}
+
+.non-ge-category-allocation-segment.is-snapshot-3 {
+  fill: rgb(168, 85, 247);
+}
+
+.non-ge-category-allocation-segment.is-snapshot-other {
+  fill: rgb(71, 85, 105);
 }
 
 .non-ge-page .btn:hover,

--- a/src/styles/non-ge-page.css
+++ b/src/styles/non-ge-page.css
@@ -2,8 +2,16 @@
   padding-bottom: 2rem;
 }
 
-.non-ge-status-companion-row {
-  grid-template-columns: minmax(27rem, 0.9fr) minmax(34rem, 1.65fr);
+.trade-status-companion-row.non-ge-status-companion-row {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.non-ge-status-companion-row > .trade-quick-actions {
+  grid-column: span 2;
+}
+
+.non-ge-status-companion-row > .non-ge-category-snapshot {
+  grid-column: span 2;
 }
 
 .non-ge-category-snapshot {
@@ -718,6 +726,15 @@
 }
 
 @media (max-width: 800px) {
+  .trade-status-companion-row.non-ge-status-companion-row {
+    grid-template-columns: 1fr;
+  }
+
+  .non-ge-status-companion-row > .trade-quick-actions,
+  .non-ge-status-companion-row > .non-ge-category-snapshot {
+    grid-column: auto;
+  }
+
   .non-ge-page-header {
     flex-direction: column;
     align-items: stretch;


### PR DESCRIPTION
## Summary
- Make GE bulk buy/sell show both Trading and Investments stocks in one picker
- Keep same-named categories separated with Trading / ... and Investments / ... labels
- Preserve sell filtering so only stocks with held quantity can be selected

Fixes #301

## Verification
- npm run build
- Browser smoke test: opened the local app and Bulk Buy modal; no console errors observed