### PR TITLE
[codex] Add active flipping profit source

### DIFF
--- a/docs/cloudflare-cache-setup.md
+++ b/docs/cloudflare-cache-setup.md
@@ -1,6 +1,6 @@
 # Cloudflare Cache Setup
 
-Use this when the Netlify site is proxied through Cloudflare. The goal is to let Cloudflare serve cacheable shared OSRS data from edge cache so Netlify Functions are only hit on cache misses.
+Use this when the Netlify site is proxied through Cloudflare. The app prefers direct browser calls to the OSRS Wiki API. These cache rules only apply to the first-party fallback API, which is used when the direct Wiki request fails because of CORS or a network issue.
 
 ## DNS
 
@@ -22,7 +22,16 @@ Browser TTL: Respect origin headers
 Cache key: Include query string, or use default full URL cache key
 ```
 
-The app calls:
+The app normally calls:
+
+```txt
+https://prices.runescape.wiki/api/v1/osrs/latest
+https://prices.runescape.wiki/api/v1/osrs/mapping
+https://prices.runescape.wiki/api/v1/osrs/1h
+https://prices.runescape.wiki/api/v1/osrs/timeseries
+```
+
+When a direct Wiki call fails, the app falls back to:
 
 ```txt
 /api/ge-prices/latest
@@ -31,7 +40,7 @@ The app calls:
 /api/ge-prices/timeseries
 ```
 
-The browser routes Wiki API calls through `/api/ge-prices/*` so production is not dependent on third-party CORS headers.
+The fallback keeps the app working if the Wiki API temporarily omits CORS headers for the production origin.
 
 Optional extra rules:
 
@@ -77,5 +86,5 @@ The first request can be `MISS`; repeat the request after a few seconds. The rep
 
 ## What Still Hits Netlify
 
-Cloudflare cache misses for `/api/ge-prices/*` still hit Netlify. Netlify then fetches the OSRS Wiki API server-side and stores cacheable responses in Netlify Blobs.
+Only fallback requests hit Netlify. Cloudflare cache misses for `/api/ge-prices/*` hit the Netlify Function, which then fetches the OSRS Wiki API server-side and stores cacheable responses in Netlify Blobs.
 

--- a/docs/cloudflare-cache-setup.md
+++ b/docs/cloudflare-cache-setup.md
@@ -15,7 +15,7 @@ Create one Cloudflare Cache Rule for cacheable GE price API paths:
 
 ```txt
 Name: Cache GE price API
-When: URI Path is /api/ge-prices/mapping or /api/ge-prices/1h
+When: URI Path is /api/ge-prices/latest, /api/ge-prices/mapping, /api/ge-prices/1h, or /api/ge-prices/timeseries
 Cache eligibility: Eligible for cache
 Edge TTL: Respect origin headers
 Browser TTL: Respect origin headers
@@ -25,12 +25,13 @@ Cache key: Include query string, or use default full URL cache key
 The app calls:
 
 ```txt
-https://prices.runescape.wiki/api/v1/osrs/latest
+/api/ge-prices/latest
 /api/ge-prices/mapping
 /api/ge-prices/1h
+/api/ge-prices/timeseries
 ```
 
-The live `/latest` price feed is fetched directly from the OSRS Wiki API by the browser. Netlify no longer proxies or warms `/latest`.
+The browser routes Wiki API calls through `/api/ge-prices/*` so production is not dependent on third-party CORS headers.
 
 Optional extra rules:
 
@@ -48,7 +49,11 @@ Both functions already return public cache headers, so a Cloudflare rule is only
 
 For `/api/ge-prices/mapping`, the origin returns longer-lived cache headers.
 
+For `/api/ge-prices/latest`, the origin returns short-lived cache headers.
+
 For `/api/ge-prices/1h`, the origin returns medium-lived cache headers.
+
+For `/api/ge-prices/timeseries`, the origin returns medium-lived cache headers and includes the query string in the cache key.
 
 ## Verification
 
@@ -56,7 +61,9 @@ After deploying and enabling Cloudflare, check:
 
 ```powershell
 curl.exe -I https://YOUR_DOMAIN/api/ge-prices/mapping
+curl.exe -I https://YOUR_DOMAIN/api/ge-prices/latest
 curl.exe -I "https://YOUR_DOMAIN/api/ge-prices/1h?timestamp=UNIX_TIMESTAMP"
+curl.exe -I "https://YOUR_DOMAIN/api/ge-prices/timeseries?id=31722&timestep=5m"
 ```
 
 Look for:
@@ -70,5 +77,5 @@ The first request can be `MISS`; repeat the request after a few seconds. The rep
 
 ## What Still Hits Netlify
 
-Cloudflare cache misses for `/api/ge-prices/mapping` and `/api/ge-prices/1h` still hit Netlify. Live `/latest` requests go directly to the OSRS Wiki API.
+Cloudflare cache misses for `/api/ge-prices/*` still hit Netlify. Netlify then fetches the OSRS Wiki API server-side and stores cacheable responses in Netlify Blobs.
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,8 +8,18 @@
      status = 200
 
    [[redirects]]
+     from = "/api/ge-prices/latest"
+     to = "/.netlify/functions/ge-prices?endpoint=latest"
+     status = 200
+
+   [[redirects]]
      from = "/api/ge-prices/1h"
      to = "/.netlify/functions/ge-prices?endpoint=1h"
+     status = 200
+
+   [[redirects]]
+     from = "/api/ge-prices/timeseries"
+     to = "/.netlify/functions/ge-prices?endpoint=timeseries"
      status = 200
 
    [[redirects]]

--- a/netlify/functions/_shared/ge-cache.mjs
+++ b/netlify/functions/_shared/ge-cache.mjs
@@ -4,6 +4,13 @@ const BASE_URL = 'https://prices.runescape.wiki/api/v1/osrs';
 const USER_AGENT = 'OSRSProfitTracker/3.0 (https://osrs-portfolio.fun; contact: osrsprofittracker@gmail.com)';
 
 export const ENDPOINTS = {
+  latest: {
+    path: '/latest',
+    key: 'latest',
+    maxBlobAgeMs: 30 * 1000,
+    cdnCacheControl: 'public, max-age=30, stale-while-revalidate=60',
+    browserCacheControl: 'public, max-age=15, stale-while-revalidate=45',
+  },
   mapping: {
     path: '/mapping',
     key: 'mapping',
@@ -21,6 +28,19 @@ export const ENDPOINTS = {
     cacheKey: (params) => {
       const timestamp = params?.get('timestamp');
       return timestamp ? `1h-${timestamp}` : '1h-latest';
+    },
+  },
+  timeseries: {
+    path: '/timeseries',
+    key: 'timeseries',
+    maxBlobAgeMs: 5 * 60 * 1000,
+    cdnCacheControl: 'public, max-age=300, stale-while-revalidate=900',
+    browserCacheControl: 'public, max-age=60, stale-while-revalidate=300',
+    queryParams: ['id', 'timestep'],
+    cacheKey: (params) => {
+      const id = params?.get('id') || 'unknown';
+      const timestep = params?.get('timestep') || 'unknown';
+      return `timeseries-${id}-${timestep}`;
     },
   },
 };

--- a/netlify/functions/ge-prices.mjs
+++ b/netlify/functions/ge-prices.mjs
@@ -51,6 +51,21 @@ function getEndpointParams(request) {
 }
 
 function validateEndpointRequest(endpoint, params) {
+  if (endpoint === 'timeseries') {
+    const id = params.get('id');
+    const timestep = params.get('timestep');
+
+    if (!id || !/^\d+$/.test(id)) {
+      return 'id must be a numeric item id';
+    }
+
+    if (!['5m', '1h', '6h', '24h'].includes(timestep)) {
+      return 'timestep must be one of: 5m, 1h, 6h, 24h';
+    }
+
+    return null;
+  }
+
   if (endpoint !== '1h') return null;
 
   const timestamp = params.get('timestamp');

--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -173,7 +173,7 @@ function MainAppInner({ session, onLogout }) {
   } = useNonGEStocks(userId);
 
   // Destructure profits
-  const { dumpProfit, referralProfit, bondsProfit } = profits;
+  const { dumpProfit, referralProfit, bondsProfit, activeFlippingProfit } = profits;
 
   // Destructure settings
   const { numberFormat, visibleColumns, visibleProfits, altAccountTimer, showCategoryStats,
@@ -770,6 +770,7 @@ function MainAppInner({ session, onLogout }) {
     handleAddDumpProfit,
     handleAddReferralProfit,
     handleAddBondsProfit,
+    handleAddActiveFlippingProfit,
     handleUpdateMilestone,
     archivedStocks,
     archivedLoading,
@@ -1537,6 +1538,7 @@ function MainAppInner({ session, onLogout }) {
             onAddDumpProfit={() => openModal('dumpProfit')}
             onAddReferralProfit={() => openModal('referralProfit')}
             onAddBondsProfit={() => openModal('bondsProfit')}
+            onAddActiveFlippingProfit={() => openModal('activeFlippingProfit')}
             onOpenMilestoneModal={() => openModal('milestone', { milestoneView: 'main' })}
             onOpenMilestoneHistory={() => openModal('milestone', { milestoneView: 'history' })}
           />
@@ -1834,6 +1836,7 @@ function MainAppInner({ session, onLogout }) {
           handleAddDumpProfit={handleAddDumpProfit}
           handleAddReferralProfit={handleAddReferralProfit}
           handleAddBondsProfit={handleAddBondsProfit}
+          handleAddActiveFlippingProfit={handleAddActiveFlippingProfit}
           handleUpdateMilestone={handleUpdateMilestone}
           archivedStocks={archivedStocks}
           archivedLoading={archivedLoading}
@@ -1873,6 +1876,7 @@ function MainAppInner({ session, onLogout }) {
           dumpProfit={dumpProfit}
           referralProfit={referralProfit}
           bondsProfit={bondsProfit}
+          activeFlippingProfit={activeFlippingProfit}
           numberFormat={numberFormat}
           groupedStocks={groupedStocks}
           groupedStatsStocks={groupedStatsStocks}

--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -744,6 +744,7 @@ function MainAppInner({ session, onLogout }) {
 
   const handleCloseChangelog = () => {
     localStorage.setItem(`lastSeenVersion_${userId}`, CURRENT_VERSION);
+    localStorage.setItem('osrs_icon_cache_version', CURRENT_VERSION);
     closeModal('changelog');
   };
 

--- a/src/components/ModalManager.jsx
+++ b/src/components/ModalManager.jsx
@@ -51,6 +51,7 @@ export default function ModalManager({
   handleAddDumpProfit,
   handleAddReferralProfit,
   handleAddBondsProfit,
+  handleAddActiveFlippingProfit,
   handleUpdateMilestone,
   archivedStocks,
   archivedLoading,
@@ -268,6 +269,14 @@ export default function ModalManager({
           type="bonds"
           onConfirm={handleAddBondsProfit}
           onCancel={() => closeModal('bondsProfit')}
+        />
+      </ModalContainer>
+
+      <ModalContainer isOpen={modals.activeFlippingProfit}>
+        <ProfitModal
+          type="activeFlipping"
+          onConfirm={handleAddActiveFlippingProfit}
+          onCancel={() => closeModal('activeFlippingProfit')}
         />
       </ModalContainer>
 

--- a/src/components/PortfolioSummary.jsx
+++ b/src/components/PortfolioSummary.jsx
@@ -10,11 +10,13 @@ export default function PortfolioSummary({
   dumpProfit,
   referralProfit,
   bondsProfit,
+  activeFlippingProfit = 0,
   statsStocks = null,
-  visibleProfits = { dumpProfit: true, referralProfit: true, bondsProfit: true },
+  visibleProfits = { dumpProfit: true, referralProfit: true, bondsProfit: true, activeFlippingProfit: true },
   onAddDumpProfit,
   onAddReferralProfit,
   onAddBondsProfit,
+  onAddActiveFlippingProfit,
   numberFormat,
   showUnrealisedProfitStats = false
 }) {
@@ -22,7 +24,7 @@ export default function PortfolioSummary({
   const { stocks, allStocks } = useTrade();
   const stocksForStats = statsStocks || (allStocks?.length > 0 ? allStocks : stocks);
   const stocksProfit = calculateStocksProfit(stocksForStats);
-  const totalProfit = calculateTotalProfit(stocksForStats, dumpProfit, referralProfit, bondsProfit);
+  const totalProfit = calculateTotalProfit(stocksForStats, dumpProfit, referralProfit, bondsProfit, activeFlippingProfit);
 
   const totalUnrealised = showUnrealisedProfitStats
     ? stocksForStats.reduce((sum, s) => {
@@ -69,7 +71,7 @@ export default function PortfolioSummary({
           label="Total Profit:"
           value={formatNumber(totalProfit)}
           color={totalProfit >= 0 ? 'rgb(52, 211, 153)' : 'rgb(248, 113, 113)'}
-          tooltip="Stocks + dumps + referrals + bonds profit combined"
+          tooltip="Stocks + dumps + referrals + bonds + active flipping profit combined"
         />
       </div>
 
@@ -124,6 +126,21 @@ export default function PortfolioSummary({
               onClick: onAddBondsProfit,
               color: 'rgb(161, 98, 7)',
               hoverColor: 'rgb(133, 77, 14)'
+            }}
+          />
+        )}
+
+        {/* Active Flipping Profit */}
+        {visibleProfits?.activeFlippingProfit !== false && (
+          <SummaryCard
+            label="Active Flipping:"
+            value={formatNumber(activeFlippingProfit)}
+            color="rgb(56, 189, 248)"
+            tooltip="Manual profit from active flipping"
+            button={{
+              onClick: onAddActiveFlippingProfit,
+              color: 'rgb(2, 132, 199)',
+              hoverColor: 'rgb(3, 105, 161)'
             }}
           />
         )}

--- a/src/components/RowActionMenu.jsx
+++ b/src/components/RowActionMenu.jsx
@@ -1,0 +1,104 @@
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { MoreHorizontal } from 'lucide-react';
+
+const MENU_GAP = 6;
+const VIEWPORT_PADDING = 8;
+
+export default function RowActionMenu({ children }) {
+  const [open, setOpen] = useState(false);
+  const [position, setPosition] = useState({ top: 0, left: 0 });
+  const triggerRef = useRef(null);
+  const menuRef = useRef(null);
+
+  const updatePosition = () => {
+    const trigger = triggerRef.current;
+    if (!trigger) return;
+
+    const triggerRect = trigger.getBoundingClientRect();
+    const menuRect = menuRef.current?.getBoundingClientRect();
+    const menuWidth = menuRect?.width || 176;
+    const menuHeight = menuRect?.height || 0;
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+
+    let top = triggerRect.bottom + MENU_GAP;
+    let left = triggerRect.right - menuWidth;
+
+    if (menuHeight && top + menuHeight > viewportHeight - VIEWPORT_PADDING) {
+      top = Math.max(VIEWPORT_PADDING, triggerRect.top - menuHeight - MENU_GAP);
+    }
+
+    left = Math.max(
+      VIEWPORT_PADDING,
+      Math.min(left, viewportWidth - menuWidth - VIEWPORT_PADDING)
+    );
+
+    setPosition({ top, left });
+  };
+
+  useLayoutEffect(() => {
+    if (open) updatePosition();
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handlePointerDown = (event) => {
+      const target = event.target;
+      if (
+        triggerRef.current?.contains(target)
+        || menuRef.current?.contains(target)
+      ) {
+        return;
+      }
+
+      setOpen(false);
+    };
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition, true);
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('resize', updatePosition);
+      window.removeEventListener('scroll', updatePosition, true);
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open]);
+
+  return (
+    <div className="row-action-menu">
+      <button
+        type="button"
+        ref={triggerRef}
+        className="row-action-menu-trigger"
+        title="More actions"
+        aria-label="More actions"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen(value => !value)}
+      >
+        <MoreHorizontal size={16} aria-hidden="true" />
+      </button>
+      {open && createPortal(
+        <div
+          ref={menuRef}
+          className="row-action-menu-list"
+          role="menu"
+          style={{ top: `${position.top}px`, left: `${position.left}px` }}
+          onClick={() => setOpen(false)}
+        >
+          {children}
+        </div>,
+        document.body
+      )}
+    </div>
+  );
+}

--- a/src/components/StockTable.jsx
+++ b/src/components/StockTable.jsx
@@ -48,6 +48,10 @@ function isInteractiveTarget(target) {
   return Boolean(target.closest('button, input, textarea, select, a, summary, details'));
 }
 
+function normalizeGEItemName(name) {
+  return String(name || '').trim().toLowerCase();
+}
+
 export default function StockTable({
   stocks,
   category,
@@ -77,8 +81,16 @@ export default function StockTable({
   onViewGraph,
   onMoveToNonGE,
 }) {
-  const { gePrices: geData, geIconMap, membershipMap } = useGEData();
+  const { gePrices: geData, geIconMap, geMapping, membershipMap } = useGEData();
   const hoveredStockRef = useRef(null);
+  const itemIdByName = useMemo(() => {
+    const map = new Map();
+    (geMapping || []).forEach(item => {
+      const name = normalizeGEItemName(item.name);
+      if (name && !map.has(name)) map.set(name, item.id);
+    });
+    return map;
+  }, [geMapping]);
   const sortedStocks = useMemo(
     () => sortStocks(stocks, sortConfig),
     [stocks, sortConfig]
@@ -151,6 +163,7 @@ export default function StockTable({
               numberFormat={numberFormat}
               geData={geData}
               geIconMap={geIconMap}
+              itemIdByName={itemIdByName}
               membershipMap={membershipMap}
               showMembershipIcon={showMembershipIcon}
               showInvestmentDate={showInvestmentDate}
@@ -237,6 +250,7 @@ function StockRow({
   numberFormat,
   geData = {},
   geIconMap = {},
+  itemIdByName = new Map(),
   membershipMap = {},
   showMembershipIcon = true,
   onArchive,
@@ -254,6 +268,7 @@ function StockRow({
   const profit = calculateProfit(stock);
   const timerDisplay = formatTimer(stock.timerEndTime);
   const isTimerActive = stock.timerEndTime && stock.timerEndTime > Date.now();
+  const displayItemId = stock.itemId || itemIdByName.get(normalizeGEItemName(stock.name));
   const handleRowClick = (event) => {
     if (!isInteractiveTarget(event.target)) {
       event.currentTarget.focus();
@@ -294,20 +309,20 @@ function StockRow({
       </td>
       <td style={{ padding: '0.5rem 0.75rem', fontWeight: '600', color: 'white', border: '1px solid rgb(51, 65, 85)' }}>
         <div className="stock-name-cell">
-          {stock.itemId && (
+          {displayItemId && (
             <ItemIcon
-              src={geIconMap[stock.itemId]}
+              src={geIconMap[displayItemId]}
               alt=""
               className="stock-table-item-icon"
               fallbackText={stock.name}
             />
           )}
-          {showMembershipIcon && stock.itemId && stock.itemId in membershipMap && (
+          {showMembershipIcon && displayItemId && displayItemId in membershipMap && (
             <Star
-              className={`members-star ${membershipMap[stock.itemId] ? 'members-star--p2p' : 'members-star--f2p'}`}
+              className={`members-star ${membershipMap[displayItemId] ? 'members-star--p2p' : 'members-star--f2p'}`}
               size={12}
               fill="currentColor"
-              title={membershipMap[stock.itemId] ? 'Members item' : 'Free-to-play item'}
+              title={membershipMap[displayItemId] ? 'Members item' : 'Free-to-play item'}
             />
           )}
           {stock.itemId && onViewGraph ? (

--- a/src/components/StockTable.jsx
+++ b/src/components/StockTable.jsx
@@ -7,7 +7,6 @@ import {
   CircleDollarSign,
   GripVertical,
   MinusCircle,
-  MoreHorizontal,
   PackageOpen,
   Pencil,
   ShoppingCart,
@@ -20,6 +19,7 @@ import { calculateAvgBuyPrice, calculateAvgSellPrice, calculateProfit } from '..
 import { calculateUnrealizedProfit } from '../utils/taxUtils';
 import { useGEData } from '../contexts/GEDataContext';
 import ItemIcon from './ItemIcon';
+import RowActionMenu from './RowActionMenu';
 import '../styles/table.css';
 import { sortStocks } from '../utils/calculations';
 import { parseLocalDate } from '../utils/localPeriods';
@@ -477,8 +477,7 @@ function StatusBadge({ stock }) {
 }
 
 function ActionButtons({ stock, onBuy, onSell, onRemove, onAdjust, onDelete, onCalculate, onArchive, onMoveToNonGE }) {
-  const handleMenuAction = (event, action) => {
-    event.currentTarget.closest('details')?.removeAttribute('open');
+  const handleMenuAction = (action) => {
     action(stock);
   };
 
@@ -492,39 +491,34 @@ function ActionButtons({ stock, onBuy, onSell, onRemove, onAdjust, onDelete, onC
         <CircleDollarSign size={12} />
         Sell
       </button>
-      <details className="row-action-menu">
-        <summary className="row-action-menu-trigger" title="More actions" aria-label="More actions">
-          <MoreHorizontal size={16} aria-hidden="true" />
-        </summary>
-        <div className="row-action-menu-list">
-          <button type="button" className="row-action-menu-item" onClick={(event) => handleMenuAction(event, onRemove)}>
-            <MinusCircle size={14} />
-            Remove
+      <RowActionMenu>
+        <button type="button" className="row-action-menu-item" onClick={() => handleMenuAction(onRemove)}>
+          <MinusCircle size={14} />
+          Remove
+        </button>
+        <button type="button" className="row-action-menu-item" onClick={() => handleMenuAction(onCalculate)}>
+          <Calculator size={14} />
+          Calc
+        </button>
+        <button type="button" className="row-action-menu-item" onClick={() => handleMenuAction(onAdjust)}>
+          <Pencil size={14} />
+          Adjust
+        </button>
+        <button type="button" className="row-action-menu-item" onClick={() => handleMenuAction(onArchive)}>
+          <Archive size={14} />
+          Archive
+        </button>
+        {onMoveToNonGE && (
+          <button type="button" className="row-action-menu-item" onClick={() => handleMenuAction(onMoveToNonGE)}>
+            <PackageOpen size={14} />
+            Move to Non-GE
           </button>
-          <button type="button" className="row-action-menu-item" onClick={(event) => handleMenuAction(event, onCalculate)}>
-            <Calculator size={14} />
-            Calc
-          </button>
-          <button type="button" className="row-action-menu-item" onClick={(event) => handleMenuAction(event, onAdjust)}>
-            <Pencil size={14} />
-            Adjust
-          </button>
-          <button type="button" className="row-action-menu-item" onClick={(event) => handleMenuAction(event, onArchive)}>
-            <Archive size={14} />
-            Archive
-          </button>
-          {onMoveToNonGE && (
-            <button type="button" className="row-action-menu-item" onClick={(event) => handleMenuAction(event, onMoveToNonGE)}>
-              <PackageOpen size={14} />
-              Move to Non-GE
-            </button>
-          )}
-          <button type="button" className="row-action-menu-item row-action-menu-item--danger" onClick={(event) => handleMenuAction(event, onDelete)}>
-            <Trash2 size={14} />
-            Delete
-          </button>
-        </div>
-      </details>
+        )}
+        <button type="button" className="row-action-menu-item row-action-menu-item--danger" onClick={() => handleMenuAction(onDelete)}>
+          <Trash2 size={14} />
+          Delete
+        </button>
+      </RowActionMenu>
     </div>
   );
 }

--- a/src/components/analytics/KpiBand.jsx
+++ b/src/components/analytics/KpiBand.jsx
@@ -14,7 +14,7 @@ function KpiCard({ label, icon, value, deltaPct, numberFormat, valueClass = '', 
     : deltaPct >= 0 ? 'is-positive' : 'is-negative';
 
   const defaultTooltip = {
-    'Total Profit': 'All-time realized profit using the same accounting as the Trade and Home screens: item profit plus dump, referral, and bonds profit.',
+    'Total Profit': 'All-time realized profit using the same accounting as the Trade and Home screens: item profit plus dump, referral, bonds, and active flipping profit.',
     'Period Profit': 'Realized profit inside the selected analytics timeframe. On All, this uses the same total as Total Profit.',
     'GP Traded': 'Total GP value of transactions in the selected timeframe, including buys and sells.',
     'Inventory Value': 'Current GP cost basis of items still held in your tracked stock.',

--- a/src/components/analytics/widgets/ProfitBySourceChart.jsx
+++ b/src/components/analytics/widgets/ProfitBySourceChart.jsx
@@ -15,6 +15,7 @@ const SOURCES = [
   { key: 'profit_dump', label: 'Dump', color: 'rgb(52, 211, 153)' },
   { key: 'profit_referral', label: 'Referral', color: 'rgb(168, 85, 247)' },
   { key: 'profit_bonds', label: 'Bonds', color: 'rgb(234, 179, 8)' },
+  { key: 'profit_active_flipping', label: 'Active Flipping', color: 'rgb(56, 189, 248)' },
 ];
 
 const getStackDomain = (data) => {
@@ -73,7 +74,7 @@ export default function ProfitBySourceChart({ buckets = [], numberFormat }) {
       <div className="analytics-widget-header">
         <h3
           className="analytics-widget-title has-tooltip"
-          data-tooltip="Breaks each period's realized profit into item sales, dump profit, referral profit, and bonds profit."
+          data-tooltip="Breaks each period's realized profit into item sales, dump profit, referral profit, bonds profit, and active flipping profit."
         >
           Profit by source
         </h3>

--- a/src/components/analytics/widgets/ProfitOverTimeChart.jsx
+++ b/src/components/analytics/widgets/ProfitOverTimeChart.jsx
@@ -34,7 +34,7 @@ export default function ProfitOverTimeChart({
   buckets = [],
   numberFormat,
   title = 'Profit over time',
-  tooltip = 'Net realized profit by bucket in the selected timeframe, including item, dump, referral, and bonds profit.',
+  tooltip = 'Net realized profit by bucket in the selected timeframe, including item, dump, referral, bonds, and active flipping profit.',
   emptyMessage = 'No activity in this window. Try a wider timeframe.',
 }) {
   if (!buckets.length) {

--- a/src/components/modals/ProfitModal.jsx
+++ b/src/components/modals/ProfitModal.jsx
@@ -25,6 +25,11 @@ export default function ProfitModal({ type, onConfirm, onCancel }) {
       title: 'Add Bonds Profit',
       color: 'rgb(161, 98, 7)',
       hoverColor: 'rgb(133, 77, 14)'
+    },
+    activeFlipping: {
+      title: 'Add Active Flipping Profit',
+      color: 'rgb(14, 165, 233)',
+      hoverColor: 'rgb(2, 132, 199)'
     }
   };
 

--- a/src/components/modals/settings/GeneralTab.jsx
+++ b/src/components/modals/settings/GeneralTab.jsx
@@ -47,6 +47,11 @@ const PROFIT_TYPES = [
     label: 'Bonds Profit',
     info: 'Track profits from buying and selling OSRS bonds'
   },
+  {
+    key: 'activeFlippingProfit',
+    label: 'Active Flipping Profit',
+    info: 'Track manual profit from active flipping outside individual item sales.'
+  },
 ];
 
 export default function GeneralTab({

--- a/src/components/non-ge/NonGETable.jsx
+++ b/src/components/non-ge/NonGETable.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
-import { Archive, ArrowDown, ArrowUp, CircleDollarSign, GripVertical, MinusCircle, MoreHorizontal, Pencil, ShoppingCart, StickyNote, Trash2 } from 'lucide-react';
+import { Archive, ArrowDown, ArrowUp, CircleDollarSign, GripVertical, MinusCircle, Pencil, ShoppingCart, StickyNote, Trash2 } from 'lucide-react';
 import ItemIcon from '../ItemIcon';
+import RowActionMenu from '../RowActionMenu';
 import { calculateAvgBuyPrice, calculateAvgSellPrice, calculateProfit } from '../../utils/calculations';
 import { formatAvgPrice, formatNumber } from '../../utils/formatters';
 import { getNonGECatalogItem, getNonGEItemImageUrl, nonGEItemDisplayName, nonGEItemRangeLabel } from '../../utils/nonGeCatalog';
@@ -83,8 +84,7 @@ function NumberCell({ value, numberFormat, className = '' }) {
   );
 }
 
-function closeMenuAndRun(event, action, stock) {
-  event.currentTarget.closest('details')?.removeAttribute('open');
+function closeMenuAndRun(action, stock) {
   action(stock);
 }
 
@@ -229,36 +229,31 @@ export default function NonGETable({
                       <CircleDollarSign size={12} />
                       Sell
                     </button>
-                    <details className="row-action-menu">
-                      <summary className="row-action-menu-trigger" title="More actions" aria-label="More actions">
-                        <MoreHorizontal size={16} aria-hidden="true" />
-                      </summary>
-                      <div className="row-action-menu-list">
-                        <button
-                          type="button"
-                          className="row-action-menu-item"
-                          onClick={(event) => closeMenuAndRun(event, onRemove, stock)}
-                          disabled={(stock.shares || 0) <= 0}
-                        >
-                          <MinusCircle size={14} />
-                          Remove
+                    <RowActionMenu>
+                      <button
+                        type="button"
+                        className="row-action-menu-item"
+                        onClick={() => closeMenuAndRun(onRemove, stock)}
+                        disabled={(stock.shares || 0) <= 0}
+                      >
+                        <MinusCircle size={14} />
+                        Remove
+                      </button>
+                      <button type="button" className="row-action-menu-item" onClick={() => closeMenuAndRun(onAdjust, stock)}>
+                        <Pencil size={14} />
+                        Adjust
+                      </button>
+                      <button type="button" className="row-action-menu-item" onClick={() => closeMenuAndRun(onArchive, stock)}>
+                        <Archive size={14} />
+                        Archive
+                      </button>
+                      {onDelete && (
+                        <button type="button" className="row-action-menu-item row-action-menu-item--danger" onClick={() => closeMenuAndRun(onDelete, stock)}>
+                          <Trash2 size={14} />
+                          Delete
                         </button>
-                        <button type="button" className="row-action-menu-item" onClick={(event) => closeMenuAndRun(event, onAdjust, stock)}>
-                          <Pencil size={14} />
-                          Adjust
-                        </button>
-                        <button type="button" className="row-action-menu-item" onClick={(event) => closeMenuAndRun(event, onArchive, stock)}>
-                          <Archive size={14} />
-                          Archive
-                        </button>
-                        {onDelete && (
-                          <button type="button" className="row-action-menu-item row-action-menu-item--danger" onClick={(event) => closeMenuAndRun(event, onDelete, stock)}>
-                            <Trash2 size={14} />
-                            Delete
-                          </button>
-                        )}
-                      </div>
-                    </details>
+                      )}
+                    </RowActionMenu>
                   </div>
                 </td>
               </tr>

--- a/src/contexts/ModalContext.jsx
+++ b/src/contexts/ModalContext.jsx
@@ -19,6 +19,7 @@ const MODAL_DEFAULTS = {
   dumpProfit: false,
   referralProfit: false,
   bondsProfit: false,
+  activeFlippingProfit: false,
   notes: false,
   settings: false,
   timeCalculator: false,

--- a/src/hooks/useAnalytics.js
+++ b/src/hooks/useAnalytics.js
@@ -48,6 +48,7 @@ const mergeGpTraded = (buckets, gpTotals) => {
       profit_dump: 0,
       profit_referral: 0,
       profit_bonds: 0,
+      profit_active_flipping: 0,
       gp_traded: 0,
       sell_basis: 0,
       by_category: {},
@@ -143,6 +144,7 @@ export function aggregateBucketsLocally({ transactions, stocks, profitHistory, s
         profit_dump: 0,
         profit_referral: 0,
         profit_bonds: 0,
+        profit_active_flipping: 0,
         gp_traded: 0,
         sell_basis: 0,
         by_category: {},
@@ -189,6 +191,7 @@ export function aggregateBucketsLocally({ transactions, stocks, profitHistory, s
     if (profit.profit_type === 'dump') row.profit_dump += amount;
     if (profit.profit_type === 'referral') row.profit_referral += amount;
     if (profit.profit_type === 'bonds') row.profit_bonds += amount;
+    if (profit.profit_type === 'active_flipping') row.profit_active_flipping += amount;
   }
 
   return [...buckets.values()].sort((a, b) => a.bucket_date.localeCompare(b.bucket_date));

--- a/src/hooks/useGEPriceBaseline.js
+++ b/src/hooks/useGEPriceBaseline.js
@@ -2,11 +2,9 @@ import { useEffect, useMemo, useState } from 'react';
 
 const PROXY_URL = '/api/ge-prices';
 const WIKI_BASE_URL = 'https://prices.runescape.wiki/api/v1/osrs';
-const USER_AGENT = 'OSRSProfitTracker - osrsprofittracker@gmail.com';
 const DAY_MS = 86_400_000;
 const HOUR_MS = 3_600_000;
 const REFRESH_INTERVAL = 15 * 60_000;
-const USE_DIRECT_WIKI_FALLBACK = import.meta.env.DEV;
 
 function getBaselineTimestamp() {
   return Math.floor((Date.now() - DAY_MS) / HOUR_MS) * 3600;
@@ -16,17 +14,22 @@ async function fetchBaseline(timestamp) {
   const endpoint = `1h?timestamp=${timestamp}`;
 
   try {
+    const res = await fetch(`${WIKI_BASE_URL}/${endpoint}`);
+    const contentType = res.headers.get('content-type') || '';
+    if (res.ok && contentType.includes('application/json')) return res;
+  } catch {
+    // Fall back to the first-party proxy when the Wiki API has a CORS or network issue.
+  }
+
+  try {
     const res = await fetch(`${PROXY_URL}/${endpoint}`);
     const contentType = res.headers.get('content-type') || '';
     if (res.ok && contentType.includes('application/json')) return res;
-  } catch (proxyError) {
-    if (!USE_DIRECT_WIKI_FALLBACK) throw proxyError;
+  } catch {
+    return null;
   }
 
-  if (!USE_DIRECT_WIKI_FALLBACK) return null;
-  return fetch(`${WIKI_BASE_URL}/${endpoint}`, {
-    headers: { 'User-Agent': USER_AGENT },
-  });
+  return null;
 }
 
 export function useGEPriceBaseline() {

--- a/src/hooks/useGEPrices.js
+++ b/src/hooks/useGEPrices.js
@@ -1,10 +1,26 @@
 import { useState, useEffect, useRef } from 'react';
+import { CURRENT_VERSION } from '../data/changelog';
 
 const PROXY_URL = '/api/ge-prices';
 const WIKI_BASE_URL = 'https://prices.runescape.wiki/api/v1/osrs';
 const REFRESH_INTERVAL = 60_000;
 const ICON_BASE_PATH = '/icons/ge';
 const ICON_MANIFEST_URL = `${ICON_BASE_PATH}/manifest.json`;
+const ICON_CACHE_VERSION_KEY = 'osrs_icon_cache_version';
+
+function getIconCacheVersion() {
+  try {
+    return localStorage.getItem(ICON_CACHE_VERSION_KEY) || CURRENT_VERSION;
+  } catch {
+    return CURRENT_VERSION;
+  }
+}
+
+function getVersionedAssetUrl(path, version) {
+  if (!path) return '';
+  if (!version) return path;
+  return `${path}${path.includes('?') ? '&' : '?'}v=${encodeURIComponent(version)}`;
+}
 
 export function useGEPrices() {
   const [prices, setPrices] = useState({});   // { [itemId]: { high, low, highTime, lowTime } }
@@ -51,7 +67,7 @@ export function useGEPrices() {
 
       let iconManifest = null;
       try {
-        const manifestRes = await fetch(ICON_MANIFEST_URL);
+        const manifestRes = await fetch(getVersionedAssetUrl(ICON_MANIFEST_URL, CURRENT_VERSION));
         if (manifestRes.ok) {
           iconManifest = await manifestRes.json();
         }
@@ -61,10 +77,11 @@ export function useGEPrices() {
 
       // Build iconMap: { [id]: iconUrl }
       const map = {};
+      const iconCacheVersion = getIconCacheVersion();
       data.forEach(item => {
         const mirroredIcon = iconManifest?.[item.id]?.path;
         if (mirroredIcon) {
-          map[item.id] = mirroredIcon;
+          map[item.id] = getVersionedAssetUrl(mirroredIcon, iconCacheVersion);
         }
       });
       setIconMap(map);

--- a/src/hooks/useGEPrices.js
+++ b/src/hooks/useGEPrices.js
@@ -26,10 +26,6 @@ export function useGEPrices() {
   };
 
   const fetchGEEndpoint = async (endpoint) => {
-    if (endpoint === 'latest') {
-      return fetchWikiEndpoint(endpoint);
-    }
-
     try {
       const res = await fetchProxyEndpoint(endpoint);
       if (isJsonResponse(res)) return res;

--- a/src/hooks/useGEPrices.js
+++ b/src/hooks/useGEPrices.js
@@ -5,7 +5,6 @@ const WIKI_BASE_URL = 'https://prices.runescape.wiki/api/v1/osrs';
 const REFRESH_INTERVAL = 60_000;
 const ICON_BASE_PATH = '/icons/ge';
 const ICON_MANIFEST_URL = `${ICON_BASE_PATH}/manifest.json`;
-const USE_DIRECT_WIKI_FALLBACK = import.meta.env.DEV;
 
 export function useGEPrices() {
   const [prices, setPrices] = useState({});   // { [itemId]: { high, low, highTime, lowTime } }
@@ -27,14 +26,20 @@ export function useGEPrices() {
 
   const fetchGEEndpoint = async (endpoint) => {
     try {
-      const res = await fetchProxyEndpoint(endpoint);
+      const res = await fetchWikiEndpoint(endpoint);
       if (isJsonResponse(res)) return res;
-    } catch (proxyError) {
-      if (!USE_DIRECT_WIKI_FALLBACK) throw proxyError;
+    } catch {
+      // Fall back to the first-party proxy when the Wiki API has a CORS or network issue.
     }
 
-    if (!USE_DIRECT_WIKI_FALLBACK) return null;
-    return fetchWikiEndpoint(endpoint);
+    try {
+      const res = await fetchProxyEndpoint(endpoint);
+      if (isJsonResponse(res)) return res;
+    } catch {
+      return null;
+    }
+
+    return null;
   };
 
   const fetchMapping = async () => {

--- a/src/hooks/useModalHandlers.js
+++ b/src/hooks/useModalHandlers.js
@@ -453,6 +453,14 @@ export function useModalHandlers() {
     closeModal('bondsProfit');
   }, [updateProfit, addProfitEntry, closeModal]);
 
+  const handleAddActiveFlippingProfit = useCallback(async (amount) => {
+    const success = await updateProfit('activeFlippingProfit', amount);
+    if (success) {
+      await addProfitEntry('active_flipping', amount);
+    }
+    closeModal('activeFlippingProfit');
+  }, [updateProfit, addProfitEntry, closeModal]);
+
   const handleUpdateMilestone = useCallback(async (period, goal, enabled) => {
     const success = await updateMilestone(period, goal, enabled);
     if (success) {
@@ -513,6 +521,7 @@ export function useModalHandlers() {
     handleAddDumpProfit,
     handleAddReferralProfit,
     handleAddBondsProfit,
+    handleAddActiveFlippingProfit,
     handleUpdateMilestone,
     archivedStocks,
     archivedLoading,

--- a/src/hooks/usePriceAlertChecker.js
+++ b/src/hooks/usePriceAlertChecker.js
@@ -3,25 +3,27 @@ import { formatNumber } from '../utils/formatters';
 
 const PROXY_URL = '/api/ge-prices';
 const WIKI_BASE_URL = 'https://prices.runescape.wiki/api/v1/osrs';
-const USER_AGENT = 'OSRSProfitTracker - osrsprofittracker@gmail.com';
-const USE_DIRECT_WIKI_FALLBACK = import.meta.env.DEV;
 
 async function fetchTimeseries(itemId, timestep) {
   const endpoint = `timeseries?id=${itemId}&timestep=${timestep}`;
 
   let res = null;
   try {
-    res = await fetch(`${PROXY_URL}/${endpoint}`);
+    res = await fetch(`${WIKI_BASE_URL}/${endpoint}`);
     const contentType = res.headers.get('content-type') || '';
     if (!res.ok || !contentType.includes('application/json')) res = null;
-  } catch (proxyError) {
-    if (!USE_DIRECT_WIKI_FALLBACK) throw proxyError;
+  } catch {
+    // Fall back to the first-party proxy when the Wiki API has a CORS or network issue.
   }
 
-  if (!res && USE_DIRECT_WIKI_FALLBACK) {
-    res = await fetch(`${WIKI_BASE_URL}/${endpoint}`, {
-      headers: { 'User-Agent': USER_AGENT },
-    });
+  if (!res) {
+    try {
+      res = await fetch(`${PROXY_URL}/${endpoint}`);
+      const contentType = res.headers.get('content-type') || '';
+      if (!res.ok || !contentType.includes('application/json')) res = null;
+    } catch {
+      res = null;
+    }
   }
 
   if (!res?.ok) throw new Error(`HTTP ${res?.status || 'unavailable'}`);

--- a/src/hooks/usePriceAlertChecker.js
+++ b/src/hooks/usePriceAlertChecker.js
@@ -1,15 +1,30 @@
 import { useEffect, useRef } from 'react';
 import { formatNumber } from '../utils/formatters';
 
-const BASE_URL = 'https://prices.runescape.wiki/api/v1/osrs';
+const PROXY_URL = '/api/ge-prices';
+const WIKI_BASE_URL = 'https://prices.runescape.wiki/api/v1/osrs';
 const USER_AGENT = 'OSRSProfitTracker - osrsprofittracker@gmail.com';
+const USE_DIRECT_WIKI_FALLBACK = import.meta.env.DEV;
 
 async function fetchTimeseries(itemId, timestep) {
-  const res = await fetch(
-    `${BASE_URL}/timeseries?id=${itemId}&timestep=${timestep}`,
-    { headers: { 'User-Agent': USER_AGENT } }
-  );
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const endpoint = `timeseries?id=${itemId}&timestep=${timestep}`;
+
+  let res = null;
+  try {
+    res = await fetch(`${PROXY_URL}/${endpoint}`);
+    const contentType = res.headers.get('content-type') || '';
+    if (!res.ok || !contentType.includes('application/json')) res = null;
+  } catch (proxyError) {
+    if (!USE_DIRECT_WIKI_FALLBACK) throw proxyError;
+  }
+
+  if (!res && USE_DIRECT_WIKI_FALLBACK) {
+    res = await fetch(`${WIKI_BASE_URL}/${endpoint}`, {
+      headers: { 'User-Agent': USER_AGENT },
+    });
+  }
+
+  if (!res?.ok) throw new Error(`HTTP ${res?.status || 'unavailable'}`);
   const json = await res.json();
   return json.data || [];
 }

--- a/src/hooks/useProfits.js
+++ b/src/hooks/useProfits.js
@@ -5,7 +5,8 @@ export function useProfits(userId) {
   const [profits, setProfits] = useState({
     dumpProfit: 0,
     referralProfit: 0,
-    bondsProfit: 0
+    bondsProfit: 0,
+    activeFlippingProfit: 0
   });
   const [loading, setLoading] = useState(true);
 
@@ -26,7 +27,8 @@ export function useProfits(userId) {
       setProfits({
         dumpProfit: data.dump_profit || 0,
         referralProfit: data.referral_profit || 0,
-        bondsProfit: data.bonds_profit || 0
+        bondsProfit: data.bonds_profit || 0,
+        activeFlippingProfit: data.active_flipping_profit || 0
       });
     } else {
       // No data exists yet, use upsert to handle race conditions
@@ -36,7 +38,8 @@ export function useProfits(userId) {
           user_id: userId,
           dump_profit: 0,
           referral_profit: 0,
-          bonds_profit: 0
+          bonds_profit: 0,
+          active_flipping_profit: 0
         }, {
           onConflict: 'user_id',
           ignoreDuplicates: false
@@ -50,7 +53,8 @@ export function useProfits(userId) {
         setProfits({
           dumpProfit: upsertData.dump_profit || 0,
           referralProfit: upsertData.referral_profit || 0,
-          bondsProfit: upsertData.bonds_profit || 0
+          bondsProfit: upsertData.bonds_profit || 0,
+          activeFlippingProfit: upsertData.active_flipping_profit || 0
         });
       }
     }
@@ -67,10 +71,13 @@ export function useProfits(userId) {
     const dbColumnMap = {
       dumpProfit: 'dump_profit',
       referralProfit: 'referral_profit',
-      bondsProfit: 'bonds_profit'
+      bondsProfit: 'bonds_profit',
+      activeFlippingProfit: 'active_flipping_profit'
     };
 
     const dbColumn = dbColumnMap[profitType];
+    if (!dbColumn) return false;
+
     const newValue = profits[profitType] + amount;
 
     const { error } = await supabase

--- a/src/hooks/useSettings.js
+++ b/src/hooks/useSettings.js
@@ -17,7 +17,8 @@ const DEFAULT_VISIBLE_COLUMNS = {
 const DEFAULT_VISIBLE_PROFITS = {
   dumpProfit: false,
   referralProfit: false,
-  bondsProfit: true
+  bondsProfit: true,
+  activeFlippingProfit: true
 };
 
 export function useSettings(userId) {

--- a/src/hooks/useTimeseries.js
+++ b/src/hooks/useTimeseries.js
@@ -1,7 +1,26 @@
 import { useState, useEffect } from 'react';
 
-const BASE_URL = 'https://prices.runescape.wiki/api/v1/osrs';
+const PROXY_URL = '/api/ge-prices';
+const WIKI_BASE_URL = 'https://prices.runescape.wiki/api/v1/osrs';
 const USER_AGENT = 'OSRSProfitTracker - osrsprofittracker@gmail.com';
+const USE_DIRECT_WIKI_FALLBACK = import.meta.env.DEV;
+
+async function fetchTimeseries(itemId, timestep) {
+  const endpoint = `timeseries?id=${itemId}&timestep=${timestep}`;
+
+  try {
+    const res = await fetch(`${PROXY_URL}/${endpoint}`);
+    const contentType = res.headers.get('content-type') || '';
+    if (res.ok && contentType.includes('application/json')) return res;
+  } catch (proxyError) {
+    if (!USE_DIRECT_WIKI_FALLBACK) throw proxyError;
+  }
+
+  if (!USE_DIRECT_WIKI_FALLBACK) return null;
+  return fetch(`${WIKI_BASE_URL}/${endpoint}`, {
+    headers: { 'User-Agent': USER_AGENT },
+  });
+}
 
 export function useTimeseries(itemId, timestep, options = {}) {
   const [data, setData] = useState([]);
@@ -20,11 +39,8 @@ export function useTimeseries(itemId, timestep, options = {}) {
       setLoading(true);
       setError(null);
       try {
-        const res = await fetch(
-          `${BASE_URL}/timeseries?id=${itemId}&timestep=${timestep}`,
-          { headers: { 'User-Agent': USER_AGENT } }
-        );
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const res = await fetchTimeseries(itemId, timestep);
+        if (!res?.ok) throw new Error(`HTTP ${res?.status || 'unavailable'}`);
         const json = await res.json();
         if (!cancelled) setData(json.data || []);
       } catch (e) {

--- a/src/hooks/useTimeseries.js
+++ b/src/hooks/useTimeseries.js
@@ -2,24 +2,27 @@ import { useState, useEffect } from 'react';
 
 const PROXY_URL = '/api/ge-prices';
 const WIKI_BASE_URL = 'https://prices.runescape.wiki/api/v1/osrs';
-const USER_AGENT = 'OSRSProfitTracker - osrsprofittracker@gmail.com';
-const USE_DIRECT_WIKI_FALLBACK = import.meta.env.DEV;
 
 async function fetchTimeseries(itemId, timestep) {
   const endpoint = `timeseries?id=${itemId}&timestep=${timestep}`;
 
   try {
+    const res = await fetch(`${WIKI_BASE_URL}/${endpoint}`);
+    const contentType = res.headers.get('content-type') || '';
+    if (res.ok && contentType.includes('application/json')) return res;
+  } catch {
+    // Fall back to the first-party proxy when the Wiki API has a CORS or network issue.
+  }
+
+  try {
     const res = await fetch(`${PROXY_URL}/${endpoint}`);
     const contentType = res.headers.get('content-type') || '';
     if (res.ok && contentType.includes('application/json')) return res;
-  } catch (proxyError) {
-    if (!USE_DIRECT_WIKI_FALLBACK) throw proxyError;
+  } catch {
+    return null;
   }
 
-  if (!USE_DIRECT_WIKI_FALLBACK) return null;
-  return fetch(`${WIKI_BASE_URL}/${endpoint}`, {
-    headers: { 'User-Agent': USER_AGENT },
-  });
+  return null;
 }
 
 export function useTimeseries(itemId, timestep, options = {}) {

--- a/src/hooks/useTransactions.js
+++ b/src/hooks/useTransactions.js
@@ -49,7 +49,7 @@ export function useTransactions(userId) {
   const [pagedTransactions, setPagedTransactions] = useState([]);
   const [pagedLoading, setPagedLoading] = useState(false);
   const [historySource, setHistorySource] = useState('transactions');
-  const [historyProfitTypes, setHistoryProfitTypes] = useState(['dump', 'referral', 'bonds']);
+  const [historyProfitTypes, setHistoryProfitTypes] = useState(['dump', 'referral', 'bonds', 'active_flipping']);
   const pagedRequestId = useRef(0);
 
   const fetchTransactions = useCallback(async (options = {}) => {
@@ -599,7 +599,8 @@ function profitTypeLabel(type) {
   const labels = {
     dump: 'Dump profit',
     referral: 'Referral profit',
-    bonds: 'Bond profit'
+    bonds: 'Bond profit',
+    active_flipping: 'Active flipping profit'
   };
   return labels[type] || 'Extra profit';
 }

--- a/src/pages/AnalyticsPage.jsx
+++ b/src/pages/AnalyticsPage.jsx
@@ -193,7 +193,8 @@ export default function AnalyticsPage({
     );
     const otherProfit = (profits?.dumpProfit || 0)
       + (profits?.referralProfit || 0)
-      + (profits?.bondsProfit || 0);
+      + (profits?.bondsProfit || 0)
+      + (profits?.activeFlippingProfit || 0);
 
     return stocksProfit + otherProfit;
   }, [safeStocksForStats, profits]);

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -33,13 +33,14 @@ const EMPTY_FILTERS = {
 
 const MARKET_FILTERS = ['all', 'ge', 'non_ge'];
 const TRANSACTION_TYPES = ['all', 'buy', 'sell', 'remove'];
-const PROFIT_TYPES = ['all', 'dump', 'referral', 'bonds'];
+const PROFIT_TYPES = ['all', 'dump', 'referral', 'bonds', 'active_flipping'];
 
 function visibleProfitTypes(visibleProfits = {}) {
   return [
     visibleProfits.dumpProfit !== false ? 'dump' : null,
     visibleProfits.referralProfit !== false ? 'referral' : null,
-    visibleProfits.bondsProfit !== false ? 'bonds' : null
+    visibleProfits.bondsProfit !== false ? 'bonds' : null,
+    visibleProfits.activeFlippingProfit !== false ? 'active_flipping' : null
   ].filter(Boolean);
 }
 
@@ -51,7 +52,8 @@ function typeLabel(type) {
     remove: 'Removes',
     dump: 'Dumps',
     referral: 'Referrals',
-    bonds: 'Bonds'
+    bonds: 'Bonds',
+    active_flipping: 'Active Flipping'
   };
   return labels[type] || type;
 }
@@ -101,7 +103,7 @@ export default function HistoryPage({
   pagedTransactions = [], pagedLoading = false, totalCount = 0, totalPages = 0,
   page = 1, pageSize = 25, filters = EMPTY_FILTERS,
   historySource = 'transactions', onChangeHistorySource,
-  historyProfitTypes = ['dump', 'referral', 'bonds'], onChangeHistoryProfitTypes,
+  historyProfitTypes = ['dump', 'referral', 'bonds', 'active_flipping'], onChangeHistoryProfitTypes,
   visibleProfits = {},
   onGoToPage, onChangePageSize, onApplyFilters, onInit, numberFormat,
   sortConfig = { key: 'date', dir: 'desc' },

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -34,7 +34,7 @@ export default function HomePage({
   profits,
   statsStocks = null,
   nonGEStatsStocks = [],
-  visibleProfits = { dumpProfit: true, referralProfit: true, bondsProfit: true },
+  visibleProfits = { dumpProfit: true, referralProfit: true, bondsProfit: true, activeFlippingProfit: true },
   watchlistItems = [],
   numberFormat,
   milestones,
@@ -44,6 +44,7 @@ export default function HomePage({
   onAddDumpProfit = () => {},
   onAddReferralProfit = () => {},
   onAddBondsProfit = () => {},
+  onAddActiveFlippingProfit = () => {},
   onOpenMilestoneModal,
   onOpenMilestoneHistory,
   profitHistory,
@@ -69,22 +70,28 @@ export default function HomePage({
   const geProfit = stocksForStats?.reduce((sum, stock) => sum + calculateProfit(stock), 0) || 0;
   const nonGEProfit = nonGEStatsStocks?.reduce((sum, stock) => sum + calculateProfit(stock), 0) || 0;
 
-  // Add dump, referral, bonds profit
-  const { dumpProfit = 0, referralProfit = 0, bondsProfit = 0 } = profits || {};
-  const totalProfit = geProfit + nonGEProfit + dumpProfit + referralProfit + bondsProfit;
+  // Add dump, referral, bonds, and active flipping profit
+  const { dumpProfit = 0, referralProfit = 0, bondsProfit = 0, activeFlippingProfit = 0 } = profits || {};
+  const totalProfit = geProfit + nonGEProfit + dumpProfit + referralProfit + bondsProfit + activeFlippingProfit;
 
   const itemProfitSources = [
     { label: 'GE Items', value: geProfit },
-    { label: 'Non-GE Items', value: nonGEProfit },
-  ];
-
-  const extraProfitSources = [
     {
       label: 'Dumps',
       value: dumpProfit,
       visible: visibleProfits?.dumpProfit !== false,
       onAdd: onAddDumpProfit
     },
+    {
+      label: 'Active Flipping',
+      value: activeFlippingProfit,
+      visible: visibleProfits?.activeFlippingProfit !== false,
+      onAdd: onAddActiveFlippingProfit
+    },
+  ].filter(source => source.visible !== false);
+
+  const extraProfitSources = [
+    { label: 'Non-GE Items', value: nonGEProfit },
     {
       label: 'Referrals',
       value: referralProfit,
@@ -278,30 +285,43 @@ export default function HomePage({
           <div className="profit-source-list">
             <div className="profit-source-column">
               {itemProfitSources.map(source => (
-                <div className="profit-source-row" key={source.label}>
+                <div className={`profit-source-row ${source.onAdd ? 'profit-source-row--action' : ''}`} key={source.label}>
                   <span className="profit-source-label">{source.label}</span>
                   <span className={`profit-source-value ${source.value >= 0 ? 'positive' : 'negative'}`}>
                     {source.value >= 0 ? '+' : ''}{formatNumber(source.value, numberFormat)}
                   </span>
+                  {source.onAdd && (
+                    <button
+                      type="button"
+                      className="profit-source-add-btn"
+                      onClick={source.onAdd}
+                      aria-label={`Add ${source.label} profit`}
+                      title={`Add ${source.label} profit`}
+                    >
+                      <Plus size={14} />
+                    </button>
+                  )}
                 </div>
               ))}
             </div>
             <div className="profit-source-column">
               {extraProfitSources.map(source => (
-                <div className="profit-source-row" key={source.label}>
+                <div className={`profit-source-row ${source.onAdd ? 'profit-source-row--action' : ''}`} key={source.label}>
                   <span className="profit-source-label">{source.label}</span>
                   <span className={`profit-source-value ${source.value >= 0 ? 'positive' : 'negative'}`}>
                     {source.value >= 0 ? '+' : ''}{formatNumber(source.value, numberFormat)}
                   </span>
-                  <button
-                    type="button"
-                    className="profit-source-add-btn"
-                    onClick={source.onAdd}
-                    aria-label={`Add ${source.label} profit`}
-                    title={`Add ${source.label} profit`}
-                  >
-                    <Plus size={14} />
-                  </button>
+                  {source.onAdd && (
+                    <button
+                      type="button"
+                      className="profit-source-add-btn"
+                      onClick={source.onAdd}
+                      aria-label={`Add ${source.label} profit`}
+                      title={`Add ${source.label} profit`}
+                    >
+                      <Plus size={14} />
+                    </button>
+                  )}
                 </div>
               ))}
             </div>

--- a/src/styles/analytics-widgets.css
+++ b/src/styles/analytics-widgets.css
@@ -229,6 +229,10 @@
   background: rgb(234, 179, 8);
 }
 
+.analytics-legend-swatch[data-color="profit_active_flipping"] {
+  background: rgb(56, 189, 248);
+}
+
 .category-filter-bar {
   display: flex;
   flex-wrap: wrap;

--- a/src/styles/history-page.css
+++ b/src/styles/history-page.css
@@ -147,6 +147,11 @@
   color: white;
 }
 
+.history-filter-btn--active_flipping.history-filter-btn--active {
+  background: rgb(2, 132, 199);
+  color: white;
+}
+
 .history-market-filter-btn--active {
   background: rgb(15, 118, 110);
   color: white;
@@ -218,6 +223,10 @@
 
 .history-row--bonds {
   border-left: 3px solid rgb(245, 158, 11);
+}
+
+.history-row--active_flipping {
+  border-left: 3px solid rgb(56, 189, 248);
 }
 
 .history-row:hover {
@@ -353,6 +362,12 @@
   background: rgba(245, 158, 11, 0.2);
   color: rgb(253, 186, 116);
   border: 1px solid rgba(245, 158, 11, 0.3);
+}
+
+.history-type-badge--active_flipping {
+  background: rgba(14, 165, 233, 0.2);
+  color: rgb(125, 211, 252);
+  border: 1px solid rgba(14, 165, 233, 0.3);
 }
 
 .history-total--buy {

--- a/src/styles/home-page.css
+++ b/src/styles/home-page.css
@@ -149,6 +149,10 @@
   grid-template-columns: minmax(6rem, 1fr) auto;
 }
 
+.profit-source-column:first-child .profit-source-row--action {
+  grid-template-columns: minmax(6rem, 1fr) auto 1.75rem;
+}
+
 .profit-source-label {
   font-size: 0.75rem;
   color: rgb(156, 163, 175);

--- a/src/styles/shared.css
+++ b/src/styles/shared.css
@@ -175,16 +175,14 @@
 }
 
 .row-action-menu-trigger:hover,
-.row-action-menu[open] .row-action-menu-trigger {
+.row-action-menu-trigger[aria-expanded="true"] {
   background: rgb(51, 65, 85);
   border-color: rgba(148, 163, 184, 0.65);
 }
 
 .row-action-menu-list {
-  position: absolute;
-  top: calc(100% + 0.35rem);
-  right: 0;
-  z-index: 30;
+  position: fixed;
+  z-index: 500;
   min-width: 11rem;
   padding: 0.35rem;
   border: 1px solid rgba(71, 85, 105, 0.95);

--- a/src/types.js
+++ b/src/types.js
@@ -73,6 +73,7 @@
  * @property {number} dumpProfit - Extra profit from item dumps
  * @property {number} referralProfit - Extra profit from referrals
  * @property {number} bondsProfit - Extra profit from bonds
+ * @property {number} activeFlippingProfit - Extra profit from active flipping
  */
 
 // ──────────────────────────────────────────────
@@ -82,7 +83,7 @@
 /**
  * @typedef {Object} ProfitHistoryEntry
  * @property {number} id
- * @property {string} profit_type - e.g. 'sell', 'dump', 'referral', 'bonds'
+ * @property {string} profit_type - e.g. 'sell', 'dump', 'referral', 'bonds', 'active_flipping'
  * @property {number} amount - GP amount (rounded integer)
  * @property {number|null} stock_id - FK to stocks.id (null for non-trade profits)
  * @property {number|null} transaction_id - FK to transactions.id (null for non-trade profits)
@@ -151,6 +152,7 @@
  * @property {boolean} dumpProfit
  * @property {boolean} referralProfit
  * @property {boolean} bondsProfit
+ * @property {boolean} activeFlippingProfit
  */
 
 /**

--- a/src/utils/analyticsHelpers.js
+++ b/src/utils/analyticsHelpers.js
@@ -41,6 +41,7 @@ export const totalProfit = (bucket) => (
   + Number(bucket.profit_dump || 0)
   + Number(bucket.profit_referral || 0)
   + Number(bucket.profit_bonds || 0)
+  + Number(bucket.profit_active_flipping || 0)
 );
 
 export const sumProfit = (buckets = []) => (

--- a/src/utils/calculations.js
+++ b/src/utils/calculations.js
@@ -4,9 +4,9 @@ export const calculateStocksProfit = (stocks) => {
   }, 0);
 };
 
-export const calculateTotalProfit = (stocks, dumpProfit, referralProfit, bondsProfit) => {
+export const calculateTotalProfit = (stocks, dumpProfit, referralProfit, bondsProfit, activeFlippingProfit = 0) => {
   const stocksProfit = calculateStocksProfit(stocks);
-  return stocksProfit + dumpProfit + referralProfit + bondsProfit;
+  return stocksProfit + dumpProfit + referralProfit + bondsProfit + activeFlippingProfit;
 };
 
 export const calculateAvgBuyPrice = (stock) => {

--- a/src/utils/nonGeCatalog.js
+++ b/src/utils/nonGeCatalog.js
@@ -1,6 +1,22 @@
 import { NON_GE_CATALOG } from '../data/nonGeCatalog';
+import { CURRENT_VERSION } from '../data/changelog';
 
 const NON_GE_ICON_BASE_PATH = '/icons/non-ge';
+const ICON_CACHE_VERSION_KEY = 'osrs_icon_cache_version';
+
+function getIconCacheVersion() {
+  try {
+    return localStorage.getItem(ICON_CACHE_VERSION_KEY) || CURRENT_VERSION;
+  } catch {
+    return CURRENT_VERSION;
+  }
+}
+
+function getVersionedIconUrl(path) {
+  if (!path || path.startsWith('http')) return path || '';
+  const version = getIconCacheVersion();
+  return version ? `${path}${path.includes('?') ? '&' : '?'}v=${encodeURIComponent(version)}` : path;
+}
 
 export function getNonGECatalogItem(key) {
   if (!key) return null;
@@ -29,7 +45,7 @@ export function nonGEItemRangeLabel(item) {
 
 export function getNonGEItemImageUrl(item) {
   if (!item) return '';
-  if (item.key) return `${NON_GE_ICON_BASE_PATH}/${item.key}.png`;
+  if (item.key) return getVersionedIconUrl(`${NON_GE_ICON_BASE_PATH}/${item.key}.png`);
   if (item.imageUrl) return item.imageUrl;
   return '';
 }


### PR DESCRIPTION
﻿## Summary
- add Active Flipping as a manual extra-profit source alongside dumps, referrals, and bonds
- include Active Flipping in Home, Trade summary plumbing, History extra-profit filters, and Analytics source totals/charts
- place Home profit rows as GE Items, Dumps, Active Flipping on the left and Non-GE Items, Referrals, Bonds on the right

## Database note
Apply this in Supabase SQL Editor before using the new button in production:

```sql
alter table public.profits
add column if not exists active_flipping_profit bigint not null default 0;
```

## Validation
- npm run build
- local browser smoke check for the Active Flipping button/modal and Home profit row order
