### PR TITLE
Fix local time boundaries

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -56,6 +56,7 @@ import {
   DEFAULT_CATEGORIES,
   DEFAULT_VISIBLE_COLUMNS
 } from './utils/constants';
+import { getNextLocalMidnight } from './utils/localPeriods';
 import { useModalHandlers } from './hooks/useModalHandlers';
 import { useNavigation } from './hooks/useNavigation';
 
@@ -85,6 +86,7 @@ export default function MainApp(props) {
 function MainAppInner({ session, onLogout }) {
   const userId = session.user.id;
   const userEmail = session.user.email;
+  const [milestoneBoundaryTick, setMilestoneBoundaryTick] = useState(0);
   const {
     tradeMode,
     setTradeMode,
@@ -583,6 +585,39 @@ function MainAppInner({ session, onLogout }) {
   }, [userId, ensureNonGEDefaultCategories]);
 
   useEffect(() => {
+    if (!userId) return;
+
+    let timeoutId;
+    let nextBoundary = getNextLocalMidnight();
+
+    function scheduleNextRefresh() {
+      window.clearTimeout(timeoutId);
+      const delay = Math.max(0, nextBoundary.getTime() - Date.now());
+      timeoutId = window.setTimeout(refreshAfterBoundary, delay);
+    }
+
+    function refreshAfterBoundary() {
+      nextBoundary = getNextLocalMidnight();
+      setMilestoneBoundaryTick(tick => tick + 1);
+      scheduleNextRefresh();
+    }
+
+    function handleVisibilityChange() {
+      if (document.visibilityState === 'visible' && Date.now() >= nextBoundary.getTime()) {
+        refreshAfterBoundary();
+      }
+    }
+
+    scheduleNextRefresh();
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [userId]);
+
+  useEffect(() => {
     if (!profitHistory || profitHistoryLoading) return;
 
     const newProgress = calculateMilestoneProgress();
@@ -632,7 +667,18 @@ function MainAppInner({ session, onLogout }) {
     if (!milestonesLoading) {
       recordCompletedPeriods(profitHistory, milestones);
     }
-  }, [profitHistory, milestones, calculateMilestoneProgress, setMilestoneProgress]);
+  }, [
+    profitHistory,
+    profitHistoryLoading,
+    milestones,
+    milestonesLoading,
+    milestoneBoundaryTick,
+    calculateMilestoneProgress,
+    setMilestoneProgress,
+    recordCompletedPeriods,
+    addNotification,
+    userId
+  ]);
 
   // OSRS News notification effect
   useEffect(() => {

--- a/src/components/StockTable.jsx
+++ b/src/components/StockTable.jsx
@@ -22,10 +22,12 @@ import { useGEData } from '../contexts/GEDataContext';
 import ItemIcon from './ItemIcon';
 import '../styles/table.css';
 import { sortStocks } from '../utils/calculations';
+import { parseLocalDate } from '../utils/localPeriods';
 
 function investmentAge(dateStr) {
   if (!dateStr) return null;
-  const start = new Date(dateStr);
+  const start = parseLocalDate(dateStr);
+  if (!start) return null;
   const now = new Date();
   let years = now.getFullYear() - start.getFullYear();
   let months = now.getMonth() - start.getMonth();

--- a/src/components/analytics/widgets/BestDaysTable.jsx
+++ b/src/components/analytics/widgets/BestDaysTable.jsx
@@ -8,6 +8,7 @@ import {
   toIsoDate,
   totalProfit,
 } from '../../../utils/analyticsHelpers';
+import { formatLocalDate } from '../../../utils/localPeriods';
 
 const TIMEFRAMES = ['1W', '1M', '3M', '6M', '1Y', 'All'];
 const PERIODS = [
@@ -98,7 +99,7 @@ function buildTopItemsByPeriod(transactions, stocks, profitHistory, period, star
     if (getProfitType(profitEntry) !== 'stock') continue;
 
     const tx = txMap.get(String(getProfitTxId(profitEntry)));
-    const iso = String(tx?.date || getProfitDate(profitEntry) || '').slice(0, 10);
+    const iso = formatLocalDate(tx?.date || getProfitDate(profitEntry));
     if (!iso) continue;
     if (startDate && iso < startDate) continue;
     if (endDate && iso > endDate) continue;
@@ -116,7 +117,7 @@ function buildTopItemsByPeriod(transactions, stocks, profitHistory, period, star
   for (const transaction of transactions) {
     if (transaction.type !== 'sell') continue;
 
-    const iso = String(transaction.date || '').slice(0, 10);
+    const iso = formatLocalDate(transaction.date);
     if (!iso) continue;
     if (startDate && iso < startDate) continue;
     if (endDate && iso > endDate) continue;

--- a/src/components/analytics/widgets/CategoryDrilldownDrawer.jsx
+++ b/src/components/analytics/widgets/CategoryDrilldownDrawer.jsx
@@ -11,6 +11,7 @@ import {
 } from 'recharts';
 import { buildCategoryDrilldownData } from '../../../utils/categoryAnalytics';
 import { formatNumber } from '../../../utils/formatters';
+import { formatLocalDate } from '../../../utils/localPeriods';
 
 function ChartTooltip({ active, payload, label, numberFormat }) {
   if (!active || !payload?.length) return null;
@@ -45,7 +46,7 @@ const formatTurnover = (value) => {
   return `${numericValue.toFixed(1)}%`;
 };
 
-const formatDate = (value) => (value ? String(value).slice(0, 10) : '-');
+const formatDate = (value) => formatLocalDate(value) || '-';
 
 export default function CategoryDrilldownDrawer({
   category,

--- a/src/components/analytics/widgets/HourlyProfitHeatmap.jsx
+++ b/src/components/analytics/widgets/HourlyProfitHeatmap.jsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useRef } from 'react';
 import { formatNumber } from '../../../utils/formatters';
+import { formatLocalDate } from '../../../utils/localPeriods';
 
 const DAY_ORDER = [1, 2, 3, 4, 5, 6, 0];
 const DAY_LABELS = {
@@ -23,16 +24,6 @@ const TOOLTIP_HEIGHT = 58;
 
 const getProfitType = (profit) => profit.profit_type ?? profit.profitType;
 const getProfitTxId = (profit) => profit.transaction_id ?? profit.transactionId;
-
-function toLocalDateKey(value) {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return '';
-
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-}
 
 function buildThresholds(values, count = 5) {
   const sorted = [...values].filter((value) => value > 0).sort((a, b) => a - b);
@@ -119,7 +110,7 @@ function rowsFromCells(cells) {
 function addSellToCells({ cells, transaction, profit, startDate, endDate }) {
   if (!transaction?.date) return;
 
-  const localDate = toLocalDateKey(transaction.date);
+  const localDate = formatLocalDate(transaction.date);
   if (startDate && localDate < startDate) return;
   if (endDate && localDate > endDate) return;
 

--- a/src/components/analytics/widgets/ItemDrilldownDrawer.jsx
+++ b/src/components/analytics/widgets/ItemDrilldownDrawer.jsx
@@ -15,6 +15,7 @@ import {
   getItemTransactions,
 } from '../../../utils/itemAnalytics';
 import { formatNumber } from '../../../utils/formatters';
+import { formatLocalDate } from '../../../utils/localPeriods';
 
 function ChartTooltip({ active, payload, label, numberFormat, valueLabel }) {
   if (!active || !payload?.length) return null;
@@ -93,7 +94,7 @@ export default function ItemDrilldownDrawer({
   const priceSeries = useMemo(() => (
     (priceData || [])
       .map((row) => ({
-        date: new Date(Number(row.timestamp) * 1000).toISOString().slice(0, 10),
+        date: formatLocalDate(new Date(Number(row.timestamp) * 1000)),
         high: Number(row.avgHighPrice),
       }))
       .filter((row) => Number.isFinite(row.high) && row.high > 0)
@@ -263,7 +264,7 @@ export default function ItemDrilldownDrawer({
             <tbody>
               {itemTransactions.map((transaction) => (
                 <tr key={transaction.id}>
-                  <td>{String(transaction.date).slice(0, 10)}</td>
+                  <td>{formatLocalDate(transaction.date)}</td>
                   <td><span className="items-badge">{transaction.type}</span></td>
                   <td>{formatNumber(transaction.shares, numberFormat)}</td>
                   <td>{formatNumber(transaction.total, numberFormat)}</td>

--- a/src/components/analytics/widgets/ProfitHeatmap.jsx
+++ b/src/components/analytics/widgets/ProfitHeatmap.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useRef } from 'react';
 import { formatNumber } from '../../../utils/formatters';
 import { parseIsoDateUtc, totalProfit } from '../../../utils/analyticsHelpers';
+import { formatLocalDate } from '../../../utils/localPeriods';
 
 const CELL = 10;
 const GAP = 2;
@@ -14,7 +15,7 @@ const TOOLTIP_TEXT_SIZE = 10;
 
 function buildLast365Days(endIso) {
   const days = [];
-  const end = endIso ? parseIsoDateUtc(endIso) : new Date();
+  const end = parseIsoDateUtc(endIso || formatLocalDate(new Date()));
 
   for (let index = 364; index >= 0; index -= 1) {
     const date = new Date(end);

--- a/src/components/analytics/widgets/ProfitVelocityWidget.jsx
+++ b/src/components/analytics/widgets/ProfitVelocityWidget.jsx
@@ -3,6 +3,7 @@ import { ArrowDown, ArrowUp, Minus } from 'lucide-react';
 import { Line, LineChart, ResponsiveContainer } from 'recharts';
 import { formatNumber } from '../../../utils/formatters';
 import { addDays, subtractDays, totalProfit } from '../../../utils/analyticsHelpers';
+import { formatLocalDate } from '../../../utils/localPeriods';
 
 const WINDOWS = [7, 30, 90];
 const SPARKLINE_POINTS = 60;
@@ -22,7 +23,7 @@ function buildDailySeries(buckets, endDate) {
   }
 
   const sortedDates = dates.sort();
-  const endIso = endDate || sortedDates[sortedDates.length - 1] || new Date().toISOString().slice(0, 10);
+  const endIso = endDate || sortedDates[sortedDates.length - 1] || formatLocalDate(new Date());
   const startIso = subtractDays(endIso, LOOKBACK_DAYS);
   const series = [];
 

--- a/src/components/modals/AdjustModal.jsx
+++ b/src/components/modals/AdjustModal.jsx
@@ -4,6 +4,7 @@ import { useGEData } from '../../contexts/GEDataContext';
 import { useTrade } from '../../contexts/TradeContext';
 import StepInput from '../StepInput';
 import { searchGEItems } from '../../utils/geItemSearch';
+import { formatLocalDate } from '../../utils/localPeriods';
 
 export default function AdjustModal({ stock, onConfirm, onCancel }) {
   const { geMapping: mapping } = useGEData();
@@ -15,7 +16,7 @@ export default function AdjustModal({ stock, onConfirm, onCancel }) {
   const [limit4h, setLimit4h] = useState(stock.limit4h.toString());
   const [onHold, setOnHold] = useState(stock.onHold || false);
   const [isInvestment, setIsInvestment] = useState(stock.isInvestment || false);
-  const [investmentStartDate, setInvestmentStartDate] = useState(stock.investmentStartDate ? stock.investmentStartDate.slice(0, 10) : '');
+  const [investmentStartDate, setInvestmentStartDate] = useState(formatLocalDate(stock.investmentStartDate));
   const [targetCategory, setTargetCategory] = useState('Uncategorized');
   const [itemId, setItemId] = useState(stock.itemId || null);
   const [searchQuery, setSearchQuery] = useState(() => {

--- a/src/contexts/UIStateContext.jsx
+++ b/src/contexts/UIStateContext.jsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useState, useCallback, useMemo, useRef } from 'react';
 import { useProfitHistoryContext } from './ProfitHistoryContext';
+import { getLocalPeriodStart } from '../utils/localPeriods';
 
 const UIStateContext = createContext(null);
 const HighlightContext = createContext(null);
@@ -32,16 +33,7 @@ export function UIStateProvider({ userId, children }) {
 
     const getStartOfPeriod = (period) => {
       const now = new Date();
-      const date = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
-      if (period === 'day') return date;
-      if (period === 'week') {
-        const dayOfWeek = (date.getUTCDay() + 6) % 7;
-        date.setUTCDate(date.getUTCDate() - dayOfWeek);
-        return date;
-      }
-      if (period === 'month') return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
-      if (period === 'year') return new Date(Date.UTC(now.getUTCFullYear(), 0, 1));
-      return date;
+      return getLocalPeriodStart(now, period);
     };
 
     const calcPeriod = (period) => {

--- a/src/hooks/useAnalytics.js
+++ b/src/hooks/useAnalytics.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { formatLocalDate } from '../utils/localPeriods';
 
 const MAX_CACHE_ENTRIES = 50;
 const cache = new Map();
@@ -25,7 +26,7 @@ const aggregateGpTradedLocally = ({ transactions, start, end, bucket }) => {
   const totals = new Map();
 
   for (const tx of transactions || []) {
-    const iso = String(tx.date || '').slice(0, 10);
+    const iso = formatLocalDate(tx.date);
     if (iso < start || iso > end) continue;
 
     const key = truncBucket(iso, bucket);
@@ -154,7 +155,7 @@ export function aggregateBucketsLocally({ transactions, stocks, profitHistory, s
   };
 
   for (const tx of transactions || []) {
-    const iso = String(tx.date || '').slice(0, 10);
+    const iso = formatLocalDate(tx.date);
     if (!inWindow(iso)) continue;
 
     const key = truncBucket(iso, bucket);
@@ -165,7 +166,7 @@ export function aggregateBucketsLocally({ transactions, stocks, profitHistory, s
   for (const profit of profitHistory || []) {
     const tx = txMap.get(String(profit.transaction_id ?? profit.transactionId ?? ''));
     const isoSource = profit.profit_type === 'stock' && tx?.date ? tx.date : profit.created_at;
-    const iso = String(isoSource || '').slice(0, 10);
+    const iso = formatLocalDate(isoSource);
     if (!inWindow(iso)) continue;
 
     const key = truncBucket(iso, bucket);

--- a/src/hooks/useAnalyticsTimeframe.js
+++ b/src/hooks/useAnalyticsTimeframe.js
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useCallback } from 'react';
-import { subtractDays, toIsoDate } from '../utils/analyticsHelpers';
+import { subtractDays } from '../utils/analyticsHelpers';
+import { formatLocalDate } from '../utils/localPeriods';
 import { useUrlState } from './useUrlState';
 
 const WINDOW_OPTIONS = ['1W', '1M', '3M', '6M', '1Y', 'All'];
@@ -68,7 +69,7 @@ export function useAnalyticsTimeframe(userId, allTimeStart = null) {
   }, [setWindowState, storageKey]);
 
   const { start, end, bucket } = useMemo(() => {
-    const endIso = toIsoDate(new Date());
+    const endIso = formatLocalDate(new Date());
     const days = daysForWindow(window);
 
     if (days == null) {

--- a/src/hooks/useGPTradedStats.js
+++ b/src/hooks/useGPTradedStats.js
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect } from 'react';
 import { supabase } from '../lib/supabase';
+import { formatLocalDate } from '../utils/localPeriods';
 
 const GP_TRADED_BATCH_SIZE = 1000;
 
@@ -10,10 +11,6 @@ const EMPTY_STATS = {
   yearly: 0,
   total: 0
 };
-
-function toIsoDate(date) {
-  return date.toISOString().slice(0, 10);
-}
 
 export function useGPTradedStats(userId) {
   const [stats, setStats] = useState(EMPTY_STATS);
@@ -31,21 +28,21 @@ export function useGPTradedStats(userId) {
       switch (period) {
         case 'day':
           date.setHours(0, 0, 0, 0);
-          return toIsoDate(date);
+          return formatLocalDate(date);
         case 'week':
           const day = date.getDay();
           const diff = date.getDate() - day + (day === 0 ? -6 : 1);
           date.setDate(diff);
           date.setHours(0, 0, 0, 0);
-          return toIsoDate(date);
+          return formatLocalDate(date);
         case 'month':
           date.setDate(1);
           date.setHours(0, 0, 0, 0);
-          return toIsoDate(date);
+          return formatLocalDate(date);
         case 'year':
           date.setMonth(0, 1);
           date.setHours(0, 0, 0, 0);
-          return toIsoDate(date);
+          return formatLocalDate(date);
         default:
           return null;
       }
@@ -60,7 +57,7 @@ export function useGPTradedStats(userId) {
       const nextStats = { ...EMPTY_STATS };
 
       for (const row of rows || []) {
-        const rowDate = String(row.bucket_date || row.date || '').slice(0, 10);
+        const rowDate = formatLocalDate(row.bucket_date || row.date);
         const gpTraded = Number(row.gp_traded ?? row.total) || 0;
 
         nextStats.total += gpTraded;

--- a/src/hooks/useMilestones.js
+++ b/src/hooks/useMilestones.js
@@ -1,67 +1,25 @@
 import { useState, useEffect, useCallback } from 'react';
 import { supabase } from '../lib/supabase';
+import { formatLocalDate, getLocalPeriodEnd, getLocalPeriodStart } from '../utils/localPeriods';
 
 const PRESET_GOALS = [10000000, 50000000, 100000000, 500000000, 1000000000]; // 10M, 50M, 100M, 500M, 1B
 
 // --- Period helpers ---
 
-const getPeriodStart = (date, period) => {
-  const d = new Date(date);
-  switch (period) {
-    case 'day':
-      return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
-    case 'week': {
-      const day = d.getUTCDay();
-      const diff = day === 0 ? -6 : 1 - day; // Monday = start
-      const start = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
-      start.setUTCDate(start.getUTCDate() + diff);
-      return start;
-    }
-    case 'month':
-      return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1));
-    case 'year':
-      return new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
-    default:
-      return d;
-  }
-};
-
-const getPeriodEnd = (periodStart, period) => {
-  const d = new Date(periodStart);
-  switch (period) {
-    case 'day':
-      d.setUTCDate(d.getUTCDate() + 1);
-      return d;
-    case 'week':
-      d.setUTCDate(d.getUTCDate() + 7);
-      return d;
-    case 'month':
-      d.setUTCMonth(d.getUTCMonth() + 1);
-      return d;
-    case 'year':
-      d.setUTCFullYear(d.getUTCFullYear() + 1);
-      return d;
-    default:
-      return d;
-  }
-};
-
 // Returns all completed period start dates between minDate and now (exclusive current period)
 const generatePastPeriods = (period, minDate) => {
   const now = new Date();
-  const currentPeriodStart = getPeriodStart(now, period);
+  const currentPeriodStart = getLocalPeriodStart(now, period);
   const periods = [];
 
-  let cursor = getPeriodStart(minDate, period);
+  let cursor = getLocalPeriodStart(minDate, period);
   while (cursor < currentPeriodStart) {
     periods.push(new Date(cursor));
-    cursor = getPeriodEnd(cursor, period);
+    cursor = getLocalPeriodEnd(cursor, period);
   }
 
   return periods;
 };
-
-const toDateString = (date) => date.toISOString().slice(0, 10);
 
 // ---
 
@@ -176,8 +134,8 @@ export function useMilestones(userId) {
     return true;
   }, [userId, fetchMilestoneHistory]);
 
-  // Scans profitHistory to backfill milestone_history for all completed past periods.
-  // Safe to call repeatedly — skips periods already recorded.
+  // Scans profitHistory to upsert milestone_history for all completed past periods.
+  // Safe to call repeatedly because completed period rows are keyed by period_start.
   const recordCompletedPeriods = useCallback(async (profitHistory, currentMilestones) => {
     if (!profitHistory || profitHistory.length === 0) return;
 
@@ -185,7 +143,7 @@ export function useMilestones(userId) {
     const entryDates = profitHistory.map(e => new Date(e.created_at).getTime());
     const minDate = new Date(Math.min(...entryDates));
     const oneYearAgo = new Date();
-    oneYearAgo.setUTCFullYear(oneYearAgo.getUTCFullYear() - 1);
+    oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
     const effectiveMinDate = minDate < oneYearAgo ? oneYearAgo : minDate;
 
     const periodTypes = ['day', 'week', 'month', 'year'];
@@ -195,21 +153,11 @@ export function useMilestones(userId) {
       const pastPeriods = generatePastPeriods(period, effectiveMinDate);
       if (pastPeriods.length === 0) continue;
 
-      // Fetch already-recorded period_starts for this user+period
-      const { data: existing } = await supabase
-        .from('milestone_history')
-        .select('period_start')
-        .eq('user_id', userId)
-        .eq('period', period);
-
-      const existingStarts = new Set((existing || []).map(r => r.period_start));
-
       const toInsert = [];
       for (const periodStart of pastPeriods) {
-        const periodStartStr = toDateString(periodStart);
-        if (existingStarts.has(periodStartStr)) continue;
+        const periodStartStr = formatLocalDate(periodStart);
 
-        const periodEnd = getPeriodEnd(periodStart, period);
+        const periodEnd = getLocalPeriodEnd(periodStart, period);
 
         const actualAmount = profitHistory
           .filter(entry => {
@@ -231,7 +179,7 @@ export function useMilestones(userId) {
       if (toInsert.length > 0) {
         const { error } = await supabase
           .from('milestone_history')
-          .upsert(toInsert, { onConflict: 'user_id,period,period_start', ignoreDuplicates: true });
+          .upsert(toInsert, { onConflict: 'user_id,period,period_start' });
 
         if (error) {
           console.error(`Error recording milestone history for ${period}:`, error);

--- a/src/hooks/useTransactions.js
+++ b/src/hooks/useTransactions.js
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { supabase } from '../lib/supabase';
+import { getLocalDateEndIso, getLocalDateStartIso } from '../utils/localPeriods';
 
 const RECENT_TRANSACTION_WINDOW_DAYS = 90;
 const RECENT_TRANSACTION_ROW_CAP = 10000;
@@ -157,8 +158,10 @@ export function useTransactions(userId) {
       if (visibleProfitTypes.includes(activeFilters.type)) {
         query = query.eq('profit_type', activeFilters.type);
       }
-      if (activeFilters.dateFrom) query = query.gte('created_at', activeFilters.dateFrom);
-      if (activeFilters.dateTo) query = query.lte('created_at', activeFilters.dateTo + 'T23:59:59');
+      const dateFromIso = getLocalDateStartIso(activeFilters.dateFrom);
+      const dateToIso = getLocalDateEndIso(activeFilters.dateTo);
+      if (dateFromIso) query = query.gte('created_at', dateFromIso);
+      if (dateToIso) query = query.lte('created_at', dateToIso);
       if (activeFilters.gpMin) query = query.gte('amount', Number(activeFilters.gpMin));
       if (activeFilters.gpMax) query = query.lte('amount', Number(activeFilters.gpMax));
       if (activeFilters.profitMin) query = query.gte('amount', Number(activeFilters.profitMin));
@@ -240,8 +243,10 @@ export function useTransactions(userId) {
     }
     if (activeFilters.type !== 'all') query = query.eq('type', activeFilters.type);
     if (activeFilters.stockName) query = query.ilike('stock_name', `%${activeFilters.stockName}%`);
-    if (activeFilters.dateFrom) query = query.gte('date', activeFilters.dateFrom);
-    if (activeFilters.dateTo) query = query.lte('date', activeFilters.dateTo + 'T23:59:59');
+    const dateFromIso = getLocalDateStartIso(activeFilters.dateFrom);
+    const dateToIso = getLocalDateEndIso(activeFilters.dateTo);
+    if (dateFromIso) query = query.gte('date', dateFromIso);
+    if (dateToIso) query = query.lte('date', dateToIso);
     if (activeFilters.gpMin) query = query.gte('total', Number(activeFilters.gpMin));
     if (activeFilters.gpMax) query = query.lte('total', Number(activeFilters.gpMax));
     if (activeFilters.priceMin) query = query.gte('price', Number(activeFilters.priceMin));

--- a/src/pages/AnalyticsPage.jsx
+++ b/src/pages/AnalyticsPage.jsx
@@ -12,6 +12,7 @@ import CategoriesTab from '../components/analytics/CategoriesTab';
 import GoalsTab from '../components/analytics/GoalsTab';
 import { useTrade } from '../contexts/TradeContext';
 import { addDays, inclusiveDayCount, subtractDays, sumProfit } from '../utils/analyticsHelpers';
+import { formatLocalDate } from '../utils/localPeriods';
 import '../styles/analytics-page.css';
 import '../styles/analytics-widgets.css';
 
@@ -109,13 +110,13 @@ export default function AnalyticsPage({
   const scopeCoversStart = (scope, start) => {
     if (scope?.full) return true;
     if (!scope?.since || !start) return false;
-    return start >= String(scope.since).slice(0, 10);
+    return start >= formatLocalDate(scope.since);
   };
 
   const localAllTimeStart = useMemo(() => {
     const dates = [
-      ...geTransactions.map((transaction) => String(transaction.date || '').slice(0, 10)),
-      ...geProfitHistory.map((profit) => String(profit.created_at || '').slice(0, 10)),
+      ...geTransactions.map((transaction) => formatLocalDate(transaction.date)),
+      ...geProfitHistory.map((profit) => formatLocalDate(profit.created_at)),
     ].filter(Boolean);
 
     return dates.length > 0 ? dates.sort()[0] : null;

--- a/src/utils/categoryAnalytics.js
+++ b/src/utils/categoryAnalytics.js
@@ -1,5 +1,6 @@
 import { calculateUnrealizedProfit } from './taxUtils';
 import { applyAverageCostExit } from './positionAnalytics';
+import { formatLocalDate } from './localPeriods';
 
 const DEFAULT_CATEGORY = 'Uncategorized';
 
@@ -11,7 +12,7 @@ const itemIdOf = (stock) => stock?.itemId ?? stock?.item_id;
 const stockIdOf = (row) => row?.stockId ?? row?.stock_id;
 const transactionIdOf = (row) => row?.transactionId ?? row?.transaction_id;
 const profitTypeOf = (row) => row?.profitType ?? row?.profit_type;
-const isoOf = (value) => String(value || '').slice(0, 10);
+const isoOf = (value) => formatLocalDate(value);
 
 const MS_PER_DAY = 86400000;
 

--- a/src/utils/goalAnalytics.js
+++ b/src/utils/goalAnalytics.js
@@ -2,6 +2,7 @@
 // shaped like { period, period_start, achieved_at, goal_amount, actual_amount }.
 
 import { addDays, inclusiveDayCount } from './analyticsHelpers';
+import { formatLocalDate, getLocalPeriodStart } from './localPeriods';
 
 const HIT_RATE_WINDOW = 7;
 
@@ -64,7 +65,7 @@ const isHit = (entry) => (
 );
 
 export const periodDate = (entry) => (
-  entry.period_start || String(entry.achieved_at || '').slice(0, 10)
+  entry.period_start || formatLocalDate(entry.achieved_at)
 );
 
 const sortedForPeriod = (history, period) => (
@@ -146,35 +147,16 @@ export function estimateTimeToGoal({ currentProgress, goal, elapsedDays, totalDa
   return { daysRemaining, onTrack, pacePerDay, projected };
 }
 
-const utcPeriodStart = (now, period) => {
-  if (period === 'day') {
-    return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
-  }
-  if (period === 'week') {
-    const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
-    const dayOfWeek = (start.getUTCDay() + 6) % 7; // Monday = 0
-    start.setUTCDate(start.getUTCDate() - dayOfWeek);
-    return start;
-  }
-  if (period === 'month') {
-    return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
-  }
-  if (period === 'year') {
-    return new Date(Date.UTC(now.getUTCFullYear(), 0, 1));
-  }
-  return now;
-};
-
-// Calendar helpers used by the estimator widget. All period boundaries are UTC.
+// Calendar helpers used by the estimator widget.
 export const periodTotalDays = (period) => {
   if (period === 'day') return 1;
   if (period === 'week') return 7;
   if (period === 'month') {
     const now = new Date();
-    return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 0)).getUTCDate();
+    return new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
   }
   if (period === 'year') {
-    const year = new Date().getUTCFullYear();
+    const year = new Date().getFullYear();
     const isLeap = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
     return isLeap ? 366 : 365;
   }
@@ -184,7 +166,7 @@ export const periodTotalDays = (period) => {
 export const periodElapsedDays = (period) => {
   const now = new Date();
   if (period === 'day' || period === 'week' || period === 'month' || period === 'year') {
-    return Math.max(1 / 1440, (now - utcPeriodStart(now, period)) / 86400000);
+    return Math.max(1 / 1440, (now - getLocalPeriodStart(now, period)) / 86400000);
   }
   return 1;
 };

--- a/src/utils/itemAnalytics.js
+++ b/src/utils/itemAnalytics.js
@@ -1,6 +1,7 @@
 import { calculateUnrealizedProfit } from './taxUtils';
+import { formatLocalDate } from './localPeriods';
 
-export const isoOf = (value) => String(value || '').slice(0, 10);
+export const isoOf = (value) => formatLocalDate(value);
 export const stockIdOf = (row) => row?.stockId ?? row?.stock_id;
 export const transactionIdOf = (row) => row?.transactionId ?? row?.transaction_id;
 export const profitTypeOf = (row) => row?.profitType ?? row?.profit_type;

--- a/src/utils/localPeriods.js
+++ b/src/utils/localPeriods.js
@@ -1,0 +1,82 @@
+export const getLocalPeriodStart = (value, period) => {
+  const date = new Date(value);
+
+  switch (period) {
+    case 'day':
+      return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+    case 'week': {
+      const start = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+      const day = start.getDay();
+      const diff = day === 0 ? -6 : 1 - day;
+      start.setDate(start.getDate() + diff);
+      return start;
+    }
+    case 'month':
+      return new Date(date.getFullYear(), date.getMonth(), 1);
+    case 'year':
+      return new Date(date.getFullYear(), 0, 1);
+    default:
+      return date;
+  }
+};
+
+export const getLocalPeriodEnd = (periodStart, period) => {
+  const date = new Date(periodStart);
+
+  switch (period) {
+    case 'day':
+      date.setDate(date.getDate() + 1);
+      return date;
+    case 'week':
+      date.setDate(date.getDate() + 7);
+      return date;
+    case 'month':
+      date.setMonth(date.getMonth() + 1);
+      return date;
+    case 'year':
+      date.setFullYear(date.getFullYear() + 1);
+      return date;
+    default:
+      return date;
+  }
+};
+
+export const getNextLocalMidnight = (value = new Date()) => {
+  const date = new Date(value);
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() + 1);
+};
+
+export const formatLocalDate = (value) => {
+  if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return value;
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+export const getLocalDateStartIso = (dateString) => {
+  if (!dateString) return null;
+  const [year, month, day] = String(dateString).slice(0, 10).split('-').map(Number);
+  if (!year || !month || !day) return null;
+  return new Date(year, month - 1, day, 0, 0, 0, 0).toISOString();
+};
+
+export const getLocalDateEndIso = (dateString) => {
+  if (!dateString) return null;
+  const [year, month, day] = String(dateString).slice(0, 10).split('-').map(Number);
+  if (!year || !month || !day) return null;
+  return new Date(year, month - 1, day, 23, 59, 59, 999).toISOString();
+};
+
+export const parseLocalDate = (dateString) => {
+  if (!dateString) return null;
+  const [year, month, day] = String(dateString).slice(0, 10).split('-').map(Number);
+  if (!year || !month || !day) return null;
+  return new Date(year, month - 1, day);
+};

--- a/src/utils/nonGeAnalytics.js
+++ b/src/utils/nonGeAnalytics.js
@@ -1,7 +1,9 @@
+import { formatLocalDate } from './localPeriods';
+
 const DEFAULT_CATEGORY = 'Uncategorized';
 
 const toNumber = (value) => Number(value) || 0;
-const isoOf = (value) => String(value || '').slice(0, 10);
+const isoOf = (value) => formatLocalDate(value);
 const stockIdOf = (row) => row?.nonGeStockId ?? row?.non_ge_stock_id ?? row?.stockId ?? row?.stock_id;
 const transactionIdOf = (row) => row?.transactionId ?? row?.transaction_id;
 const profitTypeOf = (row) => row?.profitType ?? row?.profit_type;


### PR DESCRIPTION
﻿## Summary
- add shared local date/period helpers for browser-local calendar boundaries
- use local day/week/month/year boundaries for milestones, goal history, analytics buckets, GP traded stats, and history filters
- refresh milestone progress after local midnight and when the tab becomes visible after a missed boundary

## Root cause
Several user-facing period calculations mixed browser-local dates with UTC date extraction. In timezones such as Europe/Amsterdam, timestamps around local midnight could be grouped into the wrong calendar day, and milestone progress could reset at UTC midnight instead of local midnight.

## Validation
- `npm run build`
- opened `http://127.0.0.1:5173/` in the in-app browser with zero console errors
- ran inline fixture data under `TZ=Europe/Amsterdam` for timestamps immediately before and after local midnight

Fixes #313
