### PR TITLE
Fix refreshed icon cache invalidation

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -744,7 +744,6 @@ function MainAppInner({ session, onLogout }) {
 
   const handleCloseChangelog = () => {
     localStorage.setItem(`lastSeenVersion_${userId}`, CURRENT_VERSION);
-    localStorage.setItem('osrs_icon_cache_version', CURRENT_VERSION);
     closeModal('changelog');
   };
 

--- a/src/data/changelog.js
+++ b/src/data/changelog.js
@@ -1,6 +1,13 @@
-export const CURRENT_VERSION = "4.0.0";
+export const CURRENT_VERSION = "4.0.1";
 
 export const changelog = [
+  {
+    version: "4.0.1",
+    date: "2026-07-29",
+    changes: [
+      { type: "fix", text: "Refreshed GE and Non-GE icon cache versions so newly added and updated item images appear immediately" },
+    ],
+  },
   {
     version: "4.0.0",
     date: "2026-06-09",

--- a/src/hooks/useGEPrices.js
+++ b/src/hooks/useGEPrices.js
@@ -6,15 +6,6 @@ const WIKI_BASE_URL = 'https://prices.runescape.wiki/api/v1/osrs';
 const REFRESH_INTERVAL = 60_000;
 const ICON_BASE_PATH = '/icons/ge';
 const ICON_MANIFEST_URL = `${ICON_BASE_PATH}/manifest.json`;
-const ICON_CACHE_VERSION_KEY = 'osrs_icon_cache_version';
-
-function getIconCacheVersion() {
-  try {
-    return localStorage.getItem(ICON_CACHE_VERSION_KEY) || CURRENT_VERSION;
-  } catch {
-    return CURRENT_VERSION;
-  }
-}
 
 function getVersionedAssetUrl(path, version) {
   if (!path) return '';
@@ -67,7 +58,10 @@ export function useGEPrices() {
 
       let iconManifest = null;
       try {
-        const manifestRes = await fetch(getVersionedAssetUrl(ICON_MANIFEST_URL, CURRENT_VERSION));
+        const manifestRes = await fetch(
+          getVersionedAssetUrl(ICON_MANIFEST_URL, CURRENT_VERSION),
+          { cache: 'no-store' }
+        );
         if (manifestRes.ok) {
           iconManifest = await manifestRes.json();
         }
@@ -77,11 +71,14 @@ export function useGEPrices() {
 
       // Build iconMap: { [id]: iconUrl }
       const map = {};
-      const iconCacheVersion = getIconCacheVersion();
       data.forEach(item => {
-        const mirroredIcon = iconManifest?.[item.id]?.path;
+        const manifestEntry = iconManifest?.[item.id];
+        const mirroredIcon = manifestEntry?.path;
         if (mirroredIcon) {
-          map[item.id] = getVersionedAssetUrl(mirroredIcon, iconCacheVersion);
+          map[item.id] = getVersionedAssetUrl(
+            mirroredIcon,
+            manifestEntry.updatedAt || CURRENT_VERSION
+          );
         }
       });
       setIconMap(map);

--- a/src/utils/nonGeCatalog.js
+++ b/src/utils/nonGeCatalog.js
@@ -2,20 +2,10 @@ import { NON_GE_CATALOG } from '../data/nonGeCatalog';
 import { CURRENT_VERSION } from '../data/changelog';
 
 const NON_GE_ICON_BASE_PATH = '/icons/non-ge';
-const ICON_CACHE_VERSION_KEY = 'osrs_icon_cache_version';
-
-function getIconCacheVersion() {
-  try {
-    return localStorage.getItem(ICON_CACHE_VERSION_KEY) || CURRENT_VERSION;
-  } catch {
-    return CURRENT_VERSION;
-  }
-}
 
 function getVersionedIconUrl(path) {
   if (!path || path.startsWith('http')) return path || '';
-  const version = getIconCacheVersion();
-  return version ? `${path}${path.includes('?') ? '&' : '?'}v=${encodeURIComponent(version)}` : path;
+  return `${path}${path.includes('?') ? '&' : '?'}v=${encodeURIComponent(CURRENT_VERSION)}`;
 }
 
 export function getNonGECatalogItem(key) {


### PR DESCRIPTION
## Summary

- bypass the browser cache when loading the GE icon manifest
- version each mirrored GE icon from its manifest `updatedAt` value
- use the current app version directly for Non-GE icon URLs
- release the cache refresh as version 4.0.1

## Root cause

The refreshed icon assets and manifest were deployed successfully, but clients continued requesting the existing `v4.0.0` URLs. Netlify marks icon responses as immutable for one year, and the icon cache version in local storage was only updated after dismissing the changelog. A normal page refresh therefore continued using the old manifest and icon responses.

## Impact

Newly mirrored items such as Crimson kisten appear without requiring users to clear their browser cache. Future GE icon refreshes automatically receive unique URLs based on each manifest entry's update timestamp.

## Validation

- confirmed the live manifest and Crimson kisten PNG return HTTP 200
- confirmed the live manifest contains item ID 33631
- `git diff --check`
- `npm run build`
